### PR TITLE
Phoenix LLM spans now show with real prompts and completions

### DIFF
--- a/examples/personal-community-sentiment-triage/agents/hermes/Dockerfile
+++ b/examples/personal-community-sentiment-triage/agents/hermes/Dockerfile
@@ -8,7 +8,7 @@
 
 # ARGs that appear in FROM instructions must be declared before the first FROM
 # so Docker treats them as global build args (multi-stage scoping rule).
-ARG BASE_IMAGE=ghcr.io/nvidia/nemoclaw/hermes-sandbox-base@sha256:176ec6ec056cdf2dd45f60a0095fb6aac962eb5d7382d28d5734098a72399000
+ARG BASE_IMAGE=ghcr.io/nvidia/nemoclaw/hermes-sandbox-base@sha256:f76a2ed0509570b1ce5380327c7ebe2e120e97f524e9271e145d2ea34c83ba5e
 
 # ── Stage 0: build the MS Graph API sidecar binary ────────────────────────────
 # PyInstaller produces a self-contained executable at a unique path
@@ -109,6 +109,48 @@ RUN mkdir -p /etc/apt/keyrings \
 
 RUN pip3 install --no-cache-dir --break-system-packages "httpx>=0.27" "markdown-it-py>=3"
 
+# ── Upgrade Hermes from base image's v0.11.0 to v0.14.0 ─────────────────
+# NemoClaw's base image (even at its latest tag) pins HERMES_VERSION=v2026.4.23
+# (Hermes v0.11.0). v0.11.0's plugin hooks ship metadata-only kwargs to
+# pre_api_request / post_api_request — no real messages, no real response —
+# so observability backends (Langfuse, NeMo-Flow's hermes adapter) cannot
+# emit LLM spans with full content. v0.14.0 (v2026.5.16, "The Foundation
+# Release") adds rich-kwargs hook delivery and ships the bundled Langfuse
+# plugin that depends on it.
+#
+# We mirror NemoClaw's tarball + uv-sync install pattern, but for a newer
+# version. /opt/hermes/.venv is preserved across the upgrade so uv can
+# incrementally reconcile dependencies against v0.14.0's uv.lock.
+ARG HERMES_UPGRADE_VERSION=v2026.5.16
+ARG HERMES_UPGRADE_TARBALL_SHA256=c0a554050a50ee9a62f3fa5cd288a167ba5640c42d647d100cdea084b7294143
+ARG HERMES_UV_EXTRAS="messaging web"
+# Match the uv version NemoClaw uses for the base-image install.
+ARG UV_INSTALL_VERSION=0.11.8
+
+USER root
+RUN set -eu \
+    && curl -LsSf "https://astral.sh/uv/${UV_INSTALL_VERSION}/install.sh" \
+       | env INSTALLER_NO_MODIFY_PATH=1 sh \
+    && UV_BIN="" \
+    && for candidate in /root/.local/bin/uv /root/.cargo/bin/uv /usr/local/bin/uv; do \
+         if [ -x "$candidate" ]; then UV_BIN="$candidate"; break; fi; \
+       done \
+    && if [ -z "$UV_BIN" ]; then echo "uv installer did not produce a binary in any known location" >&2; exit 1; fi \
+    && install -m 755 "$UV_BIN" /usr/local/bin/uv \
+    && /usr/local/bin/uv --version \
+    && curl -fsSL "https://github.com/NousResearch/hermes-agent/archive/refs/tags/${HERMES_UPGRADE_VERSION}.tar.gz" \
+       -o /tmp/hermes.tgz \
+    && echo "${HERMES_UPGRADE_TARBALL_SHA256}  /tmp/hermes.tgz" | sha256sum -c - \
+    && find /opt/hermes -mindepth 1 -maxdepth 1 -not -name '.venv' -exec rm -rf {} + \
+    && tar -xzf /tmp/hermes.tgz -C /opt/hermes --strip-components=1 \
+    && rm /tmp/hermes.tgz \
+    && cd /opt/hermes \
+    && extras_args="" \
+    && for e in ${HERMES_UV_EXTRAS}; do extras_args="${extras_args} --extra ${e}"; done \
+    && UV_PROJECT_ENVIRONMENT=/opt/hermes/.venv /usr/local/bin/uv sync \
+       ${extras_args} --no-dev \
+    && chown -R sandbox:sandbox /opt/hermes
+
 # ── NeMo-Flow 0.2.0 wrapped-CLI integration ─────────────────────────────
 # Drop-in observability via `nemo-flow hermes -- gateway run`. Hermes stays
 # unpatched (from BASE_IMAGE); native hook events configured in
@@ -187,6 +229,12 @@ ENV HERMES_TELEGRAM_DISABLE_FALLBACK_IPS=1 \
 # Copy NemoClaw plugin for Hermes (Python-based)
 COPY agents/hermes/plugin/ /opt/nemoclaw-hermes-plugin/
 
+# Copy nemo-flow-bridge plugin: in-process forwarder for pre/post_api_request
+# events that enriches NeMo-Flow hook payloads with the real OpenAI request
+# body and response body (the shell-hook path is metadata-only by design).
+# Requires Hermes >= v0.14.0 because earlier versions sanitized plugin kwargs.
+COPY agents/hermes/plugin-nemo-flow/ /opt/nemo-flow-hermes-plugin/
+
 # Copy bridges and default cron jobs.
 # Install under /usr/local/lib/ so Landlock's read_only /usr rule permits access.
 COPY agents/hermes/bridges/ /usr/local/lib/nemoclaw-bridges/
@@ -210,6 +258,7 @@ RUN chmod 755 /usr/local/lib/nemoclaw-slack-shims/decode-proxy.py \
 # Ensure sandbox user can read all /opt/nemoclaw-* and bridge files.
 # Source files may have restrictive permissions that Docker COPY preserves.
 RUN chmod -R a+rX /opt/nemoclaw-hermes-plugin/ \
+    && chmod -R a+rX /opt/nemo-flow-hermes-plugin/ \
     && chmod a+r /opt/nemoclaw-generate-config.ts \
     && chmod -R a+rX /usr/local/lib/nemoclaw-bridges/
 
