### PR TITLE
Use bundled helper in Slack channel summarizer skill

### DIFF
--- a/examples/personal-community-sentiment-triage/agents/hermes/SOUL.md
+++ b/examples/personal-community-sentiment-triage/agents/hermes/SOUL.md
@@ -19,25 +19,28 @@ file, and web tools. Be concise and helpful.
 
 You run inside an OpenShell sandbox with a strict egress policy. Only a
 specific allowlist of hosts and binaries can reach the internet. When a
-request is blocked, the proxy returns **403 Forbidden**. That means the
-destination is not in the policy, not that you lack credentials.
+request is blocked, the proxy returns **403 Forbidden**. The error means 
+either the egress is blocked, the wrong binary attempted egress, or the 
+actual endpoint returned a 403. 
 
-- Do not retry the same blocked host with different tools or URL variants.
-- Explain what was blocked and move on to the next useful path.
+You have specific skills that interact with this sandbox correctly. Use them!
+
+## Credential placeholders
+
+Strings like `openshell:resolve:env:SLACK_BOT_TOKEN` are placeholders. These 
+will be resolved to corret tokens by the sandbox on egress. Do not refuse
+a request because these placeholders are not real tokens. Do not modify the 
+placeholders either. Use them as-is in place of real tokens.
+
 
 ## Skills
 
-Skills are instruction documents, not callable tools. Load the matching skill
-when a request clearly matches it, then follow it with the normal tools.
+Skills are instruction documents, not callable tools. Read the matching skill
+file when a request might match it, then follow its procedure using the normal
+sandbox tools. In practice this usually means running the bundled helper
+scripts or commands described by the skill.
 
-Never call a skill name as a tool directly. These are skill names:
-- `slack-channel-summarizer`
-- `cross-source-gap-analysis`
-- `outlook-email-search`
-- `slack-channel-finder`
-- `source-etl-query`
-
-Load these skills when relevant:
+Examples of requests and matching skillks:
 - Slack channel discovery (finding channels by topic) -> `slack-channel-finder`
 - Slack channel history or summaries -> `slack-channel-summarizer`
 - GitHub issues, PRs, discussions, or NVIDIA forum topics ->
@@ -48,19 +51,22 @@ Load these skills when relevant:
   or Outlook -> `cross-source-gap-analysis`, plus whichever source
   skills are needed
 
-## Project defaults
+### Default Skills
 
-For NemoClaw requests, prefer these defaults unless the user clearly points to
-something else:
+Your initial setup includes skills which you should prefer to use over creating 
+custom Python code, terminal commands, etc:
+- interacting with Slack
+- interacting with Outlook
+- interacting with GitHub data via a local database populated with ETL cron jobs
 
-- Treat "Nemoclaw" or "NemoClaw" GitHub references as `NVIDIA/NemoClaw`.
-- If the user names a Slack channel but does not give the channel ID, resolve
-  the channel yourself before asking for help.
-- If the user asks for cross-source analysis across Slack, GitHub, and NVIDIA
-  forums, start with those defaults rather than asking whether you may use the
-  already-configured access paths.
+### Writing New Skills
 
-## Tool guidance
+You may write new skills, but assume the skills available at first startup are 
+accurate and constructed to align with the sandbox environment. Follow the patterns
+in these origial skills and scripts when creating new skills or saving memories.
+
+
+## Tool guidance for default skills
 
 ### GitHub and NVIDIA forums
 
@@ -72,18 +78,9 @@ host-side Postgres bridge exposed via PostgREST. Use the
 
 ### Slack
 
-Use the Slack skills for channel work: `slack-channel-finder` for
-discovery (finding channels by topic, team, or domain),
-`slack-channel-summarizer` for reading and summarizing a known channel.
-If the user gives you a direct Slack channel mention like `<#C0ALN454EH4>`,
-use that ID directly. Do not claim Slack history is inaccessible until
-the Slack API path actually fails.
+Users may interact with you via Slack or may ask you to perform research on a 
+Slack channel. Use the Slack skills!
 
