### PR TITLE
Use provider-backed GitHub read-only policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ yarn-error.log*
 
 # OpenShell/NemoClaw local artifacts
 .Dockerfile.staged
+.policy.staged.yaml
 .snapshots/
 docker-compose.override.yml
 docker-compose.override.yaml

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The examples in this repository demonstrate complete blueprint patterns: they sh
 
 | Directory | Description |
 | --------- | ----------- |
-| `examples/personal-community-sentiment-triage/` | NemoClaw blueprint example pairing a Hermes harness with an OpenShell sandbox and community-signal integrations across Slack, Outlook, GitHub mirrors, and NVIDIA forum mirrors. |
+| `examples/personal-community-sentiment-triage/` | NemoClaw blueprint example pairing a Hermes harness with an OpenShell sandbox and community-signal integrations across Slack, Outlook, live read-only GitHub REST, GitHub discussion mirrors, and NVIDIA forum mirrors. |
 | `scripts/` | Repository maintenance checks used by CI. |
 
 ## Getting Started
@@ -37,7 +37,7 @@ Then follow the full setup guide in [examples/personal-community-sentiment-triag
 - Linux host with Docker or a compatible container runtime
 - OpenShell CLI and gateway
 - Access to an OpenAI-compatible inference endpoint
-- Optional integration credentials for Slack, Microsoft Graph/Outlook, GitHub, and source ETL mirrors
+- Optional integration credentials for Slack, Microsoft Graph/Outlook, GitHub live reads, and source ETL mirrors
 
 This project will download and install additional third-party open source software projects. Review the license terms of these open source projects before use. See [THIRD-PARTY-NOTICES](THIRD-PARTY-NOTICES) for the repository inventory.
 

--- a/examples/personal-community-sentiment-triage/.env.example
+++ b/examples/personal-community-sentiment-triage/.env.example
@@ -70,17 +70,27 @@ SLACK_BOT_TOKEN=
 SLACK_APP_TOKEN=
 SLACK_ALLOWED_IDS=
 
-# ── GitHub (required for a usable scrape rate) ───────────────────────────
-# Used by the host-side `github-etl` container (in extras/docker-compose.yml)
-# to authenticate against the GitHub API while populating the Postgres mirror
-# that the source-etl-query skill reads from. Without a token, GitHub limits
-# the ETL to 60 requests/hour per source IP, which is too slow for any real
-# repo — tap-github will hit HTTP 403 mid-sync and fail before populating
-# the mirror. With a token, the limit is 5000/hour and syncs complete.
-# The sandbox itself does NOT use this token directly — github.com is not
-# in the sandbox's egress policy, so agent GitHub lookups go through the
-# source-etl-query skill (mirror data only), not live `gh`.
+# ── GitHub (live read-only REST) ─────────────────────────────────────────
+# The sandbox uses this token through an OpenShell provider placeholder for
+# live GitHub REST reads. The raw token is resolved by the proxy on egress,
+# and policy.yaml constrains usage to read-only api.github.com routes for
+# GITHUB_READONLY_REPO. If you also keep the host-side GitHub mirror enabled,
+# GITHUB_TOKEN gives that ETL practical API rate limits.
 GITHUB_TOKEN=
+# Optional fallback for the live sandbox provider if GITHUB_TOKEN is empty.
+# Prefer GITHUB_TOKEN when you also want the host GitHub mirror authenticated.
+GH_TOKEN=
+
+# Live sandbox GitHub read-only scope. Change this to owner/repo to choose the
+# one GitHub repo the sandbox can read. Recreate the sandbox after changing it:
+# bash scripts/tear-down.sh && bash scripts/bring-up.sh
+# scripts/03-sandbox.sh stages both policy.yaml and the Dockerfile before
+# creation, so editing .env does not update an already-running sandbox.
+GITHUB_READONLY_REPO=NVIDIA/OpenShell
+
+# Optional host-side GitHub mirror repo for source-etls. This controls mirrored
+# discussions/history in Postgres only; it does not change live sandbox access.
+# SOURCE_ETL_GITHUB_REPO=NVIDIA/NemoClaw
 
 # ── Optional: Telegram / Discord ─────────────────────────────────────────
 # TELEGRAM_BOT_TOKEN=

--- a/examples/personal-community-sentiment-triage/.gitignore
+++ b/examples/personal-community-sentiment-triage/.gitignore
@@ -4,6 +4,7 @@
 # and removed by the trap on exit. Listed here so an interrupted build can't
 # accidentally check it in.
 .Dockerfile.staged
+.policy.staged.yaml
 
 # Snapshot tarballs from scripts/snapshot.sh. Demo artifacts — local only.
 .snapshots/

--- a/examples/personal-community-sentiment-triage/README.md
+++ b/examples/personal-community-sentiment-triage/README.md
@@ -6,17 +6,22 @@ A personal Hermes agent that surfaces what the developer community is working
 on, struggling with, asking about, and flagging as gaps — and compares it
 against what internal developer/product teams are prioritizing, so resources
 can be aligned against actual community demand. The agent draws on signal
-from GitHub issues, NVIDIA forums, and Slack channels; you interact with it
-via Outlook email and/or Slack. Outlook is the recommended primary channel,
-but either is enough on its own — at least one of the two must be configured.
+from live GitHub repository state, mirrored GitHub discussions, NVIDIA forums,
+and Slack channels; you interact with it via Outlook email and/or Slack.
+Outlook is the recommended primary channel, but either is enough on its own —
+at least one of the two must be configured.
 
 ## Architecture
 
 The Hermes sandbox operates with a deliberately narrow egress policy. It connects
-live to Slack and Outlook for interactions and research. GitHub and NVIDIA forum
-data are never fetched live from inside the sandbox — host-side ETL containers
-scrape those sources on a schedule and write results into Postgres, and the
-sandbox queries that mirror through a read-only PostgREST HTTP bridge.
+live to Slack and Outlook for interactions and research. It also has
+authenticated, read-only GitHub REST access to one configured repository
+(`GITHUB_READONLY_REPO`). The GitHub token is attached through an OpenShell
+provider placeholder so GitHub rate limits are practical, while `policy.yaml`
+still limits the sandbox to repo-scoped `GET` requests. GitHub discussions,
+historical mirror data, and NVIDIA forum data come from host-side ETL
+containers that scrape on a schedule, write results into Postgres, and expose
+that mirror through a read-only PostgREST HTTP bridge.
 
 ```mermaid
 flowchart LR
@@ -25,7 +30,7 @@ flowchart LR
     slack["Internal\nSlack Bot App"]
     outlook["Internal\nOutlook / MS Graph"]
     entra["Internal\nMS Entra ID"]
-    github["External\nGitHub API\nissues · PRs · discussions"]
+    github["External\nGitHub API\nissues · PRs · contents"]
     forums["External\nNVIDIA Forums\nnemoclaw tag"]
 
     subgraph host["Host Machine"]
@@ -38,6 +43,7 @@ flowchart LR
 
             subgraph sourceSkills["Source Skills"]
                 direction LR
+                s0["github-readonly-live"]
                 s1["source-etl-query"]
                 s4["cross-source-gap-analysis"]
             end
@@ -70,7 +76,7 @@ flowchart LR
         phoenix["Phoenix Telemetry\n:6006"]
         postgrest["PostgREST\nread-only :3100"]
         postgres[("PostgreSQL\nsource mirror")]
-        etls["Source ETLs\nGitHub + Forums\nhourly deltas"]
+        etls["Source ETLs\nGitHub discussions + Forums\nhourly deltas"]
         tokenManager["MS Graph Token Manager\nMSAL sessions\n:8765"]
 
         proxy -->|"OTLP traces"| phoenix
@@ -84,6 +90,7 @@ flowchart LR
     proxy -->|"inference"| nvidia
     proxy -->|"Slack bot"| slack
     proxy -->|"Graph API"| outlook
+    proxy -->|"auth read-only REST\none configured repo"| github
     tokenManager -->|"MSAL auth"| entra
     entra -.->|"issues token"| tokenManager
     etls -->|"scheduled scrape"| github
@@ -104,11 +111,12 @@ flowchart LR
 
 **Key invariants:**
 
-- The agent never has direct network access to GitHub or the NVIDIA forums. All GitHub and forum data the agent sees comes from the Postgres mirror.
+- The agent has authenticated read-only `api.github.com` access for exactly one configured repo. The raw GitHub token stays in an OpenShell provider; the sandbox sees only a placeholder, and policy still blocks writes, non-API GitHub hosts, `git`, and `gh`.
+- GitHub discussions, historical mirror data, and NVIDIA forum data come from the Postgres mirror.
 - Slack and Outlook are live connections from the sandbox; the agent can read and write both in real time.
 - Compatible-endpoint inference egress is required for the agent's LLM calls — it's not a research/data-ingestion path.
 - The ETL containers are non-agentic — fixed scraper logic on an hourly interval, no LLM involvement.
-- The PostgREST bridge exposes a read-only HTTP API on host port `3100`, and the sandbox reaches it through `host.openshell.internal` without any live GitHub or forum egress.
+- The PostgREST bridge exposes a read-only HTTP API on host port `3100`, and the sandbox reaches it through `host.openshell.internal` without any live forum egress.
 
 ## Agent skills
 
@@ -116,7 +124,8 @@ Skills are loaded on demand by the agent when relevant to a task. They live in [
 
 | Skill | Purpose |
 |-------|---------|
-| `source-etl-query` | Query the host-side PostgREST bridge for mirrored GitHub and NVIDIA forum data. Primary data-access skill for both GitHub and forum research. |
+| `github-readonly-live` | Query the configured live GitHub repo via authenticated, policy-scoped REST `GET` requests. |
+| `source-etl-query` | Query the host-side PostgREST bridge for mirrored GitHub discussions, historical mirror data, and NVIDIA forum data. |
 | `slack-channel-finder` | Discover Slack channels by topic, team, or domain and infer what each channel is for. |
 | `slack-channel-summarizer` | Resolve Slack channels by name or ID and read message history via the Slack Web API. |
 | `outlook-email-search` | Search the Outlook mailbox via Microsoft Graph to find and read emails relevant to a question. |
@@ -190,7 +199,9 @@ Now edit `.env` and fill in everything you already have:
   holds real Entra sessions; leave commented for local experimentation
 - (optional) `SLACK_ALLOWED_IDS` — comma-separated Slack user IDs to restrict who can DM the agent; leave empty to allow anyone in the workspace
 - (optional) `OUTLOOK_ALLOWED_SENDERS` — comma-separated allowlist of email senders the agent will respond to; leave empty to accept any sender
-- (optional) `GITHUB_TOKEN`, `PHOENIX_COLLECTOR_ENDPOINT`
+- (optional) `GITHUB_TOKEN` or `GH_TOKEN` for authenticated sandbox read-only
+  GitHub REST, `GITHUB_READONLY_REPO`,
+  `PHOENIX_COLLECTOR_ENDPOINT`
 
 ### Phase 3 — Start host services
 
@@ -200,7 +211,7 @@ $ bash scripts/00-host-services.sh
 
 Brings up the long-lived Docker stack from [extras/docker-compose.yml](extras/docker-compose.yml):
 phoenix (telemetry), MS Graph token manager (Outlook OAuth broker on port 8765), postgres
-(ETL backing store), github-etl / forums-etl workers, and PostgREST on host port 3100.
+(ETL backing store), source ETL workers for mirrored discussions/forums, and PostgREST on host port 3100.
 
 These services are designed to outlive the sandbox: a `bash scripts/tear-down.sh` followed
 by another `bash scripts/bring-up.sh` does **not** require re-running this phase. Only run
@@ -248,7 +259,7 @@ endpoint into the image so OpenInference traces stream into Phoenix at
 ## What this example owns
 
 - **Owns** (in this directory): `agents/hermes/` (the full Hermes asset tree, staged
-  here for convenience), `policy.yaml` (sandbox network/filesystem policy), `extras/`,
+  here for convenience), `policy.yaml` (sandbox network/filesystem policy template), `extras/`,
   `.env`, and `scripts/`:
   - `00-host-services.sh` — host-side bootstrap (Phase 3). Independent of the sandbox lifecycle.
   - `01-gateway.sh` / `02-providers.sh` / `03-sandbox.sh` — phase scripts called by the bring-up orchestrator.
@@ -257,23 +268,21 @@ endpoint into the image so OpenInference traces stream into Phoenix at
   - `snapshot.sh` / `restore.sh` — explicit Hermes state preservation across tear-down/bring-up cycles.
   - `download-traces.sh` — pull ATIF trace records from `/tmp/atif/` inside the sandbox into a host-side tarball. See [Capturing ATIF traces](#capturing-atif-traces) for the env knobs.
   - `host-tls-proxy.py` — optional plain-HTTP forwarder for hosts where the sandbox can't validate the inference endpoint's TLS chain (corporate VPN, split-horizon DNS, mkcert). See [docs/host-tls-proxy.md](docs/host-tls-proxy.md).
-- **Generates and discards**: a sed-patched `.Dockerfile.staged` at the example dir
-  root. OpenShell does the actual build; we patch ARG defaults beforehand because
-  `openshell sandbox create` doesn't expose `--build-arg`.
+- **Generates and discards**: sed-patched `.Dockerfile.staged` and
+  `.policy.staged.yaml` files at the example dir root. OpenShell does the actual
+  build; we patch ARG defaults beforehand because `openshell sandbox create`
+  doesn't expose `--build-arg`, and we patch the GitHub read-only repo scope
+  from `.env` before applying the policy.
 
 The example's Dockerfile drops the upstream `COPY nemoclaw-blueprint/` step —
 nothing in the Hermes runtime reads `/sandbox/.nemoclaw/blueprints/`, so this
 example is **fully self-contained** and never needs a NemoClaw checkout.
 
-The Dockerfile always installs NeMo-Relay: an in-image `pip install` of the
-`nemo-relay` version pinned by `NEMO_RELAY_VERSION` in
-[agents/hermes/Dockerfile](agents/hermes/Dockerfile) (from PyPI), plus a
-re-install of Hermes with the NeMo-Relay integration patch fetched from
-[NVIDIA/NeMo-Relay](https://github.com/NVIDIA/NeMo-Relay) at the pinned
-`NEMO_RELAY_VERSION` tag and applied during the build (~1-2 min on a cold
-build, cached on rebuild). That alone is enough for the agent to write ATIF
-trace records to `/tmp/atif/` — capture them with
-[`scripts/download-traces.sh`](scripts/download-traces.sh).
+The Dockerfile always installs NeMo-Relay: it builds the pinned
+`nemo-relay-cli` release in a builder stage, upgrades Hermes to a version with
+rich plugin hook payloads, and runs a sidecar gateway at startup. That is
+enough for the agent to write ATIF trace records to `/tmp/atif/` — capture
+them with [`scripts/download-traces.sh`](scripts/download-traces.sh).
 
 Setting `PHOENIX_COLLECTOR_ENDPOINT` is a separate opt-in for live
 OpenInference egress: when present, `03-sandbox.sh` bakes the URL into the
@@ -327,7 +336,7 @@ special-case "no file."
   Otherwise leave it empty. See [`certs/README.md`](certs/README.md) for
   details.
 
-## Providers created (mirrors what `nemoclaw onboard` produces)
+## Providers created by `bring-up.sh`
 
 | Provider name | `--type` | Credential env var | Required? |
 |---|---|---|---|
@@ -335,11 +344,52 @@ special-case "no file."
 | `<sandbox>-outlook` | `generic` | `OUTLOOK_CLIENT_ID`, `OUTLOOK_TENANT_ID`, `OUTLOOK_SESSION_UUID` | Optional. Created only when the Outlook block is fully populated; partial config is rejected. At least one of Outlook or Slack must be configured. |
 | `<sandbox>-slack-bridge` | `generic` | `SLACK_BOT_TOKEN` | Optional. At least one of Outlook or Slack must be configured. |
 | `<sandbox>-slack-app` | `generic` | `SLACK_APP_TOKEN` | Optional. Required if Slack is enabled (Socket Mode needs both tokens). |
-| `<sandbox>-github` | `github` | `GITHUB_TOKEN` (or `GH_TOKEN`) | Optional |
+| `<sandbox>-github` | `github` | `GITHUB_TOKEN` or `GH_TOKEN` | Optional but recommended. Enables authenticated live GitHub REST reads. The sandbox receives only the OpenShell placeholder; `policy.yaml` limits use to repo-scoped `GET` routes from approved binaries. |
 
 The `compatible-endpoint` provider is **not** prefixed with the sandbox name — it's a
 shared inference provider and is consumed via `openshell inference set --provider
 compatible-endpoint --model <NEMOCLAW_MODEL>` rather than `--provider` on sandbox create.
+
+`GITHUB_TOKEN` is attached as `<sandbox>-github` for live sandbox GitHub reads.
+If `GITHUB_TOKEN` is empty but `GH_TOKEN` is set, `GH_TOKEN` is used for the
+provider instead. In both cases, the sandbox sees only an OpenShell placeholder;
+the raw token is resolved by the proxy on egress. GitHub write attempts are
+still blocked by the applied policy, which allows only selected `GET` paths
+under `api.github.com/repos/$GITHUB_READONLY_REPO`. If you keep the optional
+host GitHub mirror enabled, it also reads `GITHUB_TOKEN` for API rate limits.
+
+## Changing the available live GitHub repo
+
+The live GitHub policy is repo-scoped. To change the repo the sandbox can read:
+
+1. Set `GITHUB_READONLY_REPO=owner/repo` in `.env`.
+2. For practical API rate limits, set `GITHUB_TOKEN` or `GH_TOKEN`. Private
+   repos require a token with access to the target repo; public repos can be
+   read without a token but use GitHub's lower unauthenticated API limits.
+3. Recreate the sandbox so `scripts/03-sandbox.sh` can stage the Dockerfile env
+   and apply a policy for the new repo:
+
+```bash
+bash scripts/tear-down.sh
+bash scripts/bring-up.sh
+```
+
+For normal repo changes, do not edit `policy.yaml` by hand; `03-sandbox.sh`
+patches the `__GITHUB_READONLY_REPO__` placeholder before applying the staged
+policy. After bring-up, verify the live repo path from the host shell:
+
+```bash
+set -a; . ./.env; set +a
+openshell sandbox exec --name "${SANDBOX_NAME:-hermes-direct}" -- sh -lc \
+  '/usr/bin/python3 /sandbox/.hermes-data/skills/github-readonly-live/scripts/github_readonly.py get . --fields full_name,default_branch,open_issues_count'
+```
+
+`GITHUB_READONLY_REPO` controls only live REST reads through
+`github-readonly-live`. The host-side ETL mirror is independent; set
+`SOURCE_ETL_GITHUB_REPO=owner/repo` if you also want mirrored GitHub
+discussions/history from a different repo, then rerun
+`bash scripts/00-host-services.sh`. Existing mirror database/state is preserved
+unless you remove the compose volumes.
 
 ## Configuration knobs (all env vars)
 
@@ -351,6 +401,9 @@ compatible-endpoint --model <NEMOCLAW_MODEL>` rather than `--provider` on sandbo
 | `NEMOCLAW_MODEL` | `nvidia/nemotron-3-super-120b-a12b` | Inference model passed to `openshell inference set`. |
 | `NEMOCLAW_ENDPOINT_URL` | `https://integrate.api.nvidia.com/v1` | Upstream base URL for the `compatible-endpoint` provider. (`OPENAI_BASE_URL` is also accepted as a fallback.) |
 | `COMPATIBLE_API_KEY` | (none) | Inference API key. Mirrors NemoClaw's `REMOTE_PROVIDER_CONFIG.custom`. (`OPENAI_API_KEY` is also accepted.) |
+| `GITHUB_TOKEN` / `GH_TOKEN` | (none) | Optional GitHub token for authenticated live REST reads. `GITHUB_TOKEN` also feeds the optional host GitHub mirror; if it is unset, `GH_TOKEN` can still create the sandbox provider. |
+| `GITHUB_READONLY_REPO` | `NVIDIA/OpenShell` | The only repo allowed by the live GitHub REST policy, formatted as `owner/repo`. Recreate the sandbox after changing it. |
+| `SOURCE_ETL_GITHUB_REPO` | `NVIDIA/NemoClaw` | Host-side GitHub mirror repo for source-etls. This is independent of `GITHUB_READONLY_REPO`. |
 | `TOKEN_MANAGER_HOST` | `host.openshell.internal` | Host where the MS Graph token manager is reachable from inside the sandbox. |
 | `PHOENIX_COLLECTOR_ENDPOINT` | (none) | Set to e.g. `http://host.openshell.internal:6006/v1/traces` to stream OpenInference traces to a Phoenix collector. ATIF trace generation does not depend on this — NeMo-Relay is always installed and writes ATIF locally to `/tmp/atif/` regardless. |
 
@@ -388,7 +441,7 @@ $ bash scripts/tear-down.sh
 ```
 
 Removes the sandbox, the Outlook/GitHub/Slack providers, and any leftover
-`.Dockerfile.staged`. **Does not** destroy the gateway or stop host services
+staged Dockerfile/policy files. **Does not** destroy the gateway or stop host services
 (phoenix, token manager, postgres, ETLs, postgrest) by default — those are
 typically long-lived. Opt-in flags (mutually exclusive):
 

--- a/examples/personal-community-sentiment-triage/agents/hermes/Dockerfile
+++ b/examples/personal-community-sentiment-triage/agents/hermes/Dockerfile
@@ -97,8 +97,9 @@ RUN adduser --disabled-password --gecos "" --uid 1001 ms-graph-proxy
 COPY certs/ /usr/local/share/ca-certificates/
 RUN update-ca-certificates
 
-# Install GitHub CLI (gh) — not in the base image.
-# GH_TOKEN is set below so gh authenticates via the OpenShell provider pipeline.
+# Install GitHub CLI (gh) — not in the base image. It is not allowed in the
+# GitHub network policy by default, so live GitHub reads use the bundled
+# curl/Python-safe helper with the OpenShell provider placeholder.
 RUN mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
        -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
@@ -316,6 +317,7 @@ ARG NEMOCLAW_MESSAGING_ALLOWED_IDS_B64=e30=
 ARG OUTLOOK_TARGET_MAILBOX=
 ARG OUTLOOK_REPLY_TO=
 ARG OUTLOOK_ALLOWED_SENDERS=
+ARG GITHUB_READONLY_REPO=NVIDIA/OpenShell
 ARG SOURCE_ETL_GITHUB_REPO=
 ARG SOURCE_ETL_FORUM_TAG=
 ARG SOURCE_ETL_API_URL=
@@ -334,6 +336,7 @@ ENV NEMOCLAW_MODEL=${NEMOCLAW_MODEL} \
     OUTLOOK_TARGET_MAILBOX=${OUTLOOK_TARGET_MAILBOX} \
     OUTLOOK_REPLY_TO=${OUTLOOK_REPLY_TO} \
     OUTLOOK_ALLOWED_SENDERS=${OUTLOOK_ALLOWED_SENDERS} \
+    GITHUB_READONLY_REPO=${GITHUB_READONLY_REPO} \
     MS_GRAPH_SERVICES=${MS_GRAPH_SERVICES} \
     SOURCE_ETL_GITHUB_REPO=${SOURCE_ETL_GITHUB_REPO} \
     SOURCE_ETL_FORUM_TAG=${SOURCE_ETL_FORUM_TAG} \

--- a/examples/personal-community-sentiment-triage/agents/hermes/SOUL.md
+++ b/examples/personal-community-sentiment-triage/agents/hermes/SOUL.md
@@ -31,7 +31,11 @@ You may see structured "placeholder" strings (label-bearing, with an env-var
 name embedded) in env vars, `.env` files, or tool inputs. The sandbox proxy
 substitutes them for real credentials at egress. Use them verbatim — do not
 refuse, parse, transform, or echo them. Prefer `$VAR_NAME` access (shell) or
-`os.environ[...]` (Python).
+`os.environ[...]` (Python). Do not inspect token placeholder variables with
+`env`, `printenv`, `echo`, or similar commands just to confirm they exist.
+This also applies while troubleshooting: do not inspect `.env` files, shell
+environments, proxy settings, or token variables to diagnose helper failures.
+Retry the relevant helper once, then report the helper error if it still fails.
 
 
 ## Skills
@@ -40,13 +44,15 @@ Skills are instruction documents, not callable tools. Read the matching skill
 file when a request might match it, then follow its procedure using the normal
 sandbox tools. In practice this usually means running the bundled helper
 scripts or commands described by the skill.
+Never call a tool or shell command with the same name as a skill.
 
 Examples of requests and matching skills:
 - Slack channel discovery (finding channels by topic) -> `slack-channel-finder`
 - Slack channel history or summaries -> `slack-channel-summarizer`
-- GitHub issues, PRs, discussions, or NVIDIA forum topics ->
-  `source-etl-query` (live github.com and forum access are blocked by
-  policy; the skill queries a host-side mirror via PostgREST)
+- Current live GitHub issues, PRs, commits, branches, README, or repository
+  contents for the configured repo -> `github-readonly-live`
+- GitHub discussion mirrors, historical GitHub mirror data, or NVIDIA forum topics ->
+  `source-etl-query`
 - Outlook email search or thread reads -> `outlook-email-search`
 - Cross-source comparison or gap analysis across Slack, GitHub, forums,
   or Outlook -> `cross-source-gap-analysis`, plus whichever source
@@ -58,7 +64,9 @@ Your initial setup includes skills which you should prefer to use over creating
 custom Python code, terminal commands, etc:
 - interacting with Slack
 - interacting with Outlook
-- interacting with GitHub data via a local database populated with ETL cron jobs
+- interacting with live GitHub data for one policy-scoped repo
+- interacting with mirrored GitHub/forum data via a local database populated
+  with ETL cron jobs
 
 ### Writing New Skills
 
@@ -69,13 +77,41 @@ in these origial skills and scripts when creating new skills or saving memories.
 
 ## Tool guidance for default skills
 
-### GitHub and NVIDIA forums
+### GitHub live REST
 
-Live access to `github.com` and the NVIDIA forums is **blocked by sandbox
-policy** — direct calls (`gh`, `curl https://github.com/...`, fetching
-forum HTML) will return 403. Both data sources are pre-mirrored to a
-host-side Postgres bridge exposed via PostgREST. Use the
-`source-etl-query` skill for any GitHub or forum lookup.
+Live GitHub access is available only through authenticated, policy-scoped `GET`
+requests to `api.github.com` for the single configured repo in
+`$GITHUB_READONLY_REPO`. GitHub auth comes from an OpenShell provider
+placeholder in `GITHUB_TOKEN` or `GH_TOKEN`; use it only through the
+`github-readonly-live` helper and do not print, inspect, or modify it.
+For any live GitHub request, your first action must be either to read the
+`github-readonly-live` skill or to run the exact helper path documented by that
+skill. Do not run `github-readonly-live` as a command, search for GitHub
+binaries, or probe the shell environment first.
+Use `github-readonly-live` for current issues, PRs, commits, branches, README,
+or repository contents from that repo. For new GitHub questions, use the
+helper's generic `get` command with repo-relative REST routes, `--param`
+query params, `--paginate`, `--count`, `--fields`, and `--exclude-pulls` as
+needed. Do not invent one-off GitHub scripts when the generic helper can make
+the policy-compatible request directly.
+
+Do not use `gh`, `git`, `github.com`, `raw.githubusercontent.com`,
+`codeload.github.com`, GraphQL, search endpoints, or hand-written GitHub
+requests. If GitHub returns 403 from the OpenShell proxy, treat it as a policy
+boundary and report the scope instead of trying another host, binary, or method.
+If the helper reports a transient DNS, connection, or timeout error, retry the
+same helper command once. If it still fails, report that live GitHub access
+failed and include the non-secret helper error. Do not troubleshoot by checking
+token env vars, `.env` files, proxy env vars, DNS tools, `curl`, `gh`, `git`,
+custom GitHub request code, or alternate GitHub hosts.
+
+### Source ETL mirror and NVIDIA forums
+
+Use `source-etl-query` for GitHub discussions, historical GitHub mirror data,
+and NVIDIA forum topics. The mirror is served by a host-side PostgREST bridge
+and may lag live sources. Use live GitHub REST for current issues and PRs when
+the repo is covered by `$GITHUB_READONLY_REPO`. NVIDIA forum live HTML access
+is blocked by sandbox policy.
 
 ### Slack
 