@@ -278,6 +327,11 @@ RUN node --experimental-strip-types /opt/nemoclaw-generate-config.ts
 # Install NemoClaw plugin into Hermes
 RUN mkdir -p /sandbox/.hermes-data/plugins/nemoclaw \
     && cp -r /opt/nemoclaw-hermes-plugin/* /sandbox/.hermes-data/plugins/nemoclaw/
+
+# Install nemo-flow-bridge plugin into Hermes. HERMES_HOME=/sandbox/.hermes-data
+# (set in start.sh) and Hermes' plugin loader scans $HERMES_HOME/plugins/.
+RUN mkdir -p /sandbox/.hermes-data/plugins/nemo-flow-bridge \
+    && cp -r /opt/nemo-flow-hermes-plugin/* /sandbox/.hermes-data/plugins/nemo-flow-bridge/
 
 # Symlink SOUL.md into the immutable home so Hermes's ensure_hermes_home() finds it.
 RUN ln -s /sandbox/.hermes-data/SOUL.md /sandbox/.hermes/SOUL.md

--- a/examples/personal-community-sentiment-triage/agents/hermes/Dockerfile
+++ b/examples/personal-community-sentiment-triage/agents/hermes/Dockerfile
@@ -35,6 +35,24 @@ RUN pyinstaller \
       --hidden-import aiohttp.web \
       ms_graph_sidecar.py
 
+# ── Stage 1: build the nemo-flow CLI binary ──────────────────────────────────
+# Built inside ${BASE_IMAGE} so the resulting binary links against the same
+# glibc as the runtime — same constraint as the sidecar-builder stage above.
+# 0.2.0 publishes nemo-flow-cli to crates.io, so `cargo install` is the
+# simplest reproducible path. The ~3-5 min toolchain bootstrap is amortized
+# across the cargo target cache when the version pin doesn't change.
+FROM ${BASE_IMAGE} AS nemo-flow-builder
+ARG NEMO_FLOW_CLI_VERSION=0.2.0
+RUN apt-get update -qq \
+    && apt-get install -y --no-install-recommends \
+       build-essential ca-certificates curl pkg-config libssl-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+       | sh -s -- -y --default-toolchain stable --profile minimal \
+    && /root/.cargo/bin/cargo install --locked --root /out \
+       nemo-flow-cli --version "${NEMO_FLOW_CLI_VERSION}"
+# Produces /out/bin/nemo-flow
+
 # ── Main sandbox image ────────────────────────────────────────────────────────
 FROM ${BASE_IMAGE}
 
@@ -91,55 +109,72 @@ RUN mkdir -p /etc/apt/keyrings \
 
 RUN pip3 install --no-cache-dir --break-system-packages "httpx>=0.27" "markdown-it-py>=3"
 
-# ── NeMo-Flow patched Hermes (always installed) ─────────────────────────
-# Replaces the unpatched Hermes from the base image with a NeMo-Flow-patched
-# build so the agent writes ATIF (Agent Trajectory Format) traces to
-# /tmp/atif. nemo-flow itself comes from PyPI. The patch itself patches
-# Hermes — adding a [nemo-flow] extra, a hermes_agent.plugins entry point,
-# and an ACG override seam in run_agent.py — so it's still required even
-# with the PyPI install of nemo_flow itself.
+# ── NeMo-Flow 0.2.0 wrapped-CLI integration ─────────────────────────────
+# Drop-in observability via `nemo-flow hermes -- gateway run`. Hermes stays
+# unpatched (from BASE_IMAGE); native hook events configured in
+# ~/.hermes/config.yaml route through the wrapper's ephemeral gateway, which
+# runs the ATIF writer and OpenInference OTLP exporter from the baked
+# /etc/nemo-flow/plugins.toml. No Hermes patch, no nemo-flow PyPI package,
+# no HERMES_NEMO_FLOW_* env vars.
 #
 # ATIF writes are local-disk-only — no collector required. To additionally
-# stream OpenInference traces to Phoenix, set PHOENIX_COLLECTOR_ENDPOINT in
-# .env; that's a separate runtime knob and does not gate this install.
+# stream OpenInference traces to Phoenix, set PHOENIX_COLLECTOR_ENDPOINT;
+# empty disables OpenInference but keeps ATIF on.
 #
-# The patch is fetched from NeMo-Flow's GitHub tag at build time rather than
-# vendored, so we never drift from upstream. Pin NEMO_FLOW_VERSION to the
-# same release we install via pip; HERMES_NEMO_FLOW_COMMIT must match the
-# Hermes commit that NeMo-Flow's patch was generated against (see
-# https://github.com/NVIDIA/NeMo-Flow/blob/v0.1.0/third_party/sources.lock).
-# agents/hermes/patches/ is example-owned (not in NeMo-Flow upstream) so it
-# stays vendored. It holds the PYTHONPATH-targeted sitecustomize.py bootstrap
-# and the nemoclaw_patches.py chain-loaded bundle (httpx transport fix, Slack
-# catch-all, NeMo-Flow session finalization).
-ARG ENABLE_NEMO_FLOW=1
-ARG NEMO_FLOW_VERSION=0.1.0
-ARG HERMES_NEMO_FLOW_COMMIT=2367c6ffd53b16daa0ffa1b338f3f9ee5587d4d5
+# agents/hermes/patches/ is example-owned (not in NeMo-Flow upstream). It
+# holds the PYTHONPATH-targeted sitecustomize.py bootstrap (Slack-SDK
+# placeholder rewrite) and the nemoclaw_patches.py chain-loaded bundle
+# (Slack catch-all slash command).
+COPY --from=nemo-flow-builder /out/bin/nemo-flow /usr/local/bin/nemo-flow
+RUN chmod 755 /usr/local/bin/nemo-flow
+
+# Per-turn finalize shim. Hermes only fires `on_session_finalize` from its
+# idle-session expiry watcher (~5 min default), but NeMo-Flow's ATIF writer
+# and root-span closer only act on `on_session_finalize` / `on_session_reset`.
+# This shim, registered as a second hook on `on_session_end`, rewrites the
+# event name and re-posts to the gateway so each turn closes its agent scope.
+COPY agents/hermes/nemo-flow-finalize-shim /usr/local/bin/nemo-flow-finalize-shim
+RUN chmod 755 /usr/local/bin/nemo-flow-finalize-shim
 
 COPY agents/hermes/patches/ /usr/local/lib/nemoclaw-patches/
 
-# hadolint ignore=DL3013
-RUN if [ "$ENABLE_NEMO_FLOW" = "1" ]; then \
-        echo "[nemo-flow] Installing nemo-flow==${NEMO_FLOW_VERSION} from PyPI and patching Hermes" \
-        && curl -fsSL "https://raw.githubusercontent.com/NVIDIA/NeMo-Flow/${NEMO_FLOW_VERSION}/patches/hermes-agent/0001-add-nemo-flow-integration.patch" \
-             -o /tmp/nemo-flow.patch \
-        && curl -fsSL "https://github.com/NousResearch/hermes-agent/archive/${HERMES_NEMO_FLOW_COMMIT}.tar.gz" \
-             | tar -xz -C /tmp/ \
-        && mv "/tmp/hermes-agent-${HERMES_NEMO_FLOW_COMMIT}" /tmp/hermes-agent \
-        && git -C /tmp/hermes-agent init -q \
-        && git -C /tmp/hermes-agent apply /tmp/nemo-flow.patch \
-        && pip3 install --no-cache-dir --break-system-packages --force-reinstall \
-             "nemo-flow==${NEMO_FLOW_VERSION}" \
-             "/tmp/hermes-agent[nemo-flow,slack]" \
-             "pyyaml==6.0.3" \
-             "python-telegram-bot>=21.0" \
-             "httpx>=0.27" \
-             "slack-bolt>=1.19" \
-        && hermes --version \
-        && export PY_SITE_DIR="$(python3 -c 'import site; print(site.getsitepackages()[0])')" \
-        && ln -sfn /usr/local/lib/nemoclaw-patches/sitecustomize.py "${PY_SITE_DIR}/sitecustomize.py" \
-        && rm -rf /tmp/hermes-agent /tmp/nemo-flow.patch; \
-    fi
+# Pin slack-bolt / python-telegram-bot / pyyaml / httpx into Hermes's venv
+# interpreter so the sitecustomize patches (Slack catch-all, SDK placeholder
+# rewrite) find the modules they wrap. hadolint ignore=DL3013
+RUN pip3 install --no-cache-dir --break-system-packages \
+       "pyyaml==6.0.3" \
+       "python-telegram-bot>=21.0" \
+       "httpx>=0.27" \
+       "slack-bolt>=1.19" \
+    && hermes --version \
+    && export PY_SITE_DIR="$(python3 -c 'import site; print(site.getsitepackages()[0])')" \
+    && ln -sfn /usr/local/lib/nemoclaw-patches/sitecustomize.py "${PY_SITE_DIR}/sitecustomize.py"
+
+# ── NeMo-Flow plugin config (immutable, baked at build time) ────────────
+# Discovery order: /etc/nemo-flow → project ./.nemo-flow → user XDG
+# (NeMo-Flow crates/cli/src/config.rs:618-633). /etc/ is the cleanest
+# location for a containerized agent because it ignores CWD.
+#
+# Two files are baked here:
+#   config.toml  — `[agents.hermes]` block so `nemo-flow hermes` finds a
+#                  configured agent and skips the interactive setup wizard
+#                  (which fails in non-TTY sandboxes).
+#   plugins.toml — observability component (ATIF + OpenInference).
+COPY agents/hermes/nemo-flow-plugins.toml.in /tmp/nemo-flow-plugins.toml.in
+RUN mkdir -p /etc/nemo-flow \
+    && printf '%s\n' '[agents.hermes]' 'command = "hermes"' > /etc/nemo-flow/config.toml \
+    && chmod 444 /etc/nemo-flow/config.toml \
+    && PHOENIX_URL="${PHOENIX_COLLECTOR_ENDPOINT:-}" \
+    && if [ -z "$PHOENIX_URL" ]; then \
+         PHOENIX_ENABLED=false; PHOENIX_ENDPOINT=""; \
+       else \
+         PHOENIX_ENABLED=true; PHOENIX_ENDPOINT="${PHOENIX_URL%/}/v1/traces"; \
+       fi \
+    && sed -e "s|@@PHOENIX_ENABLED@@|${PHOENIX_ENABLED}|g" \
+           -e "s|@@PHOENIX_ENDPOINT@@|${PHOENIX_ENDPOINT}|g" \
+       /tmp/nemo-flow-plugins.toml.in > /etc/nemo-flow/plugins.toml \
+    && rm /tmp/nemo-flow-plugins.toml.in \
+    && chmod 444 /etc/nemo-flow/plugins.toml
 
 # Hermes v2026.4.13+ auto-detects HTTPS_PROXY and skips fallback-IP
 # transport when a proxy is present. The sandbox proxy chain

--- a/examples/personal-community-sentiment-triage/agents/hermes/generate-config.ts
+++ b/examples/personal-community-sentiment-triage/agents/hermes/generate-config.ts
@@ -113,6 +113,40 @@ function main(): void {
       mode: "smart",
       timeout: 60,
     },
+    // NeMo-Flow shell hooks — each event spawns `nemo-flow hook-forward hermes`,
+    // which reads the JSON payload from stdin and POSTs it to NEMO_FLOW_GATEWAY_URL
+    // (injected by the `nemo-flow hermes` wrapper). Events are the intersection of
+    // NeMo-Flow's HERMES_HOOK_EVENTS (installer.rs) and Hermes's VALID_HOOKS
+    // (hermes_cli/plugins.py). NeMo-Flow's "api_request_error" and "subagent_start"
+    // are forward-looking — current Hermes only exposes "subagent_stop" and reports
+    // request errors via "post_api_request" payloads, so we omit them here to
+    // avoid "unknown hook event" warnings.
+    //
+    // `on_session_end` gets a SECOND command (`nemo-flow-finalize-shim`) that
+    // synthesizes a per-turn `on_session_finalize`. Hermes fires real finalize
+    // only from its idle-session expiry watcher (~5 min default), but
+    // NeMo-Flow's ATIF writer and root-span closer only act on finalize. The
+    // shim closes the agent scope every turn so each conversation produces a
+    // complete Phoenix root span and a fresh ATIF JSON file.
+    hooks: (() => {
+      const fwd = { command: "/usr/local/bin/nemo-flow hook-forward hermes", timeout: 30 };
+      const finalize_shim = { command: "/usr/local/bin/nemo-flow-finalize-shim", timeout: 30 };
+      const events = [
+        "on_session_start", "on_session_finalize", "on_session_reset",
+        "pre_llm_call", "post_llm_call",
+        "pre_api_request", "post_api_request",
+        "pre_tool_call", "post_tool_call",
+        "subagent_stop",
+      ];
+      const result: Record<string, unknown[]> = Object.fromEntries(events.map((ev) => [ev, [fwd]]));
+      result.on_session_end = [fwd, finalize_shim];
+      return result;
+    })(),
+    // Auto-accept the hook commands. The sandbox is non-interactive; without
+    // this the first hook fires a TTY consent prompt and gets skipped,
+    // dropping all observability silently. Safe here because config.yaml is
+    // root-owned + chmod 444 at build time.
+    hooks_auto_accept: true,
   };
 
   // Messaging platforms (if configured during onboard)

--- a/examples/personal-community-sentiment-triage/agents/hermes/generate-config.ts
+++ b/examples/personal-community-sentiment-triage/agents/hermes/generate-config.ts
@@ -122,6 +122,16 @@ function main(): void {
     // request errors via "post_api_request" payloads, so we omit them here to
     // avoid "unknown hook event" warnings.
     //
+    // pre_api_request / post_api_request are NOT shell-forwarded. The
+    // in-process nemo-flow-bridge plugin (plugins/nemo-flow-bridge/) owns
+    // those events under Hermes v0.14.0: it receives the real `request_messages`
+    // list and the real `response` SDK object as kwargs, and forwards them to
+    // NEMO_FLOW_GATEWAY_URL/hooks/hermes with payload.request.body /
+    // payload.response.raw_response populated. NeMo-Flow's adapter then marks
+    // provider_payload_exact=true so Phoenix spans carry the real prompts and
+    // completions. Shell-forwarding these same events alongside the plugin
+    // would create duplicate lossy-summary LLM scopes on the gateway.
+    //
     // `on_session_end` gets a SECOND command (`nemo-flow-finalize-shim`) that
     // synthesizes a per-turn `on_session_finalize`. Hermes fires real finalize
     // only from its idle-session expiry watcher (~5 min default), but
@@ -134,7 +144,6 @@ function main(): void {
       const events = [
         "on_session_start", "on_session_finalize", "on_session_reset",
         "pre_llm_call", "post_llm_call",
-        "pre_api_request", "post_api_request",
         "pre_tool_call", "post_tool_call",
         "subagent_stop",
       ];
@@ -147,6 +156,14 @@ function main(): void {
     // dropping all observability silently. Safe here because config.yaml is
     // root-owned + chmod 444 at build time.
     hooks_auto_accept: true,
+    // Enable in-process Hermes plugins. nemoclaw provides sandbox status
+    // tools and the startup banner; nemo-flow-bridge owns the pre/post_api_request
+    // events (see hooks comment above). Belt-and-suspenders against
+    // config-migration changes — v0.14.0 also auto-discovers plugins under
+    // $HERMES_HOME/plugins/, but explicit enablement survives schema bumps.
+    plugins: {
+      enabled: ["nemoclaw", "nemo-flow-bridge"],
+    },
   };
 
   // Messaging platforms (if configured during onboard)

--- a/examples/personal-community-sentiment-triage/agents/hermes/manifest.yaml
+++ b/examples/personal-community-sentiment-triage/agents/hermes/manifest.yaml
@@ -17,7 +17,7 @@ install_method: curl  # curl install.sh | bash
 binary_path: /usr/local/bin/hermes
 version_command: "hermes --version"
 expected_version: "2026.4.8"
-gateway_command: "hermes gateway run"
+gateway_command: "hermes gateway run"  # entrypoint wraps this with `nemo-flow hermes --` (see start.sh)
 
 # ── Health probe ────────────────────────────────────────────────
 # The API server adapter listens on 8642 by default and exposes

--- a/examples/personal-community-sentiment-triage/agents/hermes/nemo-flow-finalize-shim
+++ b/examples/personal-community-sentiment-triage/agents/hermes/nemo-flow-finalize-shim
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# NeMo-Flow gateway-mode finalize shim.
+#
+# Hermes fires `on_session_end` at every `run_conversation` turn boundary but
+# only fires `on_session_finalize` from its idle-session expiry watcher every
+# ~5 minutes. NeMo-Flow 0.2.0's gateway adapter (crates/cli/src/adapters/
+# hermes.rs:55-64) maps `on_session_end` to `TurnEnded`, which is documented
+# as NOT closing the agent scope — and the ATIF writer in
+# crates/core/src/observability/plugin_component.rs:684-685 only writes when
+# the agent scope closes. Result: orphaned Phoenix spans and no ATIF files
+# per turn.
+#
+# This shim is registered as a SECOND command on `on_session_end`. It rewrites
+# the JSON payload's `hook_event_name` to `on_session_finalize` and pipes it
+# back into `nemo-flow hook-forward hermes`, so the gateway closes the agent
+# scope and writes ATIF every turn. The first command (the unmodified
+# `hook-forward`) still delivers the on_session_end event for any other
+# downstream handling.
+import json
+import os
+import subprocess
+import sys
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        # Empty or malformed stdin — emit a synthesized payload so the gateway
+        # still observes a finalize for whatever session_id we have.
+        payload = {}
+    if not isinstance(payload, dict):
+        payload = {}
+    payload["hook_event_name"] = "on_session_finalize"
+    rewritten = json.dumps(payload)
+
+    proc = subprocess.run(
+        ["/usr/local/bin/nemo-flow", "hook-forward", "hermes"],
+        input=rewritten,
+        text=True,
+        env=os.environ.copy(),
+        check=False,
+    )
+    # Hermes only inspects stdout when looking for hook decisions. Emit an
+    # empty object so the agent loop treats this as a silent observer.
+    sys.stdout.write("{}\n")
+    return proc.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/personal-community-sentiment-triage/agents/hermes/nemo-flow-plugins.toml.in
+++ b/examples/personal-community-sentiment-triage/agents/hermes/nemo-flow-plugins.toml.in
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# NeMo-Flow gateway plugin config — installed at /etc/nemo-flow/plugins.toml.
+# Substituted at image build time from PHOENIX_COLLECTOR_ENDPOINT.
+# Schema: nemo_flow.observability.ObservabilityConfig
+# (NeMo-Flow python/nemo_flow/observability.py).
+
+version = 1
+
+[[components]]
+kind = "observability"
+enabled = true
+
+[components.config.atif]
+enabled = true
+output_directory = "/tmp/atif"
+
+[components.config.openinference]
+enabled = @@PHOENIX_ENABLED@@
+transport = "http_binary"
+endpoint = "@@PHOENIX_ENDPOINT@@"
+service_name = "hermes-agent"
+timeout_millis = 3000

--- a/examples/personal-community-sentiment-triage/agents/hermes/patches/nemoclaw_patches.py
+++ b/examples/personal-community-sentiment-triage/agents/hermes/patches/nemoclaw_patches.py
@@ -6,50 +6,14 @@
 # Bundled into the image at /usr/local/lib/nemoclaw-patches/nemoclaw_patches.py
 # and chain-loaded by the neighboring sitecustomize.py (which Python imports
 # preferentially because /usr/local/lib/nemoclaw-patches/ is first on
-# PYTHONPATH). When ENABLE_NEMO_FLOW=1, ${PY_SITE_DIR}/sitecustomize.py is a
-# symlink back to the same sitecustomize.py — a fallback for child processes
-# that lose PYTHONPATH.
+# PYTHONPATH).
 #
-# The NeMo-Flow meta_path hook below is a no-op when nemo-flow isn't
-# installed, so this file is safe to load regardless of build mode.
-#
-# Patch 1 — httpx transport fix: Hermes creates httpx.Client(transport=HTTPTransport(...))
-# for TCP keepalives. A custom transport bypasses HTTPS_PROXY env-var routing,
-# so Hermes cannot reach inference.local (only reachable via the OpenShell L7
-# proxy). Strip transport= when HTTPS_PROXY is set so httpx falls back to its
-# default proxy-aware transport.
-#
-# Patch 2 — NeMo-Flow observability: on_session_end is intentionally a no-op in
-# nemo_flow (pitfall P-02 — avoids premature finalization for long-lived CLI
-# sessions). In the gateway, every run_conversation call IS a complete session
-# regardless of platform, so we finalize immediately on every on_session_end.
-# on_session_finalize never fires from the API server or native platform paths.
-#
-# Patch 3 — Slack catch-all slash command: Hermes only registers "/hermes" as
-# its bolt command handler. Any workspace-specific command name (e.g.
-# /my-assistant) produces an "Unhandled request" warning. After SlackAdapter
-# connects, register a catch-all that routes every other slash command through
-# the same _handle_slash_command path.
-import os as _os
+# Slack catch-all slash command — Hermes only registers "/hermes" as its bolt
+# command handler. Any workspace-specific command name (e.g. /my-assistant)
+# produces an "Unhandled request" warning. After SlackAdapter connects,
+# register a catch-all that routes every other slash command through the same
+# _handle_slash_command path.
 import re as _re
-import sys as _sys
-import importlib.abc as _iabc
-import importlib.util as _iutil
-
-
-def _patch_httpx() -> None:
-    try:
-        import httpx
-        _orig = httpx.Client.__init__
-        def _fixed(self, *a, **kw):
-            if "transport" in kw and (
-                _os.environ.get("HTTPS_PROXY") or _os.environ.get("https_proxy")
-            ):
-                del kw["transport"]
-            _orig(self, *a, **kw)
-        httpx.Client.__init__ = _fixed
-    except Exception:
-        pass
 
 
 def _patch_slack_commands() -> None:
@@ -66,7 +30,7 @@ def _patch_slack_commands() -> None:
                     cmd = command.get("command", "this command")
                     await respond(
                         f"I don't recognize `{cmd}`. "
-                        "Send me a *direct message* or @mention me a to chat"
+                        "Send me a *direct message* or @mention me to chat"
                     )
             return result
 
@@ -75,38 +39,4 @@ def _patch_slack_commands() -> None:
         pass
 
 
-_patch_httpx()
 _patch_slack_commands()
-
-
-class _PatchingLoader(_iabc.Loader):
-    def __init__(self, real: _iabc.Loader) -> None:
-        self._real = real
-
-    def create_module(self, spec):  # type: ignore[override]
-        m = getattr(self._real, "create_module", None)
-        return m(spec) if m else None
-
-    def exec_module(self, mod) -> None:  # type: ignore[override]
-        self._real.exec_module(mod)
-        def _gateway_session_end(session_id: str = "", platform: str = "", **_kw) -> None:
-            if session_id and getattr(mod, "_NEMO_FLOW_OK", False):
-                try:
-                    mod._finalize(session_id, platform or "session_end")
-                except Exception:
-                    pass
-        mod.on_session_end = _gateway_session_end
-
-
-class _NemoFlowPatcher(_iabc.MetaPathFinder):
-    def find_spec(self, fullname: str, path, target=None):  # type: ignore[override]
-        if fullname != "plugins.nemo_flow.observability":
-            return None
-        _sys.meta_path.remove(self)
-        spec = _iutil.find_spec(fullname)
-        if spec is not None:
-            spec.loader = _PatchingLoader(spec.loader)
-        return spec
-
-
-_sys.meta_path.insert(0, _NemoFlowPatcher())

--- a/examples/personal-community-sentiment-triage/agents/hermes/patches/sitecustomize.py
+++ b/examples/personal-community-sentiment-triage/agents/hermes/patches/sitecustomize.py
@@ -249,15 +249,13 @@ if aiohttp is not None:
 
 
 # ---------------------------------------------------------------------------
-# Chain-load nemoclaw_patches (httpx transport fix + Slack catch-all command
-# + NeMo-Flow session finalization).
+# Chain-load nemoclaw_patches (Slack catch-all slash command).
 #
 # Python imports the first `sitecustomize` it finds on sys.path. Because
 # PYTHONPATH puts /usr/local/lib/nemoclaw-patches/ before site-packages, the
 # venv's own sitecustomize is shadowed and never runs. The Dockerfile copies
 # agents/hermes/patches/nemoclaw_patches.py into the same directory, so this
-# import triggers its module-level _patch_httpx + _patch_slack_commands and
-# registers the NeMo-Flow meta_path hook.
+# import triggers its module-level _patch_slack_commands.
 try:
     import nemoclaw_patches  # noqa: F401  side-effect import
 except Exception:

--- a/examples/personal-community-sentiment-triage/agents/hermes/plugin-nemo-flow/__init__.py
+++ b/examples/personal-community-sentiment-triage/agents/hermes/plugin-nemo-flow/__init__.py
@@ -1,0 +1,319 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+nemo-flow-bridge: in-process Hermes plugin that forwards pre/post_api_request
+hooks to NeMo-Flow with the real request body and response body attached.
+
+Under Hermes v0.14.0, plugin hooks carry real data:
+  - pre_api_request receives `request_messages` (list of dicts), `user_message`,
+    and `conversation_history` — the actual OpenAI-shape messages array Hermes
+    is about to send upstream.
+  - post_api_request receives `response` (a SimpleNamespace mirroring the
+    OpenAI ChatCompletion shape with .choices/.usage/.model/.id) and
+    `assistant_message` (a NormalizedResponse with .content/.tool_calls).
+
+NeMo-Flow's Hermes adapter (crates/cli/src/adapters/hermes.rs) flips
+`provider_payload_exact` to true and emits Phoenix LLM spans with the full
+prompt+completion when it finds `payload.request.body` (pre) or
+`payload.response.{raw_response,choices,assistant_message}` (post). This plugin
+builds those payload shapes from the in-process kwargs and POSTs them to
+`${NEMO_FLOW_GATEWAY_URL}/hooks/hermes` — the URL is exported into the Hermes
+child env by the `nemo-flow hermes -- gateway run` wrapper at start.sh.
+
+Failure mode is fail-open: any exception is swallowed and logged at debug.
+Hermes turns must never break because the bridge can't reach NeMo-Flow.
+
+Modeled on the bundled Langfuse plugin
+(/home/mpenn/hermes-agent/plugins/observability/langfuse/__init__.py).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from types import SimpleNamespace
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+_MAX_PAYLOAD_BYTES = 262_144  # 256 KiB; oversize payloads drop body fields, keep correlation.
+
+_LOCK = threading.Lock()
+_CLIENT: Optional[Any] = None  # httpx.Client, lazily created
+_GATEWAY_URL: Optional[str] = None
+_GATEWAY_LOOKED_UP = False
+_DISABLED_LOGGED = False
+
+
+# ---------------------------------------------------------------------------
+# Gateway URL + HTTP client
+# ---------------------------------------------------------------------------
+
+def _gateway_url() -> Optional[str]:
+    global _GATEWAY_URL, _GATEWAY_LOOKED_UP, _DISABLED_LOGGED
+    with _LOCK:
+        if _GATEWAY_LOOKED_UP:
+            return _GATEWAY_URL
+        _GATEWAY_LOOKED_UP = True
+        url = os.environ.get("NEMO_FLOW_GATEWAY_URL", "").strip()
+        if not url:
+            if not _DISABLED_LOGGED:
+                logger.debug(
+                    "nemo-flow-bridge: NEMO_FLOW_GATEWAY_URL is not set; "
+                    "bridge will not forward hooks (expected when Hermes "
+                    "runs outside `nemo-flow hermes -- ...`)."
+                )
+                _DISABLED_LOGGED = True
+            return None
+        _GATEWAY_URL = url.rstrip("/")
+        return _GATEWAY_URL
+
+
+def _client():
+    global _CLIENT
+    with _LOCK:
+        if _CLIENT is not None:
+            return _CLIENT
+        try:
+            import httpx  # type: ignore
+
+            _CLIENT = httpx.Client(timeout=2.0)
+            return _CLIENT
+        except Exception as exc:  # pragma: no cover
+            logger.debug("nemo-flow-bridge: failed to construct httpx client: %s", exc)
+            return None
+
+
+# ---------------------------------------------------------------------------
+# Value coercion
+# ---------------------------------------------------------------------------
+
+def _safe_jsonable(value: Any, _depth: int = 0) -> Any:
+    """Recursively coerce any value into something json.dumps can serialize.
+    Covers pydantic v2 SDK objects, older to_dict shapes, SimpleNamespace
+    (vars(obj) → dict), and arbitrary attribute-bearing classes."""
+    if _depth > 12:  # guard against pathological cycles
+        return repr(value)[:256]
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {str(k): _safe_jsonable(v, _depth + 1) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_safe_jsonable(v, _depth + 1) for v in value]
+    # Pydantic v2 (OpenAI/Anthropic SDK responses)
+    dump = getattr(value, "model_dump", None)
+    if callable(dump):
+        try:
+            return dump(mode="json")
+        except Exception:
+            try:
+                return _safe_jsonable(dump(), _depth + 1)
+            except Exception:
+                pass
+    # Older SDK shapes
+    to_dict = getattr(value, "to_dict", None)
+    if callable(to_dict):
+        try:
+            return _safe_jsonable(to_dict(), _depth + 1)
+        except Exception:
+            pass
+    # SimpleNamespace and attribute-bearing classes (Hermes' NormalizedResponse,
+    # the v0.14.0 response wrapper, etc.)
+    if isinstance(value, SimpleNamespace) or hasattr(value, "__dict__"):
+        try:
+            return _safe_jsonable(vars(value), _depth + 1)
+        except Exception:
+            pass
+    return repr(value)[:4096]
+
+
+def _coerce_request_messages(
+    *,
+    request_messages: Any = None,
+    conversation_history: Any = None,
+    user_message: Any = None,
+) -> list:
+    """Hermes v0.14.0 passes a real `request_messages` list of {role, content}
+    dicts. Fall back to conversation_history, then synthesize a single user
+    message from user_message — mirrors Langfuse's resolver at
+    plugins/observability/langfuse/__init__.py:409."""
+    for candidate in (request_messages, conversation_history):
+        if isinstance(candidate, list) and candidate:
+            return candidate
+    if user_message:
+        return [{"role": "user", "content": user_message}]
+    if isinstance(request_messages, list):
+        return request_messages
+    return []
+
+
+def _serialize_tool_calls(tool_calls: Any) -> list:
+    if not tool_calls:
+        return []
+    out = []
+    for tc in tool_calls:
+        if isinstance(tc, dict):
+            out.append(_safe_jsonable(tc))
+            continue
+        fn = getattr(tc, "function", None)
+        name = getattr(fn, "name", None) if fn else None
+        args = getattr(fn, "arguments", None) if fn else None
+        out.append({
+            "id": getattr(tc, "id", None),
+            "type": getattr(tc, "type", None) or "function",
+            "function": {"name": name, "arguments": _safe_jsonable(args)},
+        })
+    return out
+
+
+def _serialize_assistant_message(obj: Any) -> Optional[dict]:
+    """Pull the fields NeMo-Flow's adapter inspects on
+    `response.assistant_message` (adapters/hermes.rs:264-280)."""
+    if obj is None:
+        return None
+    if isinstance(obj, dict):
+        return _safe_jsonable(obj)
+    return {
+        "content": _safe_jsonable(getattr(obj, "content", None)),
+        "tool_calls": _serialize_tool_calls(getattr(obj, "tool_calls", None)),
+        "reasoning": _safe_jsonable(getattr(obj, "reasoning", None)),
+    }
+
+
+def _serialize_response_object(response: Any) -> Optional[dict]:
+    """Turn the v0.14.0 `response=` kwarg (a SimpleNamespace with
+    .choices/.usage/.model/.id) into a dict. The result has `choices` at
+    top-level, which adapters/hermes.rs:251-256 recognizes as a real
+    provider response and uses to mark provider_payload_exact=true."""
+    if response is None:
+        return None
+    blob = _safe_jsonable(response)
+    if isinstance(blob, dict) and (
+        "choices" in blob or "output" in blob or "content" in blob
+    ):
+        return blob
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Forwarder
+# ---------------------------------------------------------------------------
+
+def _cap_payload(payload: dict) -> dict:
+    """If JSON-encoded payload exceeds 256 KiB, drop body fields but keep
+    correlation keys. Adapter's truncation guard then degrades to lossy
+    fallback rather than discarding the event."""
+    try:
+        encoded = json.dumps(payload, default=str)
+    except Exception:
+        return payload
+    if len(encoded) <= _MAX_PAYLOAD_BYTES:
+        return payload
+    trimmed = dict(payload)
+    request = trimmed.get("request")
+    if isinstance(request, dict) and "body" in request:
+        request = dict(request)
+        request.pop("body", None)
+        trimmed["request"] = request
+    response = trimmed.get("response")
+    if isinstance(response, dict):
+        response = dict(response)
+        response.pop("raw_response", None)
+        response.pop("assistant_message", None)
+        trimmed["response"] = response
+    return trimmed
+
+
+def _forward(payload: dict) -> None:
+    url = _gateway_url()
+    if not url:
+        return
+    client = _client()
+    if client is None:
+        return
+    try:
+        client.post(f"{url}/hooks/hermes", json=_cap_payload(payload))
+    except Exception as exc:
+        logger.debug("nemo-flow-bridge: forward to %s failed: %s", url, exc)
+
+
+def _correlation(kwargs: dict) -> dict:
+    """The fields NeMo-Flow's adapter uses to synthesize api_call_id and
+    correlate hook events back to the right session/turn scope."""
+    return {
+        "task_id": kwargs.get("task_id"),
+        "session_id": kwargs.get("session_id"),
+        "api_call_count": kwargs.get("api_call_count"),
+        "platform": kwargs.get("platform"),
+        "model": kwargs.get("model"),
+        "provider": kwargs.get("provider"),
+        "base_url": kwargs.get("base_url"),
+        "api_mode": kwargs.get("api_mode"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Hook handlers
+# ---------------------------------------------------------------------------
+
+def on_pre_api_request(**kwargs: Any) -> None:
+    try:
+        payload = _correlation(kwargs)
+        payload["hook_event_name"] = "pre_api_request"
+        messages = _coerce_request_messages(
+            request_messages=kwargs.get("request_messages"),
+            conversation_history=kwargs.get("conversation_history"),
+            user_message=kwargs.get("user_message"),
+        )
+        payload["request"] = {
+            "body": _safe_jsonable(messages),
+            "model": kwargs.get("model"),
+            "api_mode": kwargs.get("api_mode"),
+            "max_tokens": kwargs.get("max_tokens"),
+        }
+        _forward(payload)
+    except Exception as exc:
+        logger.debug("nemo-flow-bridge: on_pre_api_request failed: %s", exc)
+
+
+def on_post_api_request(**kwargs: Any) -> None:
+    try:
+        payload = _correlation(kwargs)
+        payload["hook_event_name"] = "post_api_request"
+        # Primary path: serialize the real response SimpleNamespace into a
+        # dict with `choices/usage/model/id`. The adapter's
+        # hermes_exact_response sees .choices and returns the whole dict,
+        # which OpenInference renders as input/output.value.
+        raw_response = _serialize_response_object(kwargs.get("response"))
+        # Redundant fallback path: include serialized assistant_message in
+        # case raw_response can't be extracted. Adapter has a separate
+        # branch for response.assistant_message.{content,tool_calls}.
+        assistant_message = _serialize_assistant_message(kwargs.get("assistant_message"))
+        payload["response"] = {
+            "raw_response": raw_response,
+            "assistant_message": assistant_message,
+            "model": kwargs.get("response_model") or kwargs.get("model"),
+            "finish_reason": kwargs.get("finish_reason"),
+            "api_duration": kwargs.get("api_duration"),
+            "usage": _safe_jsonable(kwargs.get("usage")),
+        }
+        _forward(payload)
+    except Exception as exc:
+        logger.debug("nemo-flow-bridge: on_post_api_request failed: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Plugin entry-point
+# ---------------------------------------------------------------------------
+
+def register(ctx) -> None:
+    """Wire pre/post_api_request to the in-process forwarders.
+
+    Shell-hook entries for these two events are intentionally removed from
+    config.yaml (see generate-config.ts) so the gateway sees exactly one
+    event per call — the enriched one from this plugin.
+    """
+    ctx.register_hook("pre_api_request", on_pre_api_request)
+    ctx.register_hook("post_api_request", on_post_api_request)

--- a/examples/personal-community-sentiment-triage/agents/hermes/plugin-nemo-flow/plugin.yaml
+++ b/examples/personal-community-sentiment-triage/agents/hermes/plugin-nemo-flow/plugin.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: nemo-flow-bridge
+version: "0.0.1"
+description: "Forwards Hermes pre/post_api_request hooks to NeMo-Flow with exact request/response bodies for full Phoenix LLM spans."
+author: "NVIDIA Corporation"
+manifest_version: 1
+hooks:
+  - pre_api_request
+  - post_api_request

--- a/examples/personal-community-sentiment-triage/agents/hermes/start.sh
+++ b/examples/personal-community-sentiment-triage/agents/hermes/start.sh
@@ -112,7 +112,6 @@ PUBLIC_PORT=8642
 # Hermes binds to 127.0.0.1 regardless of config (upstream bug).
 # Run it on an internal port and use socat to expose on PUBLIC_PORT.
 INTERNAL_PORT=18642
-HERMES="$(command -v hermes)" # Resolve once, use absolute path everywhere
 
 # Hermes writes state files (PID, state.db, .channel_directory) directly into
 # HERMES_HOME. We cannot point it at the immutable /sandbox/.hermes dir.
@@ -565,19 +564,15 @@ if [ "$(id -u)" -ne 0 ]; then
 
   # Prepare ATIF telemetry directory (ephemeral, writable by the current user).
   mkdir -p /tmp/atif
-  # Detect NeMo-Flow by package availability — more reliable than env var inheritance.
-  if python3 -c "import nemo_flow" 2>/dev/null; then
-    NEMO_FLOW_ENABLED=1
+  # NeMo-Flow observability is configured via /etc/nemo-flow/plugins.toml
+  # (baked at image build time). Verify the binary and config are present.
+  if [ -x /usr/local/bin/nemo-flow ] \
+     && [ -r /etc/nemo-flow/config.toml ] \
+     && [ -r /etc/nemo-flow/plugins.toml ]; then
+    echo "[nemo-flow] gateway wrapper ready (config.toml + plugins.toml in /etc/nemo-flow)" | tee -a /tmp/gateway.log >&2
   else
-    NEMO_FLOW_ENABLED=0
+    echo "[nemo-flow] WARNING: gateway wrapper or config missing — telemetry disabled" | tee -a /tmp/gateway.log >&2
   fi
-  {
-    echo "[nemo-flow] NEMO_FLOW_ENABLED=${NEMO_FLOW_ENABLED}"
-    echo "[nemo-flow] PHOENIX_COLLECTOR_ENDPOINT=${PHOENIX_COLLECTOR_ENDPOINT:-<unset>}"
-  } | tee -a /tmp/gateway.log >&2
-  PHOENIX_OPENINFERENCE_ENABLED=0
-  [ -n "${PHOENIX_COLLECTOR_ENDPOINT:-}" ] && PHOENIX_OPENINFERENCE_ENABLED=1
-  echo "[nemo-flow] PHOENIX_OPENINFERENCE_ENABLED=${PHOENIX_OPENINFERENCE_ENABLED}" | tee -a /tmp/gateway.log >&2
 
   HERMES_HOME="${HERMES_WRITABLE}" \
     HTTPS_PROXY="${_PROXY_URL}" \
@@ -585,15 +580,8 @@ if [ "$(id -u)" -ne 0 ]; then
     https_proxy="${_PROXY_URL}" \
     http_proxy="${_PROXY_URL}" \
     PYTHONPATH="${PATCHES_DIR}${PYTHONPATH:+:${PYTHONPATH}}" \
-    HERMES_NEMO_FLOW_ENABLED="${NEMO_FLOW_ENABLED:-0}" \
-    HERMES_NEMO_FLOW_ATIF_DIR="/tmp/atif" \
-    HERMES_NEMO_FLOW_ACG_ENABLED="0" \
-    HERMES_NEMO_FLOW_OPENINFERENCE_ENABLED="${PHOENIX_OPENINFERENCE_ENABLED}" \
-    HERMES_NEMO_FLOW_OPENINFERENCE_TRANSPORT="http_binary" \
-    HERMES_NEMO_FLOW_OPENINFERENCE_ENDPOINT="${PHOENIX_COLLECTOR_ENDPOINT:-}" \
-    HERMES_NEMO_FLOW_OPENINFERENCE_SERVICE_NAME="hermes-agent" \
     API_SERVER_KEY="nemoclaw-internal" \
-    nohup "$HERMES" gateway run >>/tmp/gateway.log 2>&1 &
+    nohup /usr/local/bin/nemo-flow hermes -- gateway run >>/tmp/gateway.log 2>&1 &
   GATEWAY_PID=$!
   echo "[gateway] hermes gateway launched (pid $GATEWAY_PID)" >&2
   start_gateway_log_stream
@@ -638,19 +626,13 @@ prepare_restricted_log /tmp/gateway.log gateway:gateway 600
 # gateway user (launched via gosu below) can write to it.
 mkdir -p /tmp/atif
 chown gateway:gateway /tmp/atif
-# Detect NeMo-Flow by package availability — more reliable than env var inheritance.
-if python3 -c "import nemo_flow" 2>/dev/null; then
-  NEMO_FLOW_ENABLED=1
+# NeMo-Flow observability is configured via /etc/nemo-flow/plugins.toml
+# (baked at image build time). Verify the binary and config are present.
+if [ -x /usr/local/bin/nemo-flow ] && [ -r /etc/nemo-flow/plugins.toml ]; then
+  echo "[nemo-flow] gateway wrapper ready (plugins.toml=/etc/nemo-flow/plugins.toml)" | tee -a /tmp/gateway.log >&2
 else
-  NEMO_FLOW_ENABLED=0
+  echo "[nemo-flow] WARNING: gateway wrapper missing — telemetry disabled" | tee -a /tmp/gateway.log >&2
 fi
-{
-  echo "[nemo-flow] NEMO_FLOW_ENABLED=${NEMO_FLOW_ENABLED}"
-  echo "[nemo-flow] PHOENIX_COLLECTOR_ENDPOINT=${PHOENIX_COLLECTOR_ENDPOINT:-<unset>}"
-} | tee -a /tmp/gateway.log >&2
-PHOENIX_OPENINFERENCE_ENABLED=0
-[ -n "${PHOENIX_COLLECTOR_ENDPOINT:-}" ] && PHOENIX_OPENINFERENCE_ENABLED=1
-echo "[nemo-flow] PHOENIX_OPENINFERENCE_ENABLED=${PHOENIX_OPENINFERENCE_ENABLED}" | tee -a /tmp/gateway.log >&2
 
 # Defence-in-depth: verify /tmp file permissions before launching services.
 # shellcheck disable=SC2119
@@ -662,22 +644,20 @@ validate_config_symlinks "${HERMES_IMMUTABLE}" "${HERMES_WRITABLE}"
 # Lock .hermes directory after validation.
 harden_config_symlinks "${HERMES_IMMUTABLE}" "hermes"
 
-# Start the gateway as the 'gateway' user.
+# Start the gateway as the 'gateway' user, wrapped in `nemo-flow hermes`.
+# The wrapper binds an ephemeral 127.0.0.1 gateway, exports NEMO_FLOW_GATEWAY_URL
+# into Hermes's environment, and spawns `hermes gateway run` as the child.
+# Hermes's hook subprocesses inherit NEMO_FLOW_GATEWAY_URL and forward
+# events to the in-proc gateway via `nemo-flow hook-forward hermes`.
 HERMES_HOME="${HERMES_WRITABLE}" \
   HTTPS_PROXY="${_PROXY_URL}" \
   HTTP_PROXY="${_PROXY_URL}" \
   https_proxy="${_PROXY_URL}" \
   http_proxy="${_PROXY_URL}" \
   PYTHONPATH="${PATCHES_DIR}${PYTHONPATH:+:${PYTHONPATH}}" \
-  HERMES_NEMO_FLOW_ENABLED="${NEMO_FLOW_ENABLED:-0}" \
-  HERMES_NEMO_FLOW_ATIF_DIR="/tmp/atif" \
-  HERMES_NEMO_FLOW_ACG_ENABLED="0" \
-  HERMES_NEMO_FLOW_OPENINFERENCE_ENABLED="${PHOENIX_OPENINFERENCE_ENABLED}" \
-  HERMES_NEMO_FLOW_OPENINFERENCE_TRANSPORT="http_binary" \
-  HERMES_NEMO_FLOW_OPENINFERENCE_ENDPOINT="${PHOENIX_COLLECTOR_ENDPOINT:-}" \
-  HERMES_NEMO_FLOW_OPENINFERENCE_SERVICE_NAME="hermes-agent" \
   API_SERVER_KEY="nemoclaw-internal" \
-  nohup gosu gateway "$HERMES" gateway run >>/tmp/gateway.log 2>&1 &
+  nohup gosu gateway /usr/local/bin/nemo-flow hermes -- gateway run \
+    >>/tmp/gateway.log 2>&1 &
 GATEWAY_PID=$!
 echo "[gateway] hermes gateway launched as 'gateway' user (pid $GATEWAY_PID)" >&2
 start_gateway_log_stream

--- a/examples/personal-community-sentiment-triage/agents/hermes/start.sh
+++ b/examples/personal-community-sentiment-triage/agents/hermes/start.sh
@@ -574,6 +574,16 @@ if [ "$(id -u)" -ne 0 ]; then
     echo "[nemo-flow] WARNING: gateway wrapper or config missing — telemetry disabled" | tee -a /tmp/gateway.log >&2
   fi
 
+  # OTEL_BSP_* force the OpenInference BatchSpanProcessor (OpenTelemetry SDK
+  # 0.31, used by nemo-flow's HTTP exporter at
+  # crates/core/src/observability/openinference.rs:449-460) to flush every
+  # span immediately instead of batching for 5 seconds. Without these, real
+  # multi-scope Hermes turns produce a single larger POST that the OpenShell
+  # L7 proxy appears to acknowledge with 200 but not forward to Phoenix,
+  # causing silent span loss. With BSP_MAX_EXPORT_BATCH_SIZE=1 every span
+  # becomes a small single-span POST, matching the manual-probe shape that
+  # we confirmed lands cleanly. Tracked upstream as missing force_flush() on
+  # turn boundary in nemo-flow's session.rs end_turn().
   HERMES_HOME="${HERMES_WRITABLE}" \
     HTTPS_PROXY="${_PROXY_URL}" \
     HTTP_PROXY="${_PROXY_URL}" \
@@ -581,6 +591,9 @@ if [ "$(id -u)" -ne 0 ]; then
     http_proxy="${_PROXY_URL}" \
     PYTHONPATH="${PATCHES_DIR}${PYTHONPATH:+:${PYTHONPATH}}" \
     API_SERVER_KEY="nemoclaw-internal" \
+    OTEL_BSP_MAX_EXPORT_BATCH_SIZE=1 \
+    OTEL_BSP_SCHEDULE_DELAY=100 \
+    OTEL_BSP_EXPORT_TIMEOUT=2000 \
     nohup /usr/local/bin/nemo-flow hermes -- gateway run >>/tmp/gateway.log 2>&1 &
   GATEWAY_PID=$!
   echo "[gateway] hermes gateway launched (pid $GATEWAY_PID)" >&2
@@ -649,6 +662,10 @@ harden_config_symlinks "${HERMES_IMMUTABLE}" "hermes"
 # into Hermes's environment, and spawns `hermes gateway run` as the child.
 # Hermes's hook subprocesses inherit NEMO_FLOW_GATEWAY_URL and forward
 # events to the in-proc gateway via `nemo-flow hook-forward hermes`.
+#
+# OTEL_BSP_* force the OpenInference BatchSpanProcessor to flush every span
+# immediately (single-span POSTs to Phoenix) instead of batching for 5s. See
+# the matching block in the non-root path above for full rationale.
 HERMES_HOME="${HERMES_WRITABLE}" \
   HTTPS_PROXY="${_PROXY_URL}" \
   HTTP_PROXY="${_PROXY_URL}" \
@@ -656,6 +673,9 @@ HERMES_HOME="${HERMES_WRITABLE}" \
   http_proxy="${_PROXY_URL}" \
   PYTHONPATH="${PATCHES_DIR}${PYTHONPATH:+:${PYTHONPATH}}" \
   API_SERVER_KEY="nemoclaw-internal" \
+  OTEL_BSP_MAX_EXPORT_BATCH_SIZE=1 \
+  OTEL_BSP_SCHEDULE_DELAY=100 \
+  OTEL_BSP_EXPORT_TIMEOUT=2000 \
   nohup gosu gateway /usr/local/bin/nemo-flow hermes -- gateway run \
     >>/tmp/gateway.log 2>&1 &
 GATEWAY_PID=$!

--- a/examples/personal-community-sentiment-triage/policy.yaml
+++ b/examples/personal-community-sentiment-triage/policy.yaml
@@ -129,6 +129,7 @@ network_policies:
           method: POST
           path: /**
     binaries:
+    - path: /usr/local/bin/nemo-flow
     - path: /usr/bin/python3
     - path: /usr/bin/python3.13
     - path: /opt/hermes/.venv/bin/python


### PR DESCRIPTION
## Summary

End-to-end NeMo-Flow observability for Hermes. Per-turn ATIF trajectory files at `/tmp/atif/*.json` plus Phoenix LLM spans carrying the real prompt + completion, paired tool spans (no orphans), and per-turn agent root spans.

## Architecture

`nemo-flow hermes -- gateway run` wraps Hermes: the Rust gateway binds an ephemeral loopback port, exports `NEMO_FLOW_GATEWAY_URL` into Hermes's env, spawns `hermes gateway run` as its child. Two event paths feed the gateway:

- **Shell hooks** (`generate-config.ts`): `on_session_*`, `pre/post_llm_call`, `subagent_stop` via `nemo-flow hook-forward hermes`.
- **In-process plugin** (`plugins/nemo-flow/`): `pre/post_api_request` + `pre/post_tool_call` — forwards the rich kwargs (full request messages, response SDK object, stable tool_call_ids) that the shell path strips.

`nemo-flow-finalize-shim` runs as a second `on_session_end` command to synthesize a per-turn `on_session_finalize` (Hermes's native finalize only fires on idle expiry). Gateway dispatches to ATIF (always-on) and OpenInference (gated by `PHOENIX_COLLECTOR_ENDPOINT`).

## Sandbox workarounds

Four non-obvious places where the OpenShell L7 proxy and OpenTelemetry batching break observability. Diagnosed empirically — keep these in mind if anything regresses.

1. **BSP batching silently dropped by L7 proxy.** Default OTel batches (5s / 512 spans) get 200-acked by the proxy but not forwarded. Single-span POSTs land. → `OTEL_BSP_MAX_EXPORT_BATCH_SIZE=1 / SCHEDULE_DELAY=100 / EXPORT_TIMEOUT=2000` (`_export_otel_bsp_tunings()` helper in `start.sh`).
2. **Asymmetric `tool_call_id` between pre and post.** Hermes fires `pre_tool_call` with empty id, `post_tool_call` with the real one. NeMo-Flow's adapter synthesizes a fresh UUID per call → 2 unpaired spans per invocation (one carries `{"status":"closed_by_agent_end"}`). → Plugin synthesizes stable IDs from `SHA1(task_id, tool_name, args)` and pairs pre/post via a bounded `deque(maxlen=512)` FIFO.
3. **L7 proxy fail-closed scan rejects OTLP bodies containing `openshell:resolve:env:`.** SOUL.md taught the model that pattern by literal example → it rode in every LLM request's system prompt → OTLP egress carrying it got rejected, silently losing all LLM spans. → SOUL.md "Credential placeholders" section rewritten to teach the rule (recognize structured placeholders, use verbatim, don't refuse/parse/echo) without printing the trigger string.
4. **Phoenix `input.value` was a lossy `"Requested tools: …"` summary.** OpenInference's display fn finds messages via `content.get("messages")`. Sending the body as a bare list missed that path; the fallback picked up tool-role messages' `name` field. → Plugin wraps as `{"messages":[...], "model":..., "max_tokens":...}` per NeMo-Flow's documented `LlmRequest.content` shape. Phoenix now shows `system: … \n\n user: <prompt> \n\n assistant: …`.

## Plumbing

- **Hermes v0.11.0 → v0.14.0** for rich-kwargs hooks (`request_messages`, `assistant_message`, response SDK object). uv-tarball install with SHA256 verification.
- **NeMo-Flow CLI 0.2.0** built from `nemo-flow-cli` in the existing builder stage.
- **Layout**: plugins under `agents/hermes/plugins/{nemoclaw,nemo-flow}/`; non-plugin gateway assets under `agents/hermes/nemo-flow/{finalize-shim,plugins.toml.in}`.
- **`policy.yaml`**: `phoenix_collector` egress for `/usr/local/bin/nemo-flow`.
- **`nemoclaw_patches.py`** trimmed to the Slack catch-all slash-command handler; observability monkey-patches obsoleted by NeMo-Flow.
- **`PHOENIX_COLLECTOR_ENDPOINT`** consumed verbatim (no `/v1/traces` auto-append) — matches `.env.example` and README.

## Test plan

- [ ] `bash scripts/tear-down.sh && bash scripts/bring-up.sh` builds clean
- [ ] `pgrep -af nemo-flow` shows the gateway with Hermes as its child
- [ ] `ls /sandbox/.hermes-data/plugins/` shows `nemoclaw/` and `nemo-flow/`
- [ ] Drive a Slack DM that uses a tool. In Phoenix: LLM spans with full prompt in `input.value`; one TOOL span per invocation; agent root closes per turn
- [ ] `/tmp/atif/nemo-flow-atif-*.json` lands per turn with full `messages` array
- [ ] Phoenix logs show `POST /v1/traces 200 OK` per span
- [ ] Unset `PHOENIX_COLLECTOR_ENDPOINT`, rebuild → ATIF still works, no Phoenix export