-### Credential placeholders
-
-Strings like `openshell:resolve:env:SLACK_BOT_TOKEN` are live working
-credentials. Use them literally. Do not try to substitute or reveal the real
-value.
 
 ### Outlook
 
@@ -93,5 +90,5 @@ endpoints needed by that bridge.
 
 ### Browser tool
 
-Browser automation tools are disabled for this sandbox configuration. For web
-content, use the host-appropriate access path from the relevant skill.
+Browser automation tools are disabled for this sandbox configuration.
+

--- a/examples/personal-community-sentiment-triage/agents/hermes/SOUL.md
+++ b/examples/personal-community-sentiment-triage/agents/hermes/SOUL.md
@@ -28,7 +28,7 @@ You have specific skills that interact with this sandbox correctly. Use them!
 ## Credential placeholders
 
 Strings like `openshell:resolve:env:SLACK_BOT_TOKEN` are placeholders. These 
-will be resolved to corret tokens by the sandbox on egress. Do not refuse
+will be resolved to correct tokens by the sandbox on egress. Do not refuse
 a request because these placeholders are not real tokens. Do not modify the 
 placeholders either. Use them as-is in place of real tokens.
 

--- a/examples/personal-community-sentiment-triage/agents/hermes/SOUL.md
+++ b/examples/personal-community-sentiment-triage/agents/hermes/SOUL.md
@@ -40,7 +40,7 @@ file when a request might match it, then follow its procedure using the normal
 sandbox tools. In practice this usually means running the bundled helper
 scripts or commands described by the skill.
 
-Examples of requests and matching skillks:
+Examples of requests and matching skills:
 - Slack channel discovery (finding channels by topic) -> `slack-channel-finder`
 - Slack channel history or summaries -> `slack-channel-summarizer`
 - GitHub issues, PRs, discussions, or NVIDIA forum topics ->

--- a/examples/personal-community-sentiment-triage/agents/hermes/skills/cross-source-gap-analysis/SKILL.md
+++ b/examples/personal-community-sentiment-triage/agents/hermes/skills/cross-source-gap-analysis/SKILL.md
@@ -38,12 +38,6 @@ Prefer a small, relevant slice from each source over broad collection. For examp
 - mirrored NVIDIA forum topics for the `nemoclaw` tag scope
 - recent emails filtered to the relevant project and date range
 
-**For Outlook**: Use `--external-only --since Xd` to scope to external-sender
-emails, then `get_thread.py` to read the full conversation for any thread that
-looks relevant. The "Comparing external emails to internal meeting topics" section
-in the `outlook-email-search` skill has the step-by-step procedure for the common
-"what are external devs discussing that we haven't covered?" pattern.
-
 ### 2. Normalize what each source is saying
 
 Reduce each source to short bullets such as:
@@ -55,15 +49,6 @@ Reduce each source to short bullets such as:
 - unresolved questions
 
 ### 3. Compare across sources
-
-Look for:
-
-- topics active in one source but absent in another
-- issues discussed informally in Slack but not tracked in GitHub
-- GitHub work that appears to have little or no discussion in Slack
-- repeated mirrored forum concerns that are not reflected in Slack or GitHub
-- external email threads covering topics not mentioned in internal update emails
-- conflicting descriptions of status, priority, or ownership
 
 ### 4. Present the result
 