@@ -92,4 +128,3 @@ endpoints needed by that bridge.
 ### Browser tool
 
 Browser automation tools are disabled for this sandbox configuration.
-

--- a/examples/personal-community-sentiment-triage/agents/hermes/skills/cross-source-gap-analysis/SKILL.md
+++ b/examples/personal-community-sentiment-triage/agents/hermes/skills/cross-source-gap-analysis/SKILL.md
@@ -21,6 +21,7 @@ Load the source skills you need first:
 
 - `slack-channel-summarizer`
 - `slack-channel-finder`
+- `github-readonly-live`
 - `source-etl-query`
 - `outlook-email-search`
 
@@ -34,7 +35,10 @@ combine the findings once you have them.
 Prefer a small, relevant slice from each source over broad collection. For example:
 
 - a recent Slack window for the relevant channel
-- mirrored GitHub issues, PRs, or discussions for the repo or feature area
+- live GitHub issues or PRs from `$GITHUB_READONLY_REPO`, when current state
+  matters
+- mirrored GitHub discussions, or historical issue/PR mirror data for the repo
+  or feature area, when the task is about the ETL mirror or discussions
 - mirrored NVIDIA forum topics for the `nemoclaw` tag scope
 - recent emails filtered to the relevant project and date range
 
@@ -69,3 +73,5 @@ Do not invent gaps just because one source had less data available.
 - Do not over-collect. A narrow comparison is usually better than an exhaustive scrape.
 - Distinguish between "not discussed" and "not observed in the sampled data".
 - Distinguish between “not observed in the mirror” and “not present on the live source”.
+- Keep live GitHub REST findings separate from source ETL mirror findings when
+  the scopes or freshness differ.

--- a/examples/personal-community-sentiment-triage/agents/hermes/skills/github-readonly-live/SKILL.md
+++ b/examples/personal-community-sentiment-triage/agents/hermes/skills/github-readonly-live/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: github-readonly-live
+description: Read the configured live GitHub repository through authenticated, policy-scoped GitHub REST GET requests.
+---
+
+# github-readonly-live
+
+Use this skill for current live GitHub REST data from the single repository
+allowed by the sandbox policy.
+
+## When to use
+
+- Inspect the currently allowed live GitHub repository.
+- Read current issues, issue comments, pull requests, pull request files,
+  reviews, commits, branches, labels, milestones, README, or repository
+  contents.
+- Check live state when the source ETL mirror may be stale or empty.
+
+Do not use this skill for GitHub discussions or NVIDIA forums. Use
+`source-etl-query` for those mirrored sources.
+
+## Access model
+
+- The allowed repository is `$GITHUB_READONLY_REPO`.
+- Requests use the OpenShell GitHub provider placeholder from `GITHUB_TOKEN`
+  or `GH_TOKEN` when present. Treat it as a secret placeholder: do not print
+  it, modify it, or copy it into responses.
+- Do not run `env`, `printenv`, `echo`, or similar commands against
+  `GITHUB_TOKEN` or `GH_TOKEN`. The helper loads the placeholder itself.
+- Do not inspect `.env` files, shell environments, proxy settings, or token
+  variables to troubleshoot GitHub. If the helper cannot authenticate or reach
+  GitHub, it will report the error itself.
+- Only repo-scoped `GET` requests to `api.github.com` are allowed.
+- Do not use `gh`, `git`, `github.com`, `raw.githubusercontent.com`,
+  `codeload.github.com`, GraphQL, or GitHub search endpoints.
+- If a request returns an OpenShell policy 403, report the policy scope instead
+  of trying another GitHub host, another binary, or a write-like method.
+- If explicitly asked to validate that a write is blocked, do not inspect the
+  token variable. Use direct shell expansion in the Authorization header and
+  report only the policy error.
+
+Write-block validation pattern:
+
+```bash
+auth="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+curl -sS -o /tmp/github-write-denied.json -w 'HTTP Status: %{http_code}\n' \
+  -X POST \
+  -H "Authorization: Bearer ${auth}" \
+  -H 'Accept: application/vnd.github+json' \
+  -H 'X-GitHub-Api-Version: 2022-11-28' \
+  "https://api.github.com/repos/${GITHUB_READONLY_REPO:-NVIDIA/OpenShell}/issues/<number>/comments" \
+  -d '{"body":"policy-validation-test"}'
+cat /tmp/github-write-denied.json
+```
+
+## Procedure
+
+Always run the bundled helper script via the terminal tool. It constructs only
+repo-scoped GitHub REST GET requests. Prefer the generic `get` command and map
+the user's question to a repo-relative REST route plus query params.
+Do not invoke `github-readonly-live` as a shell command; it is the skill name,
+not an executable. Do not call a tool named `github-readonly-live`; use
+`skill_view` only if you need to read this instruction file.
+Do not search for GitHub binaries with `which`, `command -v`, `ls /usr/bin`,
+or similar commands. The canonical helper path below is the only supported live
+GitHub access path.
+
+On transient helper failures such as DNS resolution errors, connection resets,
+or timeouts, retry the exact same helper command once. If the retry fails, give
+the user the helper error and stop. Do not diagnose by inspecting token env vars,
+`.env` files, proxy env vars, DNS tools, `curl`, `gh`, `git`, custom Python
+requests, or alternate GitHub hosts.
+
+```bash
+/usr/bin/python3 /sandbox/.hermes-data/skills/github-readonly-live/scripts/github_readonly.py rate-limit
+/usr/bin/python3 /sandbox/.hermes-data/skills/github-readonly-live/scripts/github_readonly.py get . --fields full_name,description,open_issues_count
+/usr/bin/python3 /sandbox/.hermes-data/skills/github-readonly-live/scripts/github_readonly.py get issues --param state=open --limit 20 --exclude-pulls --fields number,title,state,html_url
+/usr/bin/python3 /sandbox/.hermes-data/skills/github-readonly-live/scripts/github_readonly.py get issues/<number>/comments --paginate --fields user.login,created_at,body
+/usr/bin/python3 /sandbox/.hermes-data/skills/github-readonly-live/scripts/github_readonly.py get pulls --param state=open --paginate --count
+/usr/bin/python3 /sandbox/.hermes-data/skills/github-readonly-live/scripts/github_readonly.py get pulls/<number>/files --paginate --fields filename,status,changes
+/usr/bin/python3 /sandbox/.hermes-data/skills/github-readonly-live/scripts/github_readonly.py get contents/<path>
+```
+
+Generic route rules:
+
+- Use repo-relative REST routes only: `.`, `issues`, `issues/<number>`,
+  `issues/<number>/comments`, `pulls`, `pulls/<number>`,
+  `pulls/<number>/files`, `commits`, `branches`, `contents/<path>`, etc.
+- Put query strings in `--param KEY=VALUE`, not in the route.
+- Use `--paginate --count` for exact counts. Use `--limit` only when the user
+  asks for a sample or "latest N" items.
+- Use `--fields` to keep output small instead of piping to `python -c`, `jq`,
+  or custom scripts.
+- Use `--exclude-pulls` on the `issues` route when the user asks for issues
+  rather than PRs, because GitHub's issues endpoint includes pull requests.
+
+Compatibility aliases such as `issues`, `issue-counts`, `pulls`,
+`pull-counts`, and `contents` are available, but the generic `get` command is
+the default pattern for new GitHub questions.
+
+## Pitfalls
+
+- For "how many issues" questions, use generic count:
+  `get issues --param state=all --paginate --count --exclude-pulls`. Do not use
+  GitHub search endpoints; they are outside policy by design.
+- For "how many PRs" or "how many pull requests" questions, use generic count:
+  `get pulls --param state=open --paginate --count` or the requested state. Do
+  not estimate from a single page.
+- The live GitHub scope and the source ETL mirror scope can be different repos.
+  Do not merge their results without naming which source each fact came from.
+- If the helper is rate-limited, report that GitHub auth was absent or
+  exhausted; use `source-etl-query` only when the user's task can tolerate
+  mirrored data.
+- The helper filters pull requests out of the `issues` command. Use `pulls` or
+  `pull-counts` when the user specifically asks for PRs.