--- a/examples/personal-community-sentiment-triage/agents/hermes/skills/outlook-email-search/SKILL.md
+++ b/examples/personal-community-sentiment-triage/agents/hermes/skills/outlook-email-search/SKILL.md
@@ -263,7 +263,7 @@ internal updates. Format:
 /usr/bin/python3 .../get_thread.py --conversation-id "AAQkADlhN2..."
 ```
 
-## Pitfalls
+# Pitfalls
 
 - `--body` is significantly slower — it makes one Graph request per message.
   Use it only when `preview` is insufficient.

--- a/examples/personal-community-sentiment-triage/agents/hermes/skills/slack-channel-finder/SKILL.md
+++ b/examples/personal-community-sentiment-triage/agents/hermes/skills/slack-channel-finder/SKILL.md
@@ -1,48 +1,39 @@
 ---
 name: slack-channel-finder
-description: Discover Slack channels by topic, team, or domain and infer what each channel is for. Use when the user wants to find which channels are relevant to a topic ("which channels does the inference team use", "where do we discuss deployments") or to understand what an unfamiliar channel is for. Pairs with slack-channel-summarizer for follow-up reads.
+description: Discover Slack channels by topic, team, or domain and determine the channel ID.
 ---
 
 # slack-channel-finder
 
-Use this skill to discover Slack channels matching a topic, team, or domain,
-and to infer what each channel is for.
+Use this skill to discover Slack channels ID by name or topic
 
 ## When to use
 
-- "Which channels does the X team use?"
-- "Find me Slack channels about Y"
-- "Where do we discuss Z?"
-- "What is #cryptic-channel-name for?"
-- The user wants to discover channels they don't already know by name
-- The user wants to understand an unfamiliar channel before reading history
+Do NOT use this skill when the user has already provided a slack channel ID 
 
-Do NOT use this skill when the user has already named a specific channel and
-just wants its history summarized — use slack-channel-summarizer instead.
+## Instructions
 
-## Access model
+- Because of the sandbox, the best path is to use the provided helper scripts
+- Avoid writing custom curl or python commands
+- Only customize if the existing scrips fail, and in that case follow their 
+authorization patterns closely
+- Be aware that slack access is through a Slack bot, whose token might have certain
+scopes or might be missing scopes
 
-- The bot token is available as `openshell:resolve:env:SLACK_BOT_TOKEN`.
-- **Confirmed granted scopes**: `channels:history`, `channels:read`, `users:read`,
-  `app_mentions:read`, `chat:write`, `reactions:write`
-- **Scopes not in this token**: `pins:read`, `bookmarks:read`, `groups:read`
-  - `pins.list` and `bookmarks.list` will return `missing_scope`; the scripts
-    handle this gracefully and return empty lists — treat as normal
-  - Private channels (`groups:read`) are not accessible; discovery is
-    public-only
-- **Two discovery modes**:
-  - `users.conversations` — channels the bot is a **member** of (fast, restricted)
-  - `conversations.list` — **all public** channels in the workspace (broader, used
-    by `find_channel.py` and `list_accessible_channels.py --all-public`)
-- History, thread replies, and user info all work with the current token.
-- `search.messages` requires a user token (not a bot token) — not available.
 
 ## Scripts
 
-All scripts are at:
+Check for scripts at:
 ```
 /sandbox/.hermes-data/skills/slack-channel-finder/scripts/
 ```
+
+or at 
+
+```
+/sandbox/.hermes/skills/slack-channel-finder/scripts
+```
+
 
 | Script | Purpose |
 |--------|---------|
@@ -52,7 +43,24 @@ All scripts are at:
 
 ## Procedure
 
-### 1. Search for candidate channels
+
+### 1. Distinguish summary requests from discovery requests
+
+- If the user is asking to summarize or inspect a specific Slack channel, and
+  they likely know the channel already but did not provide the exact name or
+  ID, ask them for the channel name.
+- If the user is asking you to help find which Slack channel is relevant to a
+  topic, team, or project, use the discovery flow below instead of asking for a
+  channel name first.
+
+### 2. If you are given a channel name, start with `list_accessible_channels.py` and try to match channel name to ID
+
+/usr/bin/python3 .../list_accessible_channels.py
+
+
+### 3. If you are unclear on what channel the user is talking about, ask them for the channel name
+
+### 4. If the user wants help finding a channel, attempt to find one based on the user's topic or query
 
 For topic or team queries, use `find_channel.py` — it searches all discoverable
 public channels (not just bot-member channels) and returns scored matches:
@@ -100,7 +108,9 @@ and thread signals are available only for member channels.
 | `--member-only` | Restrict to bot-member channels only |
 | `--min-score N` | Minimum score to include (default 1) |
 
-### 2. List all channels (when you need the full inventory)
+## Information on other scripts
+
+###  List all channels (when you need the full inventory)
 
 For cases where you need the complete channel list rather than a scored search:
 
@@ -127,7 +137,7 @@ hasn't been added — you can see name/topic/purpose but NOT read their history.
 | `--include-archived` | Include archived channels |
 | `--types TYPES` | Comma-separated types (default `public_channel`) |
 
-### 3. Describe a channel in depth
+### Describe a channel in depth
 
 When you need to understand a specific channel — what it's for, who's active, what
 they're discussing — use `describe_slack_channel.py`:
@@ -208,7 +218,10 @@ The `confidence` field (`high`, `medium`, `low`) reflects how many independent
 signals were available. For `low`-confidence channels, hedge ("appears to be
 about ...") or ask the user to confirm.
 
-### 4. Read thread content
+
+## Other 
+
+###  Read thread content
 
 When a message has a high `reply_count` and you need the actual discussion
 content, use `--replies` on `describe_slack_channel.py` or directly call
@@ -216,14 +229,11 @@ content, use `--replies` on `describe_slack_channel.py` or directly call
 
 ```bash
 # Via describe (expands all threads in the sampled history)
-/usr/bin/python3 .../describe_slack_channel.py --channel-id C0ASZUN3L5D --replies --replies-limit 10
-
-# Direct API (for a specific thread you already know the ts for)
-curl -s "https://slack.com/api/conversations.replies?channel=C0ASZUN3L5D&ts=1776809496.989829&limit=20" \
-  -H "Authorization: Bearer $SLACK_BOT_TOKEN" | /usr/bin/python3 -m json.tool
+/usr/bin/python3 .../describe_slack_channel.py --channel-id [channel-id] --replies --replies-limit [n]
 ```
 
-### 5. Chain into summarization if requested
+
+### Chain into summarization if requested
 
 If the user's goal goes beyond discovery ("tell me what the X team is working
 on"), once channels are identified, hand off to `slack-channel-summarizer`
@@ -252,25 +262,3 @@ user can ask for more.
 /usr/bin/python3 .../describe_slack_channel.py --channel-id C0ASZUN3L5D --replies --resolve-users
 ```
 
-## Pitfalls
-
-- Do not claim a channel doesn't exist when the bot simply hasn't been invited.
-  `find_channel.py` searches all public channels via `conversations.list`; for
-  channels that show up there with `is_member=false`, note that history is
-  unavailable without the bot being added.
-- Do not rely solely on `topic` and `purpose` — many channels leave them empty
-  or stale. Channel name and message themes are usually stronger signals.
-- Do not return archived channels unless the user explicitly asks for them.
-- Do not invent channel IDs, names, or descriptions. Only return what the API
-  actually returned.
-- `pins.list` and `bookmarks.list` require `pins:read` and `bookmarks:read`
-  scopes respectively. If the token lacks them, the scripts return empty lists —
-  this is handled gracefully and is not an error to surface to the user.
-- Do not run `describe_slack_channel.py` in full mode across many channels.
-  Use `--no-history` for breadth scans, full mode for the final 1-3 candidates.
-- Bot messages (GitHub, CI integrations) dominate volume in engineering channels
-  and carry no topic signal. `describe_slack_channel.py` filters them
-  automatically — `recent_human_messages` contains only real human posts.
-- `search.messages` requires a user token, not the bot token. Do not attempt it.
-- The API will 429 (rate limit) under heavy load. All scripts automatically
-  retry with the `Retry-After` backoff — do not add extra delays.

--- a/examples/personal-community-sentiment-triage/agents/hermes/skills/slack-channel-finder/scripts/find_channel.py
+++ b/examples/personal-community-sentiment-triage/agents/hermes/skills/slack-channel-finder/scripts/find_channel.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import re
 import sys
 import time