--- a/examples/personal-community-sentiment-triage/agents/hermes/skills/github-readonly-live/scripts/github_readonly.py
+++ b/examples/personal-community-sentiment-triage/agents/hermes/skills/github-readonly-live/scripts/github_readonly.py
@@ -1,0 +1,422 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Authenticated, repo-scoped GitHub REST GET helper."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+API = "https://api.github.com"
+REPO_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9-]{0,38}/[A-Za-z0-9._-]+$")
+PARAM_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+GENERIC_ROOTS = {
+    "issues",
+    "labels",
+    "milestones",
+    "pulls",
+    "commits",
+    "branches",
+    "contents",
+    "readme",
+}
+
+
+def repo_name() -> str:
+    repo = (os.environ.get("GITHUB_READONLY_REPO") or "NVIDIA/OpenShell").strip()
+    if not REPO_RE.fullmatch(repo):
+        raise SystemExit(f"invalid GITHUB_READONLY_REPO {repo!r}; expected owner/repo")
+    return repo
+
+
+def positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be positive")
+    return parsed
+
+
+def per_page(value: str) -> int:
+    parsed = positive_int(value)
+    if parsed > 100:
+        raise argparse.ArgumentTypeError("GitHub per_page maximum is 100")
+    return parsed
+
+
+def optional_positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be zero or positive")
+    return parsed
+
+
+def load_env_defaults() -> None:
+    hermes_home = Path(os.environ.get("HERMES_HOME", "/sandbox/.hermes-data"))
+    for env_file in (hermes_home / ".env", Path("/sandbox/.hermes-data/.env"), Path("/sandbox/.hermes/.env")):
+        if not env_file.is_file():
+            continue
+        for raw_line in env_file.read_text(encoding="utf-8").splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            if not os.environ.get(key):
+                os.environ[key] = value.strip()
+
+
+def auth_header() -> str | None:
+    load_env_defaults()
+    token = (os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN") or "").strip()
+    if not token:
+        return None
+    return f"Bearer {token}"
+
+
+def clean_contents_path(value: str) -> str:
+    value = value.strip("/")
+    if not value:
+        return ""
+    parts = value.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise argparse.ArgumentTypeError("path must be a repository-relative path")
+    return "/".join(urllib.parse.quote(part, safe="") for part in parts)
+
+
+def clean_repo_route(value: str) -> str:
+    route = value.strip()
+    if route in {"", ".", "/"}:
+        return ""
+    if "://" in route or "?" in route or "#" in route or "\\" in route:
+        raise argparse.ArgumentTypeError("route must be a repo-relative REST path, not a URL or query string")
+    route = route.strip("/")
+    parts = route.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise argparse.ArgumentTypeError("route must not contain empty, current, or parent-directory segments")
+    if parts[0] == "repos":
+        raise argparse.ArgumentTypeError("route must be relative to the configured repo, for example 'issues/123'")
+    if parts[0] not in GENERIC_ROOTS:
+        allowed = ", ".join(sorted(GENERIC_ROOTS))
+        raise argparse.ArgumentTypeError(f"route root {parts[0]!r} is outside policy; allowed roots: {allowed}")
+    return "/".join(urllib.parse.quote(urllib.parse.unquote(part), safe="") for part in parts)
+
+
+def parse_param(value: str) -> tuple[str, str]:
+    if "=" not in value:
+        raise argparse.ArgumentTypeError("query params must use KEY=VALUE")
+    key, param_value = value.split("=", 1)
+    key = key.strip()
+    if not PARAM_RE.fullmatch(key):
+        raise argparse.ArgumentTypeError(f"invalid query parameter name: {key!r}")
+    if any(ch in param_value for ch in "\r\n\0"):
+        raise argparse.ArgumentTypeError("query parameter values must not contain control characters")
+    return key, param_value
+
+
+def params_dict(pairs: list[tuple[str, str]]) -> dict[str, str]:
+    return {key: value for key, value in pairs}
+
+
+def get_json(path: str, params: dict[str, Any] | None = None) -> Any:
+    url = f"{API}{path}"
+    if params:
+        clean_params = {k: v for k, v in params.items() if v is not None}
+        if clean_params:
+            url = f"{url}?{urllib.parse.urlencode(clean_params)}"
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "nemoclaw-github-readonly/1.0",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    auth = auth_header()
+    if auth:
+        headers["Authorization"] = auth
+
+    request = urllib.request.Request(
+        url,
+        headers=headers,
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        print(f"GitHub request failed: HTTP {exc.code} {exc.reason}", file=sys.stderr)
+        reset = exc.headers.get("X-RateLimit-Reset")
+        if reset:
+            try:
+                reset_dt = dt.datetime.fromtimestamp(int(reset), tz=dt.UTC)
+                print(f"GitHub rate limit resets at {reset_dt.isoformat()}", file=sys.stderr)
+            except ValueError:
+                pass
+        if body:
+            print(body[:2000], file=sys.stderr)
+        raise SystemExit(1) from exc
+    except urllib.error.URLError as exc:
+        print(f"GitHub request failed: {exc}", file=sys.stderr)
+        print(
+            "Retry this same github_readonly.py command once. Do not inspect "
+            "token, .env, or proxy variables; the helper loads provider "
+            "placeholders itself.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1) from exc
+
+
+def repo_path(suffix: str = "") -> str:
+    repo = repo_name()
+    return f"/repos/{repo}{suffix}"
+
+
+def paged_items(path: str, params: dict[str, Any] | None = None) -> list[Any]:
+    items, _complete = collect_items(path, params=params, paginate=True)
+    return items
+
+
+def collect_items(
+    path: str,
+    params: dict[str, Any] | None = None,
+    *,
+    paginate: bool,
+    limit: int | None = None,
+    exclude_pulls: bool = False,
+    page_size: int = 100,
+    max_pages: int = 0,
+) -> tuple[list[Any], bool]:
+    results: list[Any] = []
+    page = int((params or {}).get("page", 1) or 1)
+    base_params = {k: v for k, v in (params or {}).items() if k not in {"page", "per_page"}}
+
+    while True:
+        page_params = dict(base_params)
+        page_params.update({"per_page": min(page_size, 100), "page": page})
+        page_items = get_json(path, page_params)
+        if not isinstance(page_items, list):
+            raise SystemExit(f"unexpected GitHub list response for {path}")
+        raw_count = len(page_items)
+        if exclude_pulls:
+            page_items = issue_only(page_items)
+        results.extend(page_items)
+        if limit is not None and len(results) >= limit:
+            return results[:limit], True
+        if raw_count < min(page_size, 100):
+            return results, True
+        if not paginate:
+            return results, False
+        page += 1
+        if max_pages and page > max_pages:
+            return results, False
+
+
+def issue_only(items: list[Any]) -> list[Any]:
+    return [item for item in items if isinstance(item, dict) and "pull_request" not in item]
+
+
+def issue_counts() -> dict[str, int]:
+    counts = {"open": 0, "closed": 0, "total": 0}
+    for item in issue_only(paged_items(repo_path("/issues"), {"state": "all"})):
+        state = item.get("state")
+        if state in ("open", "closed"):
+            counts[state] += 1
+            counts["total"] += 1
+    return counts
+
+
+def pull_counts(state: str) -> dict[str, int]:
+    if state == "all":
+        open_count = len(paged_items(repo_path("/pulls"), {"state": "open"}))
+        closed_count = len(paged_items(repo_path("/pulls"), {"state": "closed"}))
+        return {"open": open_count, "closed": closed_count, "total": open_count + closed_count}
+    count = len(paged_items(repo_path("/pulls"), {"state": state}))
+    return {state: count, "total": count}
+
+
+def project_field(value: Any, field: str) -> Any:
+    current = value
+    for part in field.split("."):
+        if isinstance(current, dict) and part in current:
+            current = current[part]
+        else:
+            return None
+    return current
+
+
+def project_fields(data: Any, fields: list[str]) -> Any:
+    if not fields:
+        return data
+
+    def project_one(item: Any) -> Any:
+        if not isinstance(item, dict):
+            return item
+        return {field: project_field(item, field) for field in fields}
+
+    if isinstance(data, list):
+        return [project_one(item) for item in data]
+    return project_one(data)
+
+
+def generic_get(args: argparse.Namespace) -> Any:
+    try:
+        route = clean_repo_route(args.route)
+    except argparse.ArgumentTypeError as exc:
+        raise SystemExit(str(exc)) from exc
+    params = params_dict(args.param)
+    fields = [field.strip() for field in args.fields.split(",") if field.strip()] if args.fields else []
+    path = repo_path(f"/{route}" if route else "")
+
+    list_mode = args.paginate or args.count or args.limit is not None or args.exclude_pulls
+    if list_mode:
+        items, complete = collect_items(
+            path,
+            params=params,
+            paginate=args.paginate or args.count,
+            limit=args.limit,
+            exclude_pulls=args.exclude_pulls,
+            page_size=args.page_size,
+            max_pages=args.max_pages,
+        )
+        if args.count:
+            return {"count": len(items), "complete": complete}
+        return project_fields(items, fields)
+
+    return project_fields(get_json(path, params), fields)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    generic = sub.add_parser("get")
+    generic.add_argument("route", help="repo-relative REST route, e.g. '.', 'issues', 'issues/123/comments', 'pulls/123/files'")
+    generic.add_argument("--param", action="append", type=parse_param, default=[], metavar="KEY=VALUE")
+    generic.add_argument("--paginate", action="store_true", help="fetch every page for list responses")
+    generic.add_argument("--count", action="store_true", help="print a count for list responses; implies pagination")
+    generic.add_argument("--limit", type=positive_int, default=None, help="maximum list items to return after filtering")
+    generic.add_argument("--page-size", type=per_page, default=100)
+    generic.add_argument("--max-pages", type=optional_positive_int, default=0, help="pagination safety cap; 0 means no cap")
+    generic.add_argument("--exclude-pulls", action="store_true", help="filter pull requests out of GitHub's issues endpoint")
+    generic.add_argument("--fields", default="", help="comma-separated top-level or dotted fields to keep")
+
+    sub.add_parser("rate-limit")
+    sub.add_parser("repo")
+    sub.add_parser("readme")
+
+    labels = sub.add_parser("labels")
+    labels.add_argument("--limit", type=per_page, default=30)
+
+    milestones = sub.add_parser("milestones")
+    milestones.add_argument("--state", choices=["open", "closed", "all"], default="open")
+    milestones.add_argument("--limit", type=per_page, default=30)
+
+    issues = sub.add_parser("issues")
+    issues.add_argument("--state", choices=["open", "closed", "all"], default="open")
+    issues.add_argument("--limit", type=per_page, default=30)
+
+    sub.add_parser("issue-counts")
+
+    issue = sub.add_parser("issue")
+    issue.add_argument("number", type=positive_int)
+
+    issue_comments = sub.add_parser("issue-comments")
+    issue_comments.add_argument("number", type=positive_int)
+    issue_comments.add_argument("--limit", type=per_page, default=30)
+
+    pulls = sub.add_parser("pulls")
+    pulls.add_argument("--state", choices=["open", "closed", "all"], default="open")
+    pulls.add_argument("--limit", type=per_page, default=30)
+
+    pull_counts_parser = sub.add_parser("pull-counts")
+    pull_counts_parser.add_argument("--state", choices=["open", "closed", "all"], default="open")
+
+    pull = sub.add_parser("pull")
+    pull.add_argument("number", type=positive_int)
+
+    for name in ("pull-files", "pull-commits", "pull-reviews", "pull-comments"):
+        p = sub.add_parser(name)
+        p.add_argument("number", type=positive_int)
+        p.add_argument("--limit", type=per_page, default=30)
+
+    commits = sub.add_parser("commits")
+    commits.add_argument("--limit", type=per_page, default=30)
+
+    branches = sub.add_parser("branches")
+    branches.add_argument("--limit", type=per_page, default=30)
+
+    contents = sub.add_parser("contents")
+    contents.add_argument("path", nargs="?", type=clean_contents_path, default="")
+
+    args = parser.parse_args()
+
+    if args.command == "get":
+        data = generic_get(args)
+    elif args.command == "rate-limit":
+        data = get_json("/rate_limit")
+    elif args.command == "repo":
+        data = get_json(repo_path())
+    elif args.command == "readme":
+        data = get_json(repo_path("/readme"))
+    elif args.command == "labels":
+        data = get_json(repo_path("/labels"), {"per_page": args.limit})
+    elif args.command == "milestones":
+        data = get_json(repo_path("/milestones"), {"state": args.state, "per_page": args.limit})
+    elif args.command == "issues":
+        collected: list[Any] = []
+        page = 1
+        while len(collected) < args.limit:
+            items = get_json(repo_path("/issues"), {"state": args.state, "per_page": 100, "page": page})
+            if not isinstance(items, list):
+                raise SystemExit("unexpected GitHub issues response")
+            collected.extend(issue_only(items))
+            if len(items) < 100:
+                break
+            page += 1
+        data = collected[: args.limit]
+    elif args.command == "issue-counts":
+        data = issue_counts()
+    elif args.command == "issue":
+        data = get_json(repo_path(f"/issues/{args.number}"))
+    elif args.command == "issue-comments":
+        data = get_json(repo_path(f"/issues/{args.number}/comments"), {"per_page": args.limit})
+    elif args.command == "pulls":
+        data = get_json(repo_path("/pulls"), {"state": args.state, "per_page": args.limit})
+    elif args.command == "pull-counts":
+        data = pull_counts(args.state)
+    elif args.command == "pull":
+        data = get_json(repo_path(f"/pulls/{args.number}"))
+    elif args.command == "pull-files":
+        data = get_json(repo_path(f"/pulls/{args.number}/files"), {"per_page": args.limit})
+    elif args.command == "pull-commits":
+        data = get_json(repo_path(f"/pulls/{args.number}/commits"), {"per_page": args.limit})
+    elif args.command == "pull-reviews":
+        data = get_json(repo_path(f"/pulls/{args.number}/reviews"), {"per_page": args.limit})
+    elif args.command == "pull-comments":
+        data = get_json(repo_path(f"/pulls/{args.number}/comments"), {"per_page": args.limit})
+    elif args.command == "commits":
+        data = get_json(repo_path("/commits"), {"per_page": args.limit})
+    elif args.command == "branches":
+        data = get_json(repo_path("/branches"), {"per_page": args.limit})
+    elif args.command == "contents":
+        suffix = "/contents" if not args.path else f"/contents/{args.path}"
+        data = get_json(repo_path(suffix))
+    else:
+        parser.error(f"unknown command: {args.command}")
+
+    print(json.dumps(data, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/personal-community-sentiment-triage/agents/hermes/skills/source-etl-query/SKILL.md
+++ b/examples/personal-community-sentiment-triage/agents/hermes/skills/source-etl-query/SKILL.md
@@ -1,25 +1,33 @@
 ---
 name: source-etl-query
-description: Query the host-side source-etls REST mirror for GitHub and NVIDIA forums research.
+description: Query the host-side source-etls REST mirror for GitHub discussions, historical GitHub mirror data, and NVIDIA forums research.
 ---
 
 # source-etl-query
 
 Use this skill to query the host-side REST bridge served by `source-etls`.
+This is the mirror path, not the live GitHub REST path.
 
 ## When to use
 
-- Inspect mirrored GitHub issues
-- Inspect mirrored pull requests
+- Inspect mirrored GitHub issues or pull requests when the user explicitly asks
+  for mirror data, historical mirror state, or ETL freshness checks
 - Inspect mirrored GitHub discussions
 - Inspect mirrored NVIDIA forum topics
+- Build digests or comparisons that should use the hourly ETL mirror
+
+Use `github-readonly-live` instead when the user asks for current live GitHub
+issues, PRs, commits, branches, README, or repository contents from the single
+repo allowed by `$GITHUB_READONLY_REPO`.
 
 ## Access model
 
 - Use the helper script in this skill.
 - Prefer the helper scripts over custom REST queries
-- The sandbox should treat this bridge as the default source for mirrored GitHub
-  and forum data in the NVIDIA setup path.
+- The sandbox should treat this bridge as the default source for GitHub
+  discussions and NVIDIA forum data in the NVIDIA setup path.
+- The mirror and `$GITHUB_READONLY_REPO` may point at different repos. Keep
+  mirror facts and live GitHub facts labeled separately.
 
 ## Required Environment
 
@@ -34,16 +42,17 @@ as a named skill tool.
 ### 1. Query the mirrored source through the REST bridge
 
 ```bash
-/usr/bin/python3 /sandbox/.hermes-data/skills/source-etl-query/scripts/query_source_etl.py github-issues --limit 20
-/usr/bin/python3 /sandbox/.hermes-data/skills/source-etl-query/scripts/query_source_etl.py github-prs --limit 20
 /usr/bin/python3 /sandbox/.hermes-data/skills/source-etl-query/scripts/query_source_etl.py github-discussions --limit 20
 /usr/bin/python3 /sandbox/.hermes-data/skills/source-etl-query/scripts/query_source_etl.py forum-topics --limit 20
+# Historical mirror checks only; use github-readonly-live for current issues/PRs.
+/usr/bin/python3 /sandbox/.hermes-data/skills/source-etl-query/scripts/query_source_etl.py github-issues --limit 20
+/usr/bin/python3 /sandbox/.hermes-data/skills/source-etl-query/scripts/query_source_etl.py github-prs --limit 20
 ```
 
 ### 2. Narrow the result set when needed
 
 ```bash
-/usr/bin/python3 /sandbox/.hermes-data/skills/source-etl-query/scripts/query_source_etl.py github-issues --search <keyword> --limit 10
+/usr/bin/python3 /sandbox/.hermes-data/skills/source-etl-query/scripts/query_source_etl.py github-discussions --search <keyword> --limit 10
 /usr/bin/python3 /sandbox/.hermes-data/skills/source-etl-query/scripts/query_source_etl.py forum-topics --search <keyword> --limit 10
 ```
 
@@ -64,21 +73,25 @@ is asking about.
 **If results exist but are not relevant to the user's question:**
 - Run a broad unfiltered query first to show what IS in the database:
   ```bash
-  /usr/bin/python3 /sandbox/.hermes-data/skills/source-etl-query/scripts/query_source_etl.py github-issues --limit 5
+  /usr/bin/python3 /sandbox/.hermes-data/skills/source-etl-query/scripts/query_source_etl.py github-discussions --limit 5
   /usr/bin/python3 /sandbox/.hermes-data/skills/source-etl-query/scripts/query_source_etl.py forum-topics --limit 5
   ```
 - Then tell the user what repo/topics the mirror actually contains, e.g.:
-  "The ETL mirror contains issues from `NVIDIA/NemoClaw` and forum topics
-  tagged `nemoclaw`. If you need data from a different repo or topic, the
-  ETL target would need to be reconfigured."
+  "The ETL mirror contains discussions from `NVIDIA/NemoClaw` and forum
+  topics tagged `nemoclaw`. If you need mirror data from a different repo or
+  topic, the ETL target would need to be reconfigured."
 
-**Do not fall back to live GitHub or forum requests** — the sandbox has no
-egress to those hosts.
+**Do not fall back to live NVIDIA forum requests** — the sandbox has no egress
+to forum HTML. For GitHub, switch to `github-readonly-live` only when the user
+needs current live data from `$GITHUB_READONLY_REPO`; otherwise explain the ETL
+mirror scope or freshness limitation.
 
 ## Pitfalls
 
 - The mirror is refreshed hourly, so it is not guaranteed to match the live
   source instantly.
 - The ETL scope is configured per-deployment — forum topics follow the
-  configured tag, and GitHub issues follow the configured repo. Neither covers
-  the whole of GitHub or the entire forums site.
+  configured tag, and GitHub mirror rows follow the configured repo. Neither
+  covers the whole of GitHub or the entire forums site.
+- Do not describe mirror data as live. If combining it with live GitHub REST
+  data, say which facts came from the mirror and which came from live REST.

--- a/examples/personal-community-sentiment-triage/agents/hermes/start.sh
+++ b/examples/personal-community-sentiment-triage/agents/hermes/start.sh
@@ -143,7 +143,7 @@ refresh_hermes_provider_placeholders() {
   local env_file="${HERMES_WRITABLE}/.env"
   [ -f "$env_file" ] || return 0
 
-  local keys="TELEGRAM_BOT_TOKEN DISCORD_BOT_TOKEN SLACK_BOT_TOKEN SLACK_APP_TOKEN"
+  local keys="TELEGRAM_BOT_TOKEN DISCORD_BOT_TOKEN SLACK_BOT_TOKEN SLACK_APP_TOKEN GITHUB_TOKEN GH_TOKEN"
   local has_scoped_placeholder=0
   local key value
   for key in $keys; do
@@ -182,6 +182,7 @@ with open(env_file, encoding="utf-8") as f:
 
 changed = False
 updated = []
+seen = set()
 for line in lines:
     stripped = line.rstrip("\n")
     replaced = False
@@ -189,11 +190,17 @@ for line in lines:
         if stripped.startswith(f"{key}="):
             new_line = f"{key}={value}\n"
             updated.append(new_line)
+            seen.add(key)
             changed = changed or new_line != line
             replaced = True
             break
     if not replaced:
         updated.append(line)
+
+for key, value in replacements.items():
+    if key not in seen:
+        updated.append(f"{key}={value}\n")
+        changed = True
 
 if not changed:
     sys.exit(0)
@@ -445,6 +452,10 @@ export https_proxy="$_PROXY_URL"
 export no_proxy="$_NO_PROXY_VAL"
 export PYTHONPATH="${PATCHES_DIR}${PYTHONPATH:+:${PYTHONPATH}}"
 
+# GitHub credentials reach the sandbox only as OpenShell provider placeholders.
+# policy.yaml still limits GitHub egress to repo-scoped REST GET requests.
+export GITHUB_READONLY_REPO="${GITHUB_READONLY_REPO:-NVIDIA/OpenShell}"
+
 # OpenShell injects SSL_CERT_FILE/CURL_CA_BUNDLE for its L7 proxy CA. Persist
 # them into connect-session shells so Python Slack probes and Hermes tools trust
 # the same proxy CA that the entrypoint received at startup.
@@ -478,7 +489,7 @@ export no_proxy="$_NO_PROXY_VAL"
 export PYTHONPATH="${PATCHES_DIR}\${PYTHONPATH:+:\${PYTHONPATH}}"
 export HERMES_HOME="${HERMES_WRITABLE}"
 export SLACK_BOT_TOKEN="${SLACK_BOT_TOKEN:-openshell:resolve:env:SLACK_BOT_TOKEN}"
-export GITHUB_TOKEN="${GITHUB_TOKEN:-openshell:resolve:env:GITHUB_TOKEN}"
+export GITHUB_READONLY_REPO="${GITHUB_READONLY_REPO:-NVIDIA/OpenShell}"
 export OUTLOOK_CLIENT_ID="${OUTLOOK_CLIENT_ID:-openshell:resolve:env:OUTLOOK_CLIENT_ID}"
 export OUTLOOK_SESSION_UUID="${OUTLOOK_SESSION_UUID:-openshell:resolve:env:OUTLOOK_SESSION_UUID}"
 export MS_GRAPH_SIDECAR_URL="http://127.0.0.1:${SIDECAR_PORT}"
@@ -491,6 +502,12 @@ PROXYEOF
     _ca_env_value="${!_ca_env_name:-}"
     if [ -n "$_ca_env_value" ]; then
       printf 'export %s=%q\n' "$_ca_env_name" "$_ca_env_value"
+    fi
+  done
+  for _provider_env_name in GITHUB_TOKEN GH_TOKEN; do
+    _provider_env_value="${!_provider_env_name:-}"
+    if [ -n "$_provider_env_value" ]; then
+      printf 'export %s=%q\n' "$_provider_env_name" "$_provider_env_value"
     fi
   done
 } | emit_sandbox_sourced_file "$_PROXY_ENV_FILE"

--- a/examples/personal-community-sentiment-triage/docs/collective-wisdom.md
+++ b/examples/personal-community-sentiment-triage/docs/collective-wisdom.md
@@ -40,8 +40,9 @@ The README's [§ Persistence: collective wisdom across restarts](../README.md#pe
 | Slack app handle | Note your bot's `@`-handle from the Slack app manifest (see [set-up-slack.md](set-up-slack.md)). The doc refers to it as `@<your-bot>` — substitute as you go. |
 | At least one Slack user authorized | `grep SLACK_ALLOWED_IDS .env` lists ≥1 `U…` ID. The cross-user step (7) wants ≥2 — if you only have one, run that step yourself from a different channel and the cross-channel claim still holds. |
 | Outlook bridge works | Send `ping` to `OUTLOOK_TARGET_MAILBOX` from any address in `OUTLOOK_ALLOWED_SENDERS` (or any sender if that var is empty); reply within ~30s. |
-| ETL has data | `curl -sf http://localhost:3100/github_issues?limit=1 \| head -c 200` returns a non-empty array |
-| Skills dir is writable | `openshell sandbox exec --name hermes-direct -- ls -la /sandbox/.hermes-data/skills/` lists 5 baked-in skills, all owned by `sandbox` |
+| Live GitHub works | `openshell sandbox exec --name hermes-direct -- sh -lc '/usr/bin/python3 /sandbox/.hermes-data/skills/github-readonly-live/scripts/github_readonly.py rate-limit'` returns JSON without printing a token |
+| Discussion/forum mirror has data | `curl -sf http://localhost:3100/github_discussions?limit=1 \| head -c 200` or `curl -sf http://localhost:3100/forum_topics?limit=1 \| head -c 200` returns a non-empty array |
+| Skills dir is writable | `openshell sandbox exec --name hermes-direct -- ls -la /sandbox/.hermes-data/skills/` lists 6 baked-in skills, all owned by `sandbox` |
 
 A few notes:
 
@@ -75,14 +76,14 @@ $ openshell sandbox exec --name hermes-direct -- ls /sandbox/.hermes-data/skills
 $ grep SLACK_ALLOWED_IDS .env
 ```
 
-Expected: sandbox `Ready`; skills dir contains the 5 baked-in skills (`cross-source-gap-analysis`, `outlook-email-search`, `slack-channel-finder`, `slack-channel-summarizer`, `source-etl-query`); `SLACK_ALLOWED_IDS` lists at least one ID.
+Expected: sandbox `Ready`; skills dir contains the 6 baked-in skills (`cross-source-gap-analysis`, `github-readonly-live`, `outlook-email-search`, `slack-channel-finder`, `slack-channel-summarizer`, `source-etl-query`); `SLACK_ALLOWED_IDS` lists at least one ID.
 
-If a sixth, user-authored skill from a previous run is sitting in the skills directory, wipe anything that isn't one of the five baked-in names so the demo starts on a clean slate:
+If an extra user-authored skill from a previous run is sitting in the skills directory, wipe anything that isn't one of the six baked-in names so the demo starts on a clean slate:
 
 The command must be on a single line — `openshell sandbox exec` rejects literal newlines in the command argument (gRPC `InvalidArgument: command argument 2 contains newline or carriage return characters`). Use `;` separators instead of multi-line scripts.
 
 ```console
-$ openshell sandbox exec --name hermes-direct -- bash -c 'cd /sandbox/.hermes-data/skills/ && for d in */; do case "${d%/}" in cross-source-gap-analysis|outlook-email-search|slack-channel-finder|slack-channel-summarizer|source-etl-query) ;; *) echo "removing ${d%/}"; rm -rf "$d" ;; esac; done'
+$ openshell sandbox exec --name hermes-direct -- bash -c 'cd /sandbox/.hermes-data/skills/ && for d in */; do case "${d%/}" in cross-source-gap-analysis|github-readonly-live|outlook-email-search|slack-channel-finder|slack-channel-summarizer|source-etl-query) ;; *) echo "removing ${d%/}"; rm -rf "$d" ;; esac; done'
 ```
 
 ### Step 1 — User A iterates on a format via Slack DM
@@ -126,12 +127,12 @@ The agent picked its own name and its own organizational layout — for example,
 
 #### 2a — Find the new SKILL.md
 
-Look for any SKILL.md under `skills/`, then exclude the five baked-in skills. Capture the full path:
+Look for any SKILL.md under `skills/`, then exclude the six baked-in skills. Capture the full path:
 
 ```console
 $ NEW_SKILL_PATH=$(openshell sandbox exec --name hermes-direct -- bash -c \
     'find /sandbox/.hermes-data/skills -name SKILL.md' \
-    | grep -vE "/(cross-source-gap-analysis|outlook-email-search|slack-channel-finder|slack-channel-summarizer|source-etl-query)/SKILL.md$")
+    | grep -vE "/(cross-source-gap-analysis|github-readonly-live|outlook-email-search|slack-channel-finder|slack-channel-summarizer|source-etl-query)/SKILL.md$")
 $ echo "Path: $NEW_SKILL_PATH"
 ```
 
@@ -202,12 +203,12 @@ Wait until `openshell sandbox list` shows `hermes-direct` as `Ready` again. The 
 
 ### Step 5 — Confirm the fresh sandbox has no trace of the new skill
 
-Re-run the same `find` from step 2a — it should return empty (no SKILL.md outside the five baked-in ones):
+Re-run the same `find` from step 2a — it should return empty (no SKILL.md outside the six baked-in ones):
 
 ```console
 $ openshell sandbox exec --name hermes-direct -- bash -c \
     'find /sandbox/.hermes-data/skills -name SKILL.md' \
-    | grep -vE "/(cross-source-gap-analysis|outlook-email-search|slack-channel-finder|slack-channel-summarizer|source-etl-query)/SKILL.md$"
+    | grep -vE "/(cross-source-gap-analysis|github-readonly-live|outlook-email-search|slack-channel-finder|slack-channel-summarizer|source-etl-query)/SKILL.md$"
 $ echo "(empty output = clean slate)"
 ```
 
@@ -221,7 +222,7 @@ Expected: zero non-baked-in SKILL.md files. The category dir the agent created (
 $ bash scripts/restore.sh
 $ openshell sandbox exec --name hermes-direct -- bash -c \
     'find /sandbox/.hermes-data/skills -name SKILL.md' \
-    | grep -vE "/(cross-source-gap-analysis|outlook-email-search|slack-channel-finder|slack-channel-summarizer|source-etl-query)/SKILL.md$"
+    | grep -vE "/(cross-source-gap-analysis|github-readonly-live|outlook-email-search|slack-channel-finder|slack-channel-summarizer|source-etl-query)/SKILL.md$"
 $ openshell sandbox exec --name hermes-direct -- cat "$NEW_SKILL_PATH" | head -10
 ```
 
@@ -241,7 +242,7 @@ User B — who never participated in step 1's conversation, never saw the format
 
 Wait ~30s for the bridge to reply by email.
 
-Expected: the email reply opens with `**NemoClaw Daily Issue Digest — {date}, last 3 day(s)**`, contains exactly 5 issue bullets and 3 discussion/forum bullets, and closes with `**Bottom line:**` followed by 2-3 sentences. Actual issue numbers and titles are pulled live from the mirror — they will be specific real `NVIDIA/NemoClaw` issues, not placeholders.
+Expected: the email reply opens with `**NemoClaw Daily Issue Digest — {date}, last 3 day(s)**`, contains exactly 5 issue bullets and 3 discussion/forum bullets, and closes with `**Bottom line:**` followed by 2-3 sentences. Actual issue numbers and titles are pulled from live GitHub for the configured repo — they will be specific real issues, not placeholders.
 
 **This proves:** a different user, on a different channel, who never saw the seeding conversation, gets the same output shape — and got there from natural language, not the skill's internal name. The skill, not the conversation, holds the format.
 
@@ -251,7 +252,7 @@ User A DMs `@<your-bot>` from a *new* DM thread (not the one from step 1, so no 
 
 > Daily NemoClaw digest, last 3 days please.
 
-Expected: structurally identical reply to User B's email — same bold header form, same 5+3 bullet structure, same `**Bottom line:**` closer. Issue numbers may differ slightly if the mirror updated between requests; that's acceptable variance because the data is live.
+Expected: structurally identical reply to User B's email — same bold header form, same 5+3 bullet structure, same `**Bottom line:**` closer. Issue numbers may differ slightly if live GitHub or the discussion/forum mirror updated between requests; that's acceptable variance.
 
 **This proves:** the skill is channel-stable as well as user-stable.
 
@@ -325,15 +326,16 @@ The canonical SKILL.md text is below. Copy it into a host-side file, upload it, 
 $ cat > /tmp/SKILL.md << 'SKILLEOF'
 ---
 name: daily-issue-digest
-description: Produce a fixed-format daily digest of important NemoClaw GitHub issues, discussions, and forum topics over a recent time window.
+description: Produce a fixed-format daily digest of important GitHub issues, discussions, and forum topics over a recent time window.
 ---
 
 # daily-issue-digest
 
 Use this skill when a user asks for a "daily update", "issue digest", "what's
 hot on NemoClaw", or any recurring summary of community activity scoped to
-the configured ETL mirror. Always render the output in the **fixed format**
-defined below — that fixed format is the entire reason this skill exists.
+the configured live GitHub repo plus the discussion/forum mirror. Always render
+the output in the **fixed format** defined below — that fixed format is the
+entire reason this skill exists.
 
 ## When to use
 
@@ -344,33 +346,34 @@ defined below — that fixed format is the entire reason this skill exists.
 
 ## Access model
 
-- Use the existing `source-etl-query` skill's helper script for all data access.
-- Do not invent new ETL endpoints; do not attempt live GitHub or forum requests.
-- Read three tables in this order: github-issues, github-discussions, forum-topics.
+- Use `github-readonly-live` for current issues from `$GITHUB_READONLY_REPO`.
+- Use `source-etl-query` for mirrored GitHub discussions and NVIDIA forum topics.
+- Do not invent new ETL endpoints or direct GitHub requests; use the helpers
+  documented by those skills.
 
 ## Required Environment
 
-- SOURCE_ETL_API_URL, or SOURCE_ETL_API_HOST plus SOURCE_ETL_API_PORT
-  (the same env the source-etl-query skill consumes — already set in the sandbox).
+- `GITHUB_READONLY_REPO` for the live issue source.
+- `SOURCE_ETL_API_URL`, or `SOURCE_ETL_API_HOST` plus `SOURCE_ETL_API_PORT`
+  for discussion/forum mirror data.
 
 ## Procedure
 
 ### 1. Pull recent activity from each source
 
 Default window is 7 days. If the user gave a different window (e.g. "last 3 days"),
-adjust --limit upward to be safe — the script returns most-recent first, so
-caller-side filtering is fine.
+request enough rows to filter caller-side.
 
 ```bash
-/usr/bin/python3 /sandbox/.hermes-data/skills/source-etl-query/scripts/query_source_etl.py github-issues --limit 30
+/usr/bin/python3 /sandbox/.hermes-data/skills/github-readonly-live/scripts/github_readonly.py get issues --param state=all --param sort=updated --param direction=desc --limit 30 --exclude-pulls --fields number,title,state,updated_at,html_url
 /usr/bin/python3 /sandbox/.hermes-data/skills/source-etl-query/scripts/query_source_etl.py github-discussions --limit 20
 /usr/bin/python3 /sandbox/.hermes-data/skills/source-etl-query/scripts/query_source_etl.py forum-topics --limit 20
 ```
 
 ### 2. Rank by an importance heuristic
 
-The mirror returns number, state, updated_at, title for issues. Approximate
-importance by:
+The live GitHub helper returns number, state, updated_at, title, and html_url
+for issues. Approximate importance by:
 
 - **Recency** — items updated within the requested window come first.
 - **State** — open issues outrank closed ones inside the window.
@@ -390,7 +393,7 @@ Output exactly this shape — no flowing prose, no extra headers:
 
 **Top issues**
 - #{number} — {title} — `{state}` — updated {YYYY-MM-DD}
-  https://github.com/NVIDIA/NemoClaw/issues/{number}
+  {html_url from github-readonly-live}
   Why it matters: {one sentence, grounded in the title or a sibling row}
 - … (4 more, total of 5)
 
@@ -411,7 +414,8 @@ outlook-email-search).
 
 ## Pitfalls
 
-- The mirror refreshes hourly, so very-recent issues may not appear.
+- Live issues come from `github-readonly-live`; discussion and forum rows come
+  from the ETL mirror and may lag by up to an hour.
 - forum_topics is sparsely populated on some fixtures (3 rows is normal).
   If forum-topics returns fewer than 3 rows, fill the "Discussions and forums"
   block from github-discussions only — do not invent forum activity.

--- a/examples/personal-community-sentiment-triage/docs/verify-functionality.md
+++ b/examples/personal-community-sentiment-triage/docs/verify-functionality.md
@@ -3,8 +3,8 @@ title:
   page: "Verify Skill Functionality"
   nav: "Verify Skills"
 description:
-  main: "Walk through 10 conversational prompts (2 per skill) that prove each Hermes skill works end-to-end across Slack DM, Slack thread, and Outlook email channels."
-  agent: "End-to-end functional verification recipe for the personal-community-sentiment-triage example. Contains 10 copy-pasteable prompts (2 per skill: outlook-email-search, slack-channel-finder, slack-channel-summarizer, source-etl-query, cross-source-gap-analysis) split between Slack DM, Slack thread, and Outlook email channels. Each prompt has a stated expected behavior and a specific verification cue. Use after running scripts/bring-up.sh and confirming the README's plumbing checks pass — this guide picks up where the README's plumbing verification stops."
+  main: "Walk through 10 conversational prompts plus a live GitHub check that prove the core Hermes workflow skills end-to-end across Slack DM, Slack thread, and Outlook email channels."
+  agent: "End-to-end functional verification recipe for the personal-community-sentiment-triage example. Contains 10 copy-pasteable prompts covering outlook-email-search, slack-channel-finder, slack-channel-summarizer, source-etl-query, and cross-source-gap-analysis, plus a live github-readonly-live check. Each prompt has a stated expected behavior and a specific verification cue. Use after running scripts/bring-up.sh and confirming the README's plumbing checks pass — this guide picks up where the README's plumbing verification stops."
 keywords: ["verify nemoclaw skills", "hermes skill verification", "slack outlook smoke test", "personal community sentiment triage verification"]
 topics: ["generative_ai", "ai_agents"]
 tags: ["hermes", "openshell", "outlook", "slack", "verification", "smoke-test"]
@@ -24,7 +24,7 @@ status: published
 
 # Verify Skill Functionality
 
-Ten copy-pasteable prompts — two per skill — that prove each skill works end-to-end across Slack and Outlook. The README's [§ Verification](../README.md#verification-what-success-looks-like) only checks plumbing (the bridge runs, the sidecar exists, scripts return `ok: true`). This guide picks up where that stops: it checks whether the **agent** can use its skills correctly.
+Ten copy-pasteable prompts plus a live GitHub check that prove each skill works end-to-end across Slack and Outlook. The README's [§ Verification](../README.md#verification-what-success-looks-like) only checks plumbing (the bridge runs, the sidecar exists, scripts return `ok: true`). This guide picks up where that stops: it checks whether the **agent** can use its skills correctly.
 
 Once you've run all 10, head to [collective-wisdom.md](collective-wisdom.md) for the cross-channel skill-learning demo — where one user teaches the agent a new skill, the skill survives a full sandbox rebuild, and a different user invokes it from a different channel and gets the same output format.
 
@@ -35,14 +35,14 @@ Run through these once before starting.
 | Check | One-liner |
 |---|---|
 | Sandbox is `Ready` | `openshell sandbox list \| grep hermes-direct` |
-| Postgrest bridge is reachable | `curl -sf http://localhost:3100/github_issues?limit=1` (returns JSON; `[]` is fine — first sync may be pending) |
+| Postgrest bridge is reachable | `curl -sf http://localhost:3100/github_discussions?limit=1` (returns JSON; `[]` is fine — first sync may be pending) |
 | Slack works | DM `ping` to `@myuser_nemoclaw` produces a reply within ~10s. Red ❌ reaction = your Slack ID isn't in `SLACK_ALLOWED_IDS`. |
 | Outlook bridge works | Email `ping` to `OUTLOOK_TARGET_MAILBOX` from an allowed sender produces a reply within ~30s. |
 | **Optional** — unlocks Outlook Q2 | The owner of `OUTLOOK_REPLY_TO` has granted the bot delegate access in Outlook (**File → Account Settings → Delegate Access**). Without it, Graph returns `403: Cannot find row based on condition` for searches against `OUTLOOK_REPLY_TO`. |
 
 A few constraints to keep in mind:
 
-- **ETL freshness.** github-etl and forums-etl run hourly. If `source-etl-query` returns zero rows, wait 10 min and retry — the skill isn't broken.
+- **ETL freshness.** Source ETLs run hourly for mirrored discussions/forums. If `source-etl-query` returns zero rows, wait 10 min and retry — the skill isn't broken. Live GitHub checks use `github-readonly-live` and do not depend on the mirror.
 - **Session boundaries.** Each Outlook email opens a fresh session. Slack thread replies (same `thread_ts`) share one session. Cross-session continuity comes only from the memory subsystem.
 
 ---
@@ -154,12 +154,44 @@ In either case, the agent may **loop trying to satisfy "from my inbox"** rather 
 
 ---
 
+### github-readonly-live
+
+Sanity-check the live GitHub path from the host shell:
+
+```console
+$ openshell sandbox exec --name hermes-direct -- sh -lc \
+    '/usr/bin/python3 /sandbox/.hermes-data/skills/github-readonly-live/scripts/github_readonly.py rate-limit'
+```
+
+**Expected:** the response shows the authenticated GitHub REST rate limit when
+`GITHUB_TOKEN` or `GH_TOKEN` is configured. The token itself should never appear
+in output.
+
+Ask the agent:
+
+> How many issues does the configured GitHub repo have? Use live GitHub, not the ETL mirror.
+
+**Expected:** agent uses the generic helper pattern, for example
+`github_readonly.py get issues --param state=all --paginate --count --exclude-pulls`.
+It should not use `gh`, `git`, GitHub search, GraphQL, or the source ETL
+mirror for this live count.
+
+Also ask:
+
+> How many pull requests are currently open in the configured GitHub repo? Use live GitHub, not the ETL mirror.
+
+**Expected:** agent uses the generic helper pattern, for example
+`github_readonly.py get pulls --param state=open --paginate --count`; it should
+not estimate from a single `pulls --limit` page.
+
+---
+
 ### source-etl-query
 
 Sanity-check the postgrest bridge first (host shell):
 
 ```console
-$ curl -sf http://localhost:3100/github_issues?limit=1 | head -c 300
+$ curl -sf http://localhost:3100/github_discussions?limit=1 | head -c 300
 ```
 
 Empty array `[]` is fine — bridge is up but ETL hasn't finished first sync. A `404` or refusal means re-run `bash scripts/00-host-services.sh`.
@@ -168,10 +200,12 @@ Empty array `[]` is fine — bridge is up but ETL hasn't finished first sync. A 
 
 **Send via:** Slack DM to `@myuser_nemoclaw`
 
-> Show me the 3 most recently mirrored GitHub issues from the source-etl postgrest bridge — title and number only.
+> Show me the 3 most recently mirrored GitHub discussions from the source-etl postgrest bridge — title and number only.
 
-**Expected:** agent runs `query_source_etl.py github-issues --limit 3`.
-**Verify:** response contains 3 numbered items. The agent should *not* claim GitHub is unreachable — that path is correctly blocked by sandbox policy; the postgrest mirror is the supported route.
+**Expected:** agent runs `query_source_etl.py github-discussions --limit 3`.
+**Verify:** response contains 3 numbered items. The agent should identify this
+as mirrored PostgREST data, not live GitHub data. Current GitHub issues and PRs
+should use the separate `github-readonly-live` skill for `GITHUB_READONLY_REPO`.
 
 #### Q8 — realistic
 
@@ -191,9 +225,9 @@ Empty array `[]` is fine — bridge is up but ETL hasn't finished first sync. A 
 
 **Send via:** Slack DM to `@myuser_nemoclaw`
 
-> Use cross-source-gap-analysis. Compare one Slack channel related to NemoClaw against the github-issues mirror. Just confirm both sources returned data and report the row count from each — no analysis yet.
+> Use cross-source-gap-analysis. Compare one Slack channel related to NemoClaw against live GitHub issues for the configured repo. Just confirm both sources returned data and report the row count from each — no analysis yet.
 
-**Expected:** agent loads `cross-source-gap-analysis`, then `slack-channel-finder` and `source-etl-query`, fetches a small slice from each.
+**Expected:** agent loads `cross-source-gap-analysis`, then `slack-channel-finder` and `github-readonly-live`, fetches a small slice from each.
 **Verify:** reply mentions both source counts as concrete numbers. No actual gap analysis yet — wiring proof only.
 
 #### Q10 — realistic
@@ -201,9 +235,9 @@ Empty array `[]` is fine — bridge is up but ETL hasn't finished first sync. A 
 **Send via:** email to `OUTLOOK_TARGET_MAILBOX`
 **Subject:** `Slack-vs-GitHub gaps for NemoClaw`
 
-> Run a cross-source-gap-analysis: pick one NemoClaw-related Slack channel, sample the last 7 days, and compare against open GitHub issues in the mirror. Tell me which topics are discussed in Slack but have no corresponding GitHub issue, and which GitHub issues have no Slack discussion. Use the skill's documented "scope / agree / gaps / follow-ups" structure.
+> Run a cross-source-gap-analysis: pick one NemoClaw-related Slack channel, sample the last 7 days, and compare against live open GitHub issues in the configured repo. Tell me which topics are discussed in Slack but have no corresponding GitHub issue, and which GitHub issues have no Slack discussion. Use the skill's documented "scope / agree / gaps / follow-ups" structure.
 
-**Expected:** agent picks a channel via `slack-channel-finder`, summarizes via `slack-channel-summarizer`, queries `source-etl-query github-issues`, normalizes both, presents a 4-section reply.
+**Expected:** agent picks a channel via `slack-channel-finder`, summarizes via `slack-channel-summarizer`, queries live issues through `github-readonly-live`, normalizes both, presents a 4-section reply.
 **Verify:** reply contains all four documented section headings — `scope and time window`, `what all sources agree on`, `gaps or mismatches`, `concrete follow-ups` — and grounds each gap in a specific channel message or GitHub issue number, not generic abstractions.
 
 ---
@@ -214,5 +248,5 @@ Empty array `[]` is fine — bridge is up but ETL hasn't finished first sync. A 
 |---|---|
 | Outlook search Q2 returns 403 | Bot lacks delegate access to `OUTLOOK_REPLY_TO`. Either grant it (Outlook → File → Account Settings → Delegate Access) or substitute `OUTLOOK_TARGET_MAILBOX` in the prompt. |
 | Outlook search Q2 hangs without ever replying | `OUTLOOK_REPLY_TO` returns 404 from Graph — the address isn't a real Entra user in your tenant. Confirm via the sidecar log (`openshell sandbox exec --name hermes-direct -- tail -50 /tmp/ms-graph-sidecar.log \| grep 404`). Fix: set `OUTLOOK_REPLY_TO` to a real mailbox you own and rebuild. To unblock the in-flight request: `openshell sandbox exec --name hermes-direct -- pkill -f outlook-bridge.py`. |
-| `source-etl-query` returns 0 rows for everything | Run `curl -sf http://localhost:3100/github_issues?limit=1`. Empty → ETL hasn't completed first sync (wait 10 min). Unreachable → re-run `bash scripts/00-host-services.sh`. |
+| `source-etl-query` returns 0 rows for everything | Run `curl -sf http://localhost:3100/github_discussions?limit=1` and `curl -sf http://localhost:3100/forum_topics?limit=1`. Empty → ETL hasn't completed first sync (wait 10 min). Unreachable → re-run `bash scripts/00-host-services.sh`. |
 | `grep: /sandbox/.hermes-data/...: No such file or directory` (running side-checks against the sandbox) | `openshell sandbox exec` doesn't run a shell, so `*.md` and other globs don't expand. Wrap in `bash -c '…'`, or pass explicit filenames. |

--- a/examples/personal-community-sentiment-triage/extras/source-etls/README.md
+++ b/examples/personal-community-sentiment-triage/extras/source-etls/README.md
@@ -14,6 +14,11 @@ directly.
 - initial backfill: 72 hours
 - recurring refresh: hourly
 
+The GitHub repo above is the host-side mirror scope, controlled by
+`SOURCE_ETL_GITHUB_REPO`. It is separate from the sandbox's live read-only
+GitHub scope, which is controlled by `GITHUB_READONLY_REPO` and applied through
+OpenShell policy during sandbox creation.
+
 ## Services
 
 - `postgres`: shared sink and ETL metadata store

--- a/examples/personal-community-sentiment-triage/policy.yaml
+++ b/examples/personal-community-sentiment-triage/policy.yaml
@@ -156,6 +156,39 @@ network_policies:
     - path: /usr/local/bin/hermes
     - path: /opt/hermes/.venv/bin/hermes
     - path: /usr/bin/curl
+  github_repo_readonly:
+    name: github-repo-readonly
+    # scripts/03-sandbox.sh replaces __GITHUB_READONLY_REPO__ with
+    # GITHUB_READONLY_REPO from .env before applying this policy.
+    endpoints:
+    - host: api.github.com
+      port: 443
+      protocol: rest
+      tls: terminate
+      enforcement: enforce
+      rules:
+      - allow: { method: GET, path: /rate_limit }
+      - allow: { method: GET, path: /repos/__GITHUB_READONLY_REPO__ }
+      - allow: { method: GET, path: /repos/__GITHUB_READONLY_REPO__/issues }
+      - allow: { method: GET, path: /repos/__GITHUB_READONLY_REPO__/issues/** }
+      - allow: { method: GET, path: /repos/__GITHUB_READONLY_REPO__/labels }
+      - allow: { method: GET, path: /repos/__GITHUB_READONLY_REPO__/labels/** }
+      - allow: { method: GET, path: /repos/__GITHUB_READONLY_REPO__/milestones }
+      - allow: { method: GET, path: /repos/__GITHUB_READONLY_REPO__/milestones/** }
+      - allow: { method: GET, path: /repos/__GITHUB_READONLY_REPO__/pulls }
+      - allow: { method: GET, path: /repos/__GITHUB_READONLY_REPO__/pulls/** }
+      - allow: { method: GET, path: /repos/__GITHUB_READONLY_REPO__/commits }
+      - allow: { method: GET, path: /repos/__GITHUB_READONLY_REPO__/commits/** }
+      - allow: { method: GET, path: /repos/__GITHUB_READONLY_REPO__/branches }
+      - allow: { method: GET, path: /repos/__GITHUB_READONLY_REPO__/branches/** }
+      - allow: { method: GET, path: /repos/__GITHUB_READONLY_REPO__/contents }
+      - allow: { method: GET, path: /repos/__GITHUB_READONLY_REPO__/contents/** }
+      - allow: { method: GET, path: /repos/__GITHUB_READONLY_REPO__/readme }
+    binaries:
+    - path: /usr/bin/curl
+    - path: /usr/bin/python3
+    - path: /usr/bin/python3.13
+    - path: /opt/hermes/.venv/bin/python
   slack:
     name: slack
     endpoints:

--- a/examples/personal-community-sentiment-triage/scripts/02-providers.sh
+++ b/examples/personal-community-sentiment-triage/scripts/02-providers.sh
@@ -17,7 +17,7 @@
 #   <sandbox>-outlook             — Outlook (3 credentials)
 #   <sandbox>-slack-bridge        — Slack bot token
 #   <sandbox>-slack-app           — Slack app token
-#   <sandbox>-github              — GitHub token
+#   <sandbox>-github              — GitHub token placeholder
 #
 # OpenShell commands you'll see:
 #   - openshell provider create / update / get / list
@@ -107,6 +107,9 @@ if [[ -n "${SLACK_APP_TOKEN:-}" ]]; then
 fi
 
 # ── GitHub provider ─────────────────────────────────────────────────────
+# GitHub access is authenticated to avoid public unauthenticated rate limits,
+# but the sandbox receives only an OpenShell placeholder. policy.yaml still
+# restricts live GitHub egress to repo-scoped REST GET requests from curl/Python.
 if [[ -n "${GITHUB_TOKEN:-}" || -n "${GH_TOKEN:-}" ]]; then
   GH_PROVIDER="$SANDBOX_NAME-github"
   if [[ -n "${GITHUB_TOKEN:-}" ]]; then

--- a/examples/personal-community-sentiment-triage/scripts/03-sandbox.sh
+++ b/examples/personal-community-sentiment-triage/scripts/03-sandbox.sh
@@ -60,7 +60,8 @@ fi
 command -v openshell >/dev/null || { echo "openshell not in PATH" >&2; exit 1; }
 
 STAGED_DOCKERFILE="$EXAMPLE_DIR/.Dockerfile.staged"
-trap 'rm -f "$STAGED_DOCKERFILE"' EXIT
+STAGED_POLICY="$EXAMPLE_DIR/.policy.staged.yaml"
+trap 'rm -f "$STAGED_DOCKERFILE" "$STAGED_POLICY"' EXIT
 
 # ── Build CHANNELS_B64 and ALLOWED_IDS_B64 ─────────────────────────────
 # These two base64-JSON blobs tell the Hermes config generator which
@@ -94,7 +95,13 @@ ALLOWED_SENDERS="${OUTLOOK_ALLOWED_SENDERS:-}"
 TM_HOST="$(detect_token_manager_host)"
 SOURCE_ETL_HOST="${SOURCE_ETL_API_HOST:-host.openshell.internal}"
 SOURCE_ETL_PORT="${SOURCE_ETL_API_PORT:-3100}"
+GITHUB_READONLY_REPO="${GITHUB_READONLY_REPO:-NVIDIA/OpenShell}"
+if [[ ! "$GITHUB_READONLY_REPO" =~ ^[A-Za-z0-9][A-Za-z0-9-]{0,38}/[A-Za-z0-9._-]+$ ]]; then
+  echo "Invalid GITHUB_READONLY_REPO '$GITHUB_READONLY_REPO' — expected owner/repo" >&2
+  exit 1
+fi
 echo "Resolved TOKEN_MANAGER_HOST → $TM_HOST"
+echo "GitHub read-only repo scope: $GITHUB_READONLY_REPO"
 
 # ── Stage the Dockerfile and patch ARG defaults ────────────────────────
 cp "$EXAMPLE_DIR/agents/hermes/Dockerfile" "$STAGED_DOCKERFILE"
@@ -104,6 +111,7 @@ sed -i \
   -e "s|^ARG OUTLOOK_TARGET_MAILBOX=.*|ARG OUTLOOK_TARGET_MAILBOX=${OUTLOOK_TARGET_MAILBOX:-}|" \
   -e "s|^ARG OUTLOOK_REPLY_TO=.*|ARG OUTLOOK_REPLY_TO=${OUTLOOK_REPLY_TO:-}|" \
   -e "s|^ARG OUTLOOK_ALLOWED_SENDERS=.*|ARG OUTLOOK_ALLOWED_SENDERS=$ALLOWED_SENDERS|" \
+  -e "s|^ARG GITHUB_READONLY_REPO=.*|ARG GITHUB_READONLY_REPO=$GITHUB_READONLY_REPO|" \
   -e "s|^ARG TOKEN_MANAGER_HOST=.*|ARG TOKEN_MANAGER_HOST=$TM_HOST|" \
   -e "s|^ARG SOURCE_ETL_API_HOST=.*|ARG SOURCE_ETL_API_HOST=$SOURCE_ETL_HOST|" \
   -e "s|^ARG SOURCE_ETL_API_PORT=.*|ARG SOURCE_ETL_API_PORT=$SOURCE_ETL_PORT|" \
@@ -132,6 +140,12 @@ if [[ -n "${PHOENIX_COLLECTOR_ENDPOINT:-}" ]]; then
     "$STAGED_DOCKERFILE"
 fi
 
+# ── Stage policy and patch per-run repo scope ───────────────────────────
+cp "$EXAMPLE_DIR/policy.yaml" "$STAGED_POLICY"
+sed -i \
+  -e "s|__GITHUB_READONLY_REPO__|$GITHUB_READONLY_REPO|g" \
+  "$STAGED_POLICY"
+
 # ── Build provider flags from what 02-providers.sh actually created ────
 PROVIDER_FLAGS=()
 [[ -n "${OUTLOOK_CLIENT_ID:-}" ]] && PROVIDER_FLAGS+=(--provider "$SANDBOX_NAME-outlook")
@@ -159,13 +173,14 @@ echo "Creating sandbox $SANDBOX_NAME (OpenShell will build the image)…"
 setsid openshell sandbox create \
   --from "$STAGED_DOCKERFILE" \
   --name "$SANDBOX_NAME" \
-  --policy "$EXAMPLE_DIR/policy.yaml" \
+  --policy "$STAGED_POLICY" \
   "${PROVIDER_FLAGS[@]}" \
   -- env \
     OUTLOOK_TARGET_MAILBOX="${OUTLOOK_TARGET_MAILBOX:-}" \
     OUTLOOK_REPLY_TO="${OUTLOOK_REPLY_TO:-}" \
     OUTLOOK_ALLOWED_SENDERS="$ALLOWED_SENDERS" \
     TOKEN_MANAGER_HOST="$TM_HOST" \
+    GITHUB_READONLY_REPO="$GITHUB_READONLY_REPO" \
     NEMOCLAW_MESSAGING_CHANNELS_B64="$CHANNELS_B64" \
     CHAT_UI_URL="http://127.0.0.1:8642" \
     PHOENIX_COLLECTOR_ENDPOINT="${PHOENIX_COLLECTOR_ENDPOINT:-}" \
@@ -212,10 +227,10 @@ fi
 echo "  Sandbox reported ready; detached local create stream."
 
 # ── Re-apply policy (matches nemoclaw onboard's two-stage flow) ────────
-# Without this, network rules from policy.yaml may not be activated even
+# Without this, network rules from the staged policy may not be activated even
 # though they were passed at create time. Symptom: L7 proxy denies outlook
 # token-manager requests with `[policy:outlook]` despite a matching rule.
 echo "Re-applying policy via 'openshell policy set --wait' (stage 2)"
-openshell policy set --policy "$EXAMPLE_DIR/policy.yaml" --wait "$SANDBOX_NAME"
+openshell policy set --policy "$STAGED_POLICY" --wait "$SANDBOX_NAME"
 
 echo "Sandbox $SANDBOX_NAME is ready."

--- a/examples/personal-community-sentiment-triage/scripts/tear-down.sh
+++ b/examples/personal-community-sentiment-triage/scripts/tear-down.sh
@@ -93,13 +93,15 @@ case "$stop_mode" in
     ;;
 esac
 
-# Clean up the staged Dockerfile if a prior bring-up left one behind.
+# Clean up staged files if a prior bring-up left them behind.
 # The bring-up trap normally handles this; this is the belt-and-suspenders
 # pass for cases where the script was killed before the trap fired.
-if [[ -e "$EXAMPLE_DIR/.Dockerfile.staged" ]]; then
-  echo "Removing leftover $EXAMPLE_DIR/.Dockerfile.staged"
-  rm -f "$EXAMPLE_DIR/.Dockerfile.staged"
-fi
+for staged in "$EXAMPLE_DIR/.Dockerfile.staged" "$EXAMPLE_DIR/.policy.staged.yaml"; do
+  if [[ -e "$staged" ]]; then
+    echo "Removing leftover $staged"
+    rm -f "$staged"
+  fi
+done
 
 echo
 echo "Tear-down complete."


### PR DESCRIPTION
## Goal

Enable GitHub read access for a user configured repository. An OpenShell GitHub provider is used so that a GH token is never in the sandbox, but requests are authenticated on egress. An OpenShell policy enforces write only requests. 

The main risk of this change is that the agent could pick up contaminated PRs/issues from GitHub. That contamination could co-mingle with Outlook / Slack access to propagate information through those channels. 

Risk mitigation: 
- Tokens are never in the sandbox or available to the agent
- External data exfiltration is avoided by enforcing read-only GitHub access, 
- We enforce the agent identity in Outlook can not email external domains
- Only a single github repo (specified by the human operator) is enabled by the OpenShell policy

## Changes

- Adds a repo-scoped `github_repo_readonly` OpenShell policy for `api.github.com`.
- Uses `GITHUB_READONLY_REPO` from `.env` to choose the allowed `owner/repo` target; default remains `NVIDIA/OpenShell`.
- `02-providers.sh` adds a gh provider from `GITHUB_TOKEN`, or from `GH_TOKEN` when `GITHUB_TOKEN` is empty.
- Adds `github-readonly-live`, including a helper that uses the provider placeholder for `Authorization: Bearer ...` and never prints the token.
- Adds a generic helper command: `github_readonly.py get <repo-relative-route> --param KEY=VALUE --paginate --count --limit N --fields ... --exclude-pulls`.
- Keeps compatibility aliases such as `issues`, `pulls`, `issue-counts`, and `pull-counts`, but updates the skill to prefer generic `get` for new questions.
- Updates SOUL, skill docs, README, `.env.example`, Dockerfile comments, and verification docs to describe authenticated live GitHub reads instead of the old ETL-only model.
- Tightens SOUL/skill guidance so the agent does not inspect or echo `GITHUB_TOKEN` / `GH_TOKEN` placeholders, does not try to call skill names as tools or shell commands, and does not troubleshoot helper failures by probing env/proxy/DNS state or alternate GitHub tools/hosts.
- Adds a non-secret helper error hint for transient URL/network failures: retry the same helper command once, then report the helper error.

## Security Boundary

Allowed:

- `GET https://api.github.com/rate_limit`
- selected `GET https://api.github.com/repos/<GITHUB_READONLY_REPO>/...` paths for repo metadata, issues, issue comments, labels, milestones, PRs, commits, branches, README, and contents
- approved binaries only: `curl` and Python/Hermes Python paths

Denied by design:

- `POST`, `PUT`, `PATCH`, `DELETE`
- `github.com`, `raw.githubusercontent.com`, `codeload.github.com`
- `/usr/bin/git`, `/usr/bin/gh`
- GitHub Search and GraphQL
- broad GitHub API access outside the configured repo scope


## Verification

Static checks:

- `bash -n` on `02-providers.sh`, `03-sandbox.sh`, and `agents/hermes/start.sh`
- `python3 -m py_compile` on `github_readonly.py`
- `git diff --check`
- stale-instruction sweep for old unauthenticated / ETL-only GitHub guidance


Hermes agent interaction validation:

- Asked the running Hermes API for the 5 latest live OpenShell issues. It used `github-readonly-live` and returned issue-only rows: `#1487`, `#1486`, `#1485`, `#1481`, `#1477`.
- Asked the running Hermes API for the exact count of open PRs. Initial test exposed a gap because the skill had no generic count workflow. This PR now adds generic `get`. After the fix, Hermes answered using `/usr/bin/python3 /sandbox/.hermes-data/skills/github-readonly-live/scripts/github_readonly.py get pulls --param state=open --paginate --count` and returned `48`.
- Asked Hermes to attempt a blocked GitHub write by POSTing a comment to nonexistent issue `#999999999`. With the final instructions, Hermes reported `HTTP Status: 403` and the OpenShell policy error: `POST /repos/NVIDIA/OpenShell/issues/999999999/comments not permitted by policy`.
- Asked Hermes about issue `#1487`. It used `/usr/bin/python3 /sandbox/.hermes-data/skills/github-readonly-live/scripts/github_readonly.py get issues/1487 --fields title,state,user.login,labels,created_at,body` and returned the issue title/state/author/created date/body summary.
- Asked Hermes about PR `#1484`. It used generic `get pulls/1484`, `get pulls/1484/files --paginate --count`, and `get pulls/1484/files --limit 5 --fields filename`; returned title/state/author, `13` changed files, and the first five paths.
- Asked Hermes about PR `#1484` reviews and review comments. It used `get pulls/1484/reviews` and `get pulls/1484/comments`; both returned `[]`, and Hermes reported no reviews or review comments.
- A failure-mode test initially exposed that transient DNS errors could make the agent inspect env/proxy state. SOUL, the skill, and the helper error text were tightened, then `hermes-direct` was redeployed from the updated commit.
- Trace inspection after the fresh deploy showed the latest three GitHub sessions used `skill_view github-readonly-live` followed only by canonical `github_readonly.py get ...` terminal calls. No `gh`, `git`, curl, token-env inspection, raw/codeload hosts, search endpoints, or skill-name shell invocation appeared in the tool calls.