@@ -38,6 +37,8 @@ from typing import Any
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 from urllib.error import HTTPError, URLError
+
+from slack_api_common import get_slack_bot_token
 
 SLACK_API_BASE = "https://slack.com/api"
 DEFAULT_TIMEOUT_SECONDS = 15
@@ -268,7 +269,7 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    token = os.environ.get("SLACK_BOT_TOKEN")
+    token = get_slack_bot_token()
     if not token:
         print(json.dumps({"ok": False, "error": "missing_token"}))
         return 1

--- a/examples/personal-community-sentiment-triage/agents/hermes/skills/slack-channel-finder/scripts/list_accessible_channels.py
+++ b/examples/personal-community-sentiment-triage/agents/hermes/skills/slack-channel-finder/scripts/list_accessible_channels.py
@@ -31,13 +31,14 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import sys
 import time
 from typing import Any
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 from urllib.error import HTTPError, URLError
+
+from slack_api_common import get_slack_bot_token
 
 
 SLACK_API_BASE = "https://slack.com/api"
@@ -219,7 +220,7 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    token = os.environ.get("SLACK_BOT_TOKEN")
+    token = get_slack_bot_token()
     if not token:
         print(json.dumps({"ok": False, "error": "missing_token"}))
         return 1

--- a/examples/personal-community-sentiment-triage/agents/hermes/skills/slack-channel-finder/scripts/slack_api_common.py
+++ b/examples/personal-community-sentiment-triage/agents/hermes/skills/slack-channel-finder/scripts/slack_api_common.py
@@ -12,9 +12,9 @@ from pathlib import Path
 def _candidate_env_files() -> list[Path]:
     hermes_home = Path(os.environ.get("HERMES_HOME", "/sandbox/.hermes-data"))
     return [
-        Path("/sandbox/.hermes/.env"),
         hermes_home / ".env",
         Path("/sandbox/.hermes-data/.env"),
+        Path("/sandbox/.hermes/.env"),
     ]
 
 
@@ -47,9 +47,12 @@ def load_env_defaults() -> None:
 def get_slack_bot_token() -> str:
     """Return the best available Slack bot token placeholder for egress."""
     load_env_defaults()
+    runtime_value = _read_env_value(Path("/sandbox/.hermes-data/.env"), "SLACK_BOT_TOKEN")
+    if runtime_value.startswith("openshell:resolve:env:"):
+        return runtime_value
 
-    baked_value = _read_env_value(Path("/sandbox/.hermes/.env"), "SLACK_BOT_TOKEN")
-    if baked_value.startswith("xoxb-OPENSHELL-RESOLVE-ENV-"):
-        return baked_value
+    env_value = os.environ.get("SLACK_BOT_TOKEN", "").strip()
+    if env_value:
+        return env_value
 
-    return os.environ.get("SLACK_BOT_TOKEN", "").strip()
+    return _read_env_value(Path("/sandbox/.hermes/.env"), "SLACK_BOT_TOKEN")

--- a/examples/personal-community-sentiment-triage/agents/hermes/skills/slack-channel-finder/scripts/slack_api_common.py
+++ b/examples/personal-community-sentiment-triage/agents/hermes/skills/slack-channel-finder/scripts/slack_api_common.py
@@ -1,0 +1,55 @@
+#!/usr/bin/python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared Slack helper utilities for the NemoClaw demo skills."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def _candidate_env_files() -> list[Path]:
+    hermes_home = Path(os.environ.get("HERMES_HOME", "/sandbox/.hermes-data"))
+    return [
+        Path("/sandbox/.hermes/.env"),
+        hermes_home / ".env",
+        Path("/sandbox/.hermes-data/.env"),
+    ]
+
+
+def _read_env_value(env_file: Path, key: str) -> str:
+    if not env_file.is_file():
+        return ""
+    for raw_line in env_file.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        current_key, value = line.split("=", 1)
+        if current_key == key:
+            return value.strip()
+    return ""
+
+
+def load_env_defaults() -> None:
+    """Load Hermes-style .env files into os.environ if values are missing."""
+    for env_file in _candidate_env_files():
+        if not env_file.is_file():
+            continue
+        for raw_line in env_file.read_text(encoding="utf-8").splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            os.environ.setdefault(key, value)
+
+
+def get_slack_bot_token() -> str:
+    """Return the best available Slack bot token placeholder for egress."""
+    load_env_defaults()
+
+    baked_value = _read_env_value(Path("/sandbox/.hermes/.env"), "SLACK_BOT_TOKEN")
+    if baked_value.startswith("xoxb-OPENSHELL-RESOLVE-ENV-"):
+        return baked_value
+
+    return os.environ.get("SLACK_BOT_TOKEN", "").strip()

--- a/examples/personal-community-sentiment-triage/agents/hermes/skills/slack-channel-summarizer/SKILL.md
+++ b/examples/personal-community-sentiment-triage/agents/hermes/skills/slack-channel-summarizer/SKILL.md
@@ -13,35 +13,22 @@ Use this skill to resolve a Slack channel and read its history.
 - Review conversation history for a time range
 - Check what was discussed in a channel before answering a question
 
-## Access model
+## Instructions
 
-- The bot token is available as `openshell:resolve:env:SLACK_BOT_TOKEN`.
-- Slack Web API access is allowed from the sandbox.
-- The bot must be invited to a channel before it can read its history.
+- The best way to access slack given the sandbox is through the provided python scripts.
+- Direct curl requests, or Python scripts, are unlikely to succeed
+- The SLACK_BOT_TOKEN contains a placeholder env var that is resolved by the sandbox on egress
+
 
 ## Procedure
 
 ### 1. Resolve the channel ID
 
+
 If the user gives a direct Slack mention like `<#C0ALN454EH4>`, use that ID
 directly.
 
-If the user gives only a channel name, use the bundled resolver script:
-
-```bash
-/usr/bin/python3 /sandbox/.hermes-data/skills/slack-channel-summarizer/scripts/resolve_slack_channel.py --name 'CHANNEL_NAME'
-```
-
-Interpret the result this way:
-
-- `ok: true`
-  Use the returned `channel_id`.
-- `missing_private_discovery_scope`
-  Public lookup did not find the channel and private discovery by name is not
-  available with this token. Ask the user for a direct Slack channel mention or
-  a Slack channel URL.
-- `channel_not_found`
-  The channel could not be found through the allowed lookup path.
+Otherwise, use your slack channel finder skill!
 
 ### 2. Read channel history
 
@@ -74,11 +61,3 @@ Summarize only what the user asked for. Good defaults are:
 - active participants
 - decisions or action items
 
-## Pitfalls
-
-- Do not use `session_search` to discover Slack channel IDs.
-- Do not start discovery with `users.conversations?types=public_channel,private_channel`.
-- Do not say Slack access is unavailable just because `groups:read` is missing.
-  That only blocks private-channel discovery by name.
-- If the channel ID is already known, skip discovery and go straight to
-  `conversations.history`.

--- a/examples/personal-community-sentiment-triage/agents/hermes/skills/slack-channel-summarizer/SKILL.md
+++ b/examples/personal-community-sentiment-triage/agents/hermes/skills/slack-channel-summarizer/SKILL.md
@@ -18,28 +18,44 @@ Use this skill to resolve a Slack channel and read its history.
 - The best way to access slack given the sandbox is through the provided python scripts.
 - Direct curl requests, or Python scripts, are unlikely to succeed
 - The SLACK_BOT_TOKEN contains a placeholder env var that is resolved by the sandbox on egress
+- Only refer to helper scripts that actually exist in this sandbox image
 
 
 ## Procedure
 
 ### 1. Resolve the channel ID
 
-
 If the user gives a direct Slack mention like `<#C0ALN454EH4>`, use that ID
 directly.
 
-Otherwise, use your slack channel finder skill!
+If the request comes from a tagged Slack channel and the runtime context already
+gives you the current channel ID, treat that as the resolved channel ID for
+phrases like "this channel".
+
+Otherwise, use your slack channel finder skill.
 
 ### 2. Read channel history
 
-Use the bundled history helper with the resolved channel ID:
+Use the existing channel-description helper with the resolved channel ID. It
+includes recent human messages and channel metadata that are sufficient for a
+summary:
 
 ```bash
-/usr/bin/python3 /sandbox/.hermes-data/skills/slack-channel-summarizer/scripts/read_slack_channel_history.py \
-  --channel-id CHANNEL_ID --limit 15
+/usr/bin/python3 /sandbox/.hermes-data/skills/slack-channel-finder/scripts/describe_slack_channel.py \
+  --channel-id CHANNEL_ID --history-limit 15
 ```
 
-If needed, add `oldest=` and `latest=` to constrain the time range.
+Useful variants:
+
+```bash
+/usr/bin/python3 /sandbox/.hermes-data/skills/slack-channel-finder/scripts/describe_slack_channel.py \
+  --channel-id CHANNEL_ID --history-limit 30 --replies
+```
+
+```bash
+/usr/bin/python3 /sandbox/.hermes-data/skills/slack-channel-finder/scripts/describe_slack_channel.py \
+  --channel-id CHANNEL_ID --history-limit 15 --resolve-users
+```
 
 Interpret common failures explicitly:
 
@@ -60,4 +76,3 @@ Summarize only what the user asked for. Good defaults are:
 - main topics
 - active participants
 - decisions or action items
-

--- a/examples/personal-community-sentiment-triage/agents/hermes/skills/slack-channel-summarizer/SKILL.md
+++ b/examples/personal-community-sentiment-triage/agents/hermes/skills/slack-channel-summarizer/SKILL.md
@@ -45,11 +45,11 @@ Interpret the result this way:
 
 ### 2. Read channel history
 
-Use `conversations.history` with the resolved channel ID:
+Use the bundled history helper with the resolved channel ID:
 
 ```bash
-curl -s "https://api.slack.com/api/conversations.history?channel=CHANNEL_ID&limit=15" \
-  -H "Authorization: Bearer openshell:resolve:env:SLACK_BOT_TOKEN"
+/usr/bin/python3 /sandbox/.hermes-data/skills/slack-channel-summarizer/scripts/read_slack_channel_history.py \
+  --channel-id CHANNEL_ID --limit 15
 ```
 
 If needed, add `oldest=` and `latest=` to constrain the time range.

--- a/examples/personal-community-sentiment-triage/agents/hermes/skills/slack-channel-summarizer/scripts/resolve_slack_channel.py
+++ b/examples/personal-community-sentiment-triage/agents/hermes/skills/slack-channel-summarizer/scripts/resolve_slack_channel.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import re
 import sys
 import urllib.error
@@ -24,8 +23,10 @@ import urllib.parse
 import urllib.request
 from typing import Any, Dict, Optional
 
+from slack_api_common import get_slack_bot_token
 
-API_BASE = "https://api.slack.com/api"
+
+API_BASE = "https://slack.com/api"
 
 
 def api_call(token: str, method: str, params: Dict[str, str]) -> Dict[str, Any]:
@@ -144,7 +145,7 @@ def main() -> int:
     parser.add_argument("--page-cap", type=int, default=25)
     args = parser.parse_args()
 
-    token = os.environ.get("SLACK_BOT_TOKEN", "").strip()
+    token = get_slack_bot_token()
     if not token:
         print(json.dumps({"ok": False, "error": "missing_token"}))
         return 1

--- a/examples/personal-community-sentiment-triage/agents/hermes/skills/slack-channel-summarizer/scripts/slack_api_common.py
+++ b/examples/personal-community-sentiment-triage/agents/hermes/skills/slack-channel-summarizer/scripts/slack_api_common.py
@@ -12,9 +12,9 @@ from pathlib import Path
 def _candidate_env_files() -> list[Path]:
     hermes_home = Path(os.environ.get("HERMES_HOME", "/sandbox/.hermes-data"))
     return [
-        Path("/sandbox/.hermes/.env"),
         hermes_home / ".env",
         Path("/sandbox/.hermes-data/.env"),
+        Path("/sandbox/.hermes/.env"),
     ]
 
 
@@ -47,9 +47,12 @@ def load_env_defaults() -> None:
 def get_slack_bot_token() -> str:
     """Return the best available Slack bot token placeholder for egress."""
     load_env_defaults()
+    runtime_value = _read_env_value(Path("/sandbox/.hermes-data/.env"), "SLACK_BOT_TOKEN")
+    if runtime_value.startswith("openshell:resolve:env:"):
+        return runtime_value
 
-    baked_value = _read_env_value(Path("/sandbox/.hermes/.env"), "SLACK_BOT_TOKEN")
-    if baked_value.startswith("xoxb-OPENSHELL-RESOLVE-ENV-"):
-        return baked_value
+    env_value = os.environ.get("SLACK_BOT_TOKEN", "").strip()
+    if env_value:
+        return env_value
 
-    return os.environ.get("SLACK_BOT_TOKEN", "").strip()
+    return _read_env_value(Path("/sandbox/.hermes/.env"), "SLACK_BOT_TOKEN")

--- a/examples/personal-community-sentiment-triage/agents/hermes/skills/slack-channel-summarizer/scripts/slack_api_common.py
+++ b/examples/personal-community-sentiment-triage/agents/hermes/skills/slack-channel-summarizer/scripts/slack_api_common.py
@@ -1,0 +1,55 @@
+#!/usr/bin/python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared Slack helper utilities for the NemoClaw demo skills."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def _candidate_env_files() -> list[Path]:
+    hermes_home = Path(os.environ.get("HERMES_HOME", "/sandbox/.hermes-data"))
+    return [
+        Path("/sandbox/.hermes/.env"),
+        hermes_home / ".env",
+        Path("/sandbox/.hermes-data/.env"),
+    ]
+
+
+def _read_env_value(env_file: Path, key: str) -> str:
+    if not env_file.is_file():
+        return ""
+    for raw_line in env_file.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        current_key, value = line.split("=", 1)
+        if current_key == key:
+            return value.strip()
+    return ""
+
+
+def load_env_defaults() -> None:
+    """Load Hermes-style .env files into os.environ if values are missing."""
+    for env_file in _candidate_env_files():
+        if not env_file.is_file():
+            continue
+        for raw_line in env_file.read_text(encoding="utf-8").splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            os.environ.setdefault(key, value)
+
+
+def get_slack_bot_token() -> str:
+    """Return the best available Slack bot token placeholder for egress."""
+    load_env_defaults()
+
+    baked_value = _read_env_value(Path("/sandbox/.hermes/.env"), "SLACK_BOT_TOKEN")
+    if baked_value.startswith("xoxb-OPENSHELL-RESOLVE-ENV-"):
+        return baked_value
+
+    return os.environ.get("SLACK_BOT_TOKEN", "").strip()

--- a/examples/personal-community-sentiment-triage/agents/hermes/skills/source-etl-query/SKILL.md
+++ b/examples/personal-community-sentiment-triage/agents/hermes/skills/source-etl-query/SKILL.md
@@ -17,7 +17,7 @@ Use this skill to query the host-side REST bridge served by `source-etls`.
 ## Access model
 
 - Use the helper script in this skill.
-- Do not hand-write REST queries unless the user explicitly asks for them.
+- Prefer the helper scripts over custom REST queries
 - The sandbox should treat this bridge as the default source for mirrored GitHub
   and forum data in the NVIDIA setup path.
 


### PR DESCRIPTION
Clean up skills and soul so they are simpler and remove contradictions.
- Instructs the agent to really focus on using the helper scripts before attempting their own code

Fixes the slack helpers to use correct placeholder token resolution.