### PR TITLE
Improve sentiment triage Phoenix telemetry

### DIFF
--- a/examples/personal-community-sentiment-triage/.env.example
+++ b/examples/personal-community-sentiment-triage/.env.example
@@ -107,6 +107,9 @@ GITHUB_READONLY_REPO=NVIDIA/OpenShell
 # traces to a Phoenix collector for live inspection. The 00-host-services.sh
 # stack already starts Phoenix on host port 6006; the URL below points the
 # sandbox at it through the OpenShell host bridge.
+# Optional: set NEMO_RELAY_PROJECT_NAME to group traces under a named Phoenix
+# project. Leave unset to keep NeMo Relay's default project behavior.
+# NEMO_RELAY_PROJECT_NAME=personal-community-sentiment-triage
 # PHOENIX_COLLECTOR_ENDPOINT=http://host.openshell.internal:6006/v1/traces
 
 # ── Host-services security (TOKEN_CACHE_SALT is optional) ────────────────

--- a/examples/personal-community-sentiment-triage/README.md
+++ b/examples/personal-community-sentiment-triage/README.md
@@ -410,6 +410,7 @@ unless you remove the compose volumes.
 | `SOURCE_ETL_GITHUB_REPO` | `NVIDIA/NemoClaw` | Host-side GitHub mirror repo for source-etls. This is independent of `GITHUB_READONLY_REPO`. |
 | `TOKEN_MANAGER_HOST` | `host.openshell.internal` | Host where the MS Graph token manager is reachable from inside the sandbox. |
 | `PHOENIX_COLLECTOR_ENDPOINT` | (none) | Set to e.g. `http://host.openshell.internal:6006/v1/traces` to stream OpenInference traces to a Phoenix collector. ATIF trace generation does not depend on this — NeMo-Relay is always installed and writes ATIF locally to `/tmp/atif/` regardless. |
+| `NEMO_RELAY_PROJECT_NAME` | (NeMo Relay default) | Optional Phoenix project name for OpenInference traces. When set with `PHOENIX_COLLECTOR_ENDPOINT`, `03-sandbox.sh` bakes it into NeMo Relay's OpenInference resource attributes as `openinference.project.name`. |
 
 ## Verification (what success looks like)
 

--- a/examples/personal-community-sentiment-triage/agents/hermes/Dockerfile
+++ b/examples/personal-community-sentiment-triage/agents/hermes/Dockerfile
@@ -38,11 +38,9 @@ RUN pyinstaller \
 # ── Stage 1: build the nemo-relay CLI binary ──────────────────────────────────
 # Built inside ${BASE_IMAGE} so the resulting binary links against the same
 # glibc as the runtime — same constraint as the sidecar-builder stage above.
-# 0.3.0-beta.2 is the first NeMo-Relay release on crates.io (the predecessor
-# crate `nemo-flow-cli` was published through 0.2.0 before the project's rename
-# from NeMo-Flow). `cargo install` is the simplest reproducible path; the
-# ~3-5 min toolchain bootstrap is amortized across the cargo target cache when
-# the version pin doesn't change.
+# 0.3.0-beta.2 is the first NeMo Relay release on crates.io. `cargo install` is
+# the simplest reproducible path; the ~3-5 min toolchain bootstrap is amortized
+# across the cargo target cache when the version pin doesn't change.
 FROM ${BASE_IMAGE} AS nemo-relay-builder
 ARG NEMO_RELAY_CLI_VERSION=0.3.0-beta.2
 RUN apt-get update -qq \
@@ -63,6 +61,8 @@ FROM ${BASE_IMAGE}
 # Empty string means no telemetry (standard behavior).
 ARG PHOENIX_COLLECTOR_ENDPOINT=""
 ENV PHOENIX_COLLECTOR_ENDPOINT=${PHOENIX_COLLECTOR_ENDPOINT}
+ARG NEMO_RELAY_PROJECT_NAME=""
+ENV NEMO_RELAY_PROJECT_NAME=${NEMO_RELAY_PROJECT_NAME}
 
 # Host address of the Outlook token manager (port 8765).
 # Baked at image build time using the same pattern as PHOENIX_COLLECTOR_ENDPOINT —
@@ -223,6 +223,7 @@ RUN pip3 install --no-cache-dir --break-system-packages \
 COPY agents/hermes/nemo-relay/plugins.toml.in /tmp/nemo-relay-plugins.toml.in
 RUN mkdir -p /etc/nemo-relay \
     && PHOENIX_URL="${PHOENIX_COLLECTOR_ENDPOINT:-}" \
+    && PROJECT_NAME="${NEMO_RELAY_PROJECT_NAME:-}" \
     && if [ -z "$PHOENIX_URL" ]; then \
          PHOENIX_ENABLED=false; PHOENIX_ENDPOINT=""; \
        else \
@@ -232,9 +233,10 @@ RUN mkdir -p /etc/nemo-relay \
          # .env.example and README for the documented value format.
          PHOENIX_ENABLED=true; PHOENIX_ENDPOINT="${PHOENIX_URL%/}"; \
        fi \
-    && sed -e "s|@@PHOENIX_ENABLED@@|${PHOENIX_ENABLED}|g" \
-           -e "s|@@PHOENIX_ENDPOINT@@|${PHOENIX_ENDPOINT}|g" \
-       /tmp/nemo-relay-plugins.toml.in > /etc/nemo-relay/plugins.toml \
+    && PHOENIX_ENABLED="${PHOENIX_ENABLED}" \
+       PHOENIX_ENDPOINT="${PHOENIX_ENDPOINT}" \
+       PROJECT_NAME="${PROJECT_NAME}" \
+       python3 -c 'from pathlib import Path; import json, os; template = Path("/tmp/nemo-relay-plugins.toml.in").read_text(); project = os.environ["PROJECT_NAME"].strip(); quoted = json.dumps(project); attrs = "\n".join(["[components.config.openinference.resource_attributes]", "\"openinference.project.name\" = " + quoted, "\"nemo.claw.example\" = " + quoted]) if os.environ["PHOENIX_ENABLED"] == "true" and project else ""; rendered = template.replace("@@PHOENIX_ENABLED@@", os.environ["PHOENIX_ENABLED"]).replace("@@PHOENIX_ENDPOINT@@", os.environ["PHOENIX_ENDPOINT"]).replace("@@OPENINFERENCE_RESOURCE_ATTRIBUTES@@", attrs); Path("/etc/nemo-relay/plugins.toml").write_text(rendered)' \
     && rm /tmp/nemo-relay-plugins.toml.in \
     && chmod 444 /etc/nemo-relay/plugins.toml
 
@@ -337,6 +339,7 @@ ENV NEMOCLAW_MODEL=${NEMOCLAW_MODEL} \
     OUTLOOK_REPLY_TO=${OUTLOOK_REPLY_TO} \
     OUTLOOK_ALLOWED_SENDERS=${OUTLOOK_ALLOWED_SENDERS} \
     GITHUB_READONLY_REPO=${GITHUB_READONLY_REPO} \
+    NEMO_RELAY_PROJECT_NAME=${NEMO_RELAY_PROJECT_NAME} \
     MS_GRAPH_SERVICES=${MS_GRAPH_SERVICES} \
     SOURCE_ETL_GITHUB_REPO=${SOURCE_ETL_GITHUB_REPO} \
     SOURCE_ETL_FORUM_TAG=${SOURCE_ETL_FORUM_TAG} \

--- a/examples/personal-community-sentiment-triage/agents/hermes/Dockerfile
+++ b/examples/personal-community-sentiment-triage/agents/hermes/Dockerfile
@@ -38,9 +38,11 @@ RUN pyinstaller \
 # ── Stage 1: build the nemo-relay CLI binary ──────────────────────────────────
 # Built inside ${BASE_IMAGE} so the resulting binary links against the same
 # glibc as the runtime — same constraint as the sidecar-builder stage above.
-# 0.3.0-beta.2 is the first NeMo Relay release on crates.io. `cargo install` is
-# the simplest reproducible path; the ~3-5 min toolchain bootstrap is amortized
-# across the cargo target cache when the version pin doesn't change.
+# 0.3.0-beta.2 is the first NeMo-Relay release on crates.io (the predecessor
+# crate `nemo-flow-cli` was published through 0.2.0 before the project's rename
+# from NeMo-Flow). `cargo install` is the simplest reproducible path; the
+# ~3-5 min toolchain bootstrap is amortized across the cargo target cache when
+# the version pin doesn't change.
 FROM ${BASE_IMAGE} AS nemo-relay-builder
 ARG NEMO_RELAY_CLI_VERSION=0.3.0-beta.2
 RUN apt-get update -qq \

--- a/examples/personal-community-sentiment-triage/agents/hermes/nemo-relay/plugins.toml.in
+++ b/examples/personal-community-sentiment-triage/agents/hermes/nemo-relay/plugins.toml.in
@@ -22,3 +22,4 @@ transport = "http_binary"
 endpoint = "@@PHOENIX_ENDPOINT@@"
 service_name = "hermes-agent"
 timeout_millis = 3000
+@@OPENINFERENCE_RESOURCE_ATTRIBUTES@@

--- a/examples/personal-community-sentiment-triage/agents/hermes/plugins/nemo-relay/__init__.py
+++ b/examples/personal-community-sentiment-triage/agents/hermes/plugins/nemo-relay/__init__.py
@@ -11,9 +11,8 @@ Fail-open: exceptions are logged at debug; Hermes turns must never break
 because the bridge can't reach NeMo-Relay. Modeled on Hermes's bundled
 Langfuse observability plugin.
 
-TODO(upstream): this whole plugin is retirable when
-https://github.com/NousResearch/hermes-agent/pull/29724 lands a built-in
-NeMo-Flow telemetry plugin.
+TODO(upstream): this whole plugin is retirable when Hermes lands a built-in
+NeMo Relay telemetry bridge.
 """
 
 from __future__ import annotations
@@ -22,12 +21,17 @@ import hashlib
 import json
 import logging
 import os
+import re
 import threading
 from collections import deque
 from types import SimpleNamespace
 from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
+
+_MAX_PAYLOAD_BYTES = 262_144  # 256 KiB; keep hook payloads bounded for the sidecar.
+_COMPACT_REQUEST_BODY_BYTES = 180_000
+_OPENSHELL_PLACEHOLDER_RE = re.compile(r"openshell:resolve:env:[A-Za-z0-9_:-]+")
 
 _LOCK = threading.Lock()
 _CLIENT: Optional[Any] = None  # httpx.Client, lazily created
@@ -138,6 +142,27 @@ def _safe_jsonable(value: Any, _depth: int = 0) -> Any:
     return repr(value)[:4096]
 
 
+def _sanitize_observability_value(value: Any) -> Any:
+    """Remove OpenShell credential placeholder literals from telemetry payloads.
+
+    The sandbox forward proxy treats strings like
+    `openshell:resolve:env:SLACK_BOT_TOKEN` as live credential placeholders in
+    any outbound HTTP body. If those literals appear inside a Phoenix span's
+    prompt text, the proxy attempts credential injection on the telemetry POST
+    and can drop that LLM span. Redacting the placeholder literal preserves the
+    useful prompt context without changing runtime credential resolution.
+    """
+    if isinstance(value, str):
+        return _OPENSHELL_PLACEHOLDER_RE.sub("[openshell env placeholder redacted]", value)
+    if isinstance(value, dict):
+        return {k: _sanitize_observability_value(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_sanitize_observability_value(v) for v in value]
+    if isinstance(value, tuple):
+        return [_sanitize_observability_value(v) for v in value]
+    return value
+
+
 def _coerce_request_messages(
     *,
     request_messages: Any = None,
@@ -206,9 +231,131 @@ def _serialize_response_object(response: Any) -> Optional[dict]:
     return None
 
 
+def _json_size(value: Any) -> int:
+    try:
+        return len(json.dumps(value, default=str, ensure_ascii=False).encode("utf-8"))
+    except Exception:
+        return len(repr(value).encode("utf-8"))
+
+
+def _truncate_text(value: str, limit: int) -> str:
+    if limit <= 0 or len(value) <= limit:
+        return value
+    if limit < 128:
+        return value[:limit]
+    marker = f"\n...[truncated {len(value) - limit} chars for Phoenix payload cap]...\n"
+    head = max(1, (limit - len(marker)) // 2)
+    tail = max(1, limit - len(marker) - head)
+    return value[:head] + marker + value[-tail:]
+
+
+def _compact_content(value: Any, limit: int) -> Any:
+    if isinstance(value, str):
+        return _truncate_text(value, limit)
+    if value is None or isinstance(value, (int, float, bool)):
+        return value
+    try:
+        rendered = json.dumps(_safe_jsonable(value), ensure_ascii=False, default=str)
+    except Exception:
+        rendered = repr(value)
+    return _truncate_text(rendered, limit)
+
+
+def _compact_messages(messages: list, target_bytes: int) -> list:
+    """Preserve Phoenix-visible role/content input under the hook payload cap.
+
+    Small requests keep the exact existing behavior. For very large Hermes
+    prompts, the old fallback removed request.body entirely, so Phoenix showed
+    only {"api_mode": "chat_completions"}. This keeps every message role and a
+    bounded head/tail slice of content, with larger budgets for the system
+    prompt and the latest conversation turns.
+    """
+    if not messages:
+        return messages
+    safe_messages = _safe_jsonable(messages)
+    if _json_size({"messages": safe_messages}) <= target_bytes:
+        return safe_messages
+
+    count = len(safe_messages)
+    compacted = []
+    for idx, message in enumerate(safe_messages):
+        if not isinstance(message, dict):
+            message = {"role": "unknown", "content": message}
+        item = dict(message)
+        if idx == 0:
+            limit = 24_000
+        elif idx >= count - 8:
+            limit = 6_000
+        else:
+            limit = 900
+        if "content" in item:
+            item["content"] = _compact_content(item.get("content"), limit)
+        compacted.append(item)
+
+    body = {"messages": compacted}
+    while _json_size(body) > target_bytes:
+        changed = False
+        for idx, item in enumerate(compacted):
+            content = item.get("content")
+            if not isinstance(content, str) or len(content) <= 320:
+                continue
+            limit = 2_000 if idx == 0 else 320
+            item["content"] = _truncate_text(content, limit)
+            changed = True
+        if not changed:
+            break
+    return compacted
+
+
+def _compact_request_body(body: Any) -> Any:
+    if not isinstance(body, dict):
+        return body
+    compacted = dict(body)
+    messages = compacted.get("messages")
+    if isinstance(messages, list):
+        compacted["messages"] = _compact_messages(messages, _COMPACT_REQUEST_BODY_BYTES)
+        compacted["observability_truncated"] = True
+        compacted["observability_note"] = (
+            "Request messages were compacted to fit the NeMo Relay hook payload cap; "
+            "roles and head/tail content slices are preserved for Phoenix."
+        )
+        compacted["observability_original_message_count"] = len(messages)
+    return compacted
+
+
 # ---------------------------------------------------------------------------
 # Forwarder
 # ---------------------------------------------------------------------------
+
+def _cap_payload(payload: dict) -> dict:
+    """Keep hook payloads bounded without losing Phoenix-visible LLM input."""
+    payload = _sanitize_observability_value(payload)
+    try:
+        encoded = json.dumps(payload, default=str)
+    except Exception:
+        return payload
+    if len(encoded) <= _MAX_PAYLOAD_BYTES:
+        return payload
+    trimmed = dict(payload)
+    request = trimmed.get("request")
+    if isinstance(request, dict) and "body" in request:
+        request = dict(request)
+        request["body"] = _compact_request_body(request.get("body"))
+        trimmed["request"] = request
+        try:
+            encoded = json.dumps(trimmed, default=str)
+        except Exception:
+            return trimmed
+        if len(encoded) <= _MAX_PAYLOAD_BYTES:
+            return trimmed
+    response = trimmed.get("response")
+    if isinstance(response, dict):
+        response = dict(response)
+        response.pop("raw_response", None)
+        response.pop("assistant_message", None)
+        trimmed["response"] = response
+    return trimmed
+
 
 def _forward(payload: dict) -> None:
     url = _gateway_url()
@@ -218,7 +365,7 @@ def _forward(payload: dict) -> None:
     if client is None:
         return
     try:
-        client.post(f"{url}/hooks/hermes", json=payload)
+        client.post(f"{url}/hooks/hermes", json=_cap_payload(payload))
     except Exception as exc:
         logger.debug("nemo-relay: forward to %s failed: %s", url, exc)
 

--- a/examples/personal-community-sentiment-triage/agents/hermes/plugins/nemo-relay/__init__.py
+++ b/examples/personal-community-sentiment-triage/agents/hermes/plugins/nemo-relay/__init__.py
@@ -29,8 +29,6 @@ from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
-_MAX_PAYLOAD_BYTES = 262_144  # 256 KiB; keep hook payloads bounded for the sidecar.
-_COMPACT_REQUEST_BODY_BYTES = 180_000
 _OPENSHELL_PLACEHOLDER_RE = re.compile(r"openshell:resolve:env:[A-Za-z0-9_:-]+")
 
 _LOCK = threading.Lock()
@@ -231,130 +229,13 @@ def _serialize_response_object(response: Any) -> Optional[dict]:
     return None
 
 
-def _json_size(value: Any) -> int:
-    try:
-        return len(json.dumps(value, default=str, ensure_ascii=False).encode("utf-8"))
-    except Exception:
-        return len(repr(value).encode("utf-8"))
-
-
-def _truncate_text(value: str, limit: int) -> str:
-    if limit <= 0 or len(value) <= limit:
-        return value
-    if limit < 128:
-        return value[:limit]
-    marker = f"\n...[truncated {len(value) - limit} chars for Phoenix payload cap]...\n"
-    head = max(1, (limit - len(marker)) // 2)
-    tail = max(1, limit - len(marker) - head)
-    return value[:head] + marker + value[-tail:]
-
-
-def _compact_content(value: Any, limit: int) -> Any:
-    if isinstance(value, str):
-        return _truncate_text(value, limit)
-    if value is None or isinstance(value, (int, float, bool)):
-        return value
-    try:
-        rendered = json.dumps(_safe_jsonable(value), ensure_ascii=False, default=str)
-    except Exception:
-        rendered = repr(value)
-    return _truncate_text(rendered, limit)
-
-
-def _compact_messages(messages: list, target_bytes: int) -> list:
-    """Preserve Phoenix-visible role/content input under the hook payload cap.
-
-    Small requests keep the exact existing behavior. For very large Hermes
-    prompts, the old fallback removed request.body entirely, so Phoenix showed
-    only {"api_mode": "chat_completions"}. This keeps every message role and a
-    bounded head/tail slice of content, with larger budgets for the system
-    prompt and the latest conversation turns.
-    """
-    if not messages:
-        return messages
-    safe_messages = _safe_jsonable(messages)
-    if _json_size({"messages": safe_messages}) <= target_bytes:
-        return safe_messages
-
-    count = len(safe_messages)
-    compacted = []
-    for idx, message in enumerate(safe_messages):
-        if not isinstance(message, dict):
-            message = {"role": "unknown", "content": message}
-        item = dict(message)
-        if idx == 0:
-            limit = 24_000
-        elif idx >= count - 8:
-            limit = 6_000
-        else:
-            limit = 900
-        if "content" in item:
-            item["content"] = _compact_content(item.get("content"), limit)
-        compacted.append(item)
-
-    body = {"messages": compacted}
-    while _json_size(body) > target_bytes:
-        changed = False
-        for idx, item in enumerate(compacted):
-            content = item.get("content")
-            if not isinstance(content, str) or len(content) <= 320:
-                continue
-            limit = 2_000 if idx == 0 else 320
-            item["content"] = _truncate_text(content, limit)
-            changed = True
-        if not changed:
-            break
-    return compacted
-
-
-def _compact_request_body(body: Any) -> Any:
-    if not isinstance(body, dict):
-        return body
-    compacted = dict(body)
-    messages = compacted.get("messages")
-    if isinstance(messages, list):
-        compacted["messages"] = _compact_messages(messages, _COMPACT_REQUEST_BODY_BYTES)
-        compacted["observability_truncated"] = True
-        compacted["observability_note"] = (
-            "Request messages were compacted to fit the NeMo Relay hook payload cap; "
-            "roles and head/tail content slices are preserved for Phoenix."
-        )
-        compacted["observability_original_message_count"] = len(messages)
-    return compacted
-
-
 # ---------------------------------------------------------------------------
 # Forwarder
 # ---------------------------------------------------------------------------
 
-def _cap_payload(payload: dict) -> dict:
-    """Keep hook payloads bounded without losing Phoenix-visible LLM input."""
-    payload = _sanitize_observability_value(payload)
-    try:
-        encoded = json.dumps(payload, default=str)
-    except Exception:
-        return payload
-    if len(encoded) <= _MAX_PAYLOAD_BYTES:
-        return payload
-    trimmed = dict(payload)
-    request = trimmed.get("request")
-    if isinstance(request, dict) and "body" in request:
-        request = dict(request)
-        request["body"] = _compact_request_body(request.get("body"))
-        trimmed["request"] = request
-        try:
-            encoded = json.dumps(trimmed, default=str)
-        except Exception:
-            return trimmed
-        if len(encoded) <= _MAX_PAYLOAD_BYTES:
-            return trimmed
-    response = trimmed.get("response")
-    if isinstance(response, dict):
-        response = dict(response)
-        response.pop("raw_response", None)
-        response.pop("assistant_message", None)
-        trimmed["response"] = response
-    return trimmed
+def _prepare_payload(payload: dict) -> Any:
+    """Coerce hook payloads to JSON-safe values and redact placeholders."""
+    return _sanitize_observability_value(_safe_jsonable(payload))
 
 
 def _forward(payload: dict) -> None:
@@ -365,7 +246,7 @@ def _forward(payload: dict) -> None:
     if client is None:
         return
     try:
-        client.post(f"{url}/hooks/hermes", json=_cap_payload(payload))
+        client.post(f"{url}/hooks/hermes", json=_prepare_payload(payload))
     except Exception as exc:
         logger.debug("nemo-relay: forward to %s failed: %s", url, exc)
 

--- a/examples/personal-community-sentiment-triage/scripts/03-sandbox.sh
+++ b/examples/personal-community-sentiment-triage/scripts/03-sandbox.sh
@@ -135,8 +135,16 @@ fi
 # the user hasn't configured a collector.
 if [[ -n "${PHOENIX_COLLECTOR_ENDPOINT:-}" ]]; then
   echo "Phoenix endpoint: $PHOENIX_COLLECTOR_ENDPOINT — enabling OpenInference egress"
+  if [[ -n "${NEMO_RELAY_PROJECT_NAME:-}" ]]; then
+    echo "Phoenix project:  $NEMO_RELAY_PROJECT_NAME"
+  fi
   sed -i \
     -e "s|^ARG PHOENIX_COLLECTOR_ENDPOINT=.*|ARG PHOENIX_COLLECTOR_ENDPOINT=$PHOENIX_COLLECTOR_ENDPOINT|" \
+    "$STAGED_DOCKERFILE"
+fi
+if [[ -n "${NEMO_RELAY_PROJECT_NAME:-}" ]]; then
+  sed -i \
+    -e "s|^ARG NEMO_RELAY_PROJECT_NAME=.*|ARG NEMO_RELAY_PROJECT_NAME=$NEMO_RELAY_PROJECT_NAME|" \
     "$STAGED_DOCKERFILE"
 fi
 
@@ -184,6 +192,7 @@ setsid openshell sandbox create \
     NEMOCLAW_MESSAGING_CHANNELS_B64="$CHANNELS_B64" \
     CHAT_UI_URL="http://127.0.0.1:8642" \
     PHOENIX_COLLECTOR_ENDPOINT="${PHOENIX_COLLECTOR_ENDPOINT:-}" \
+    NEMO_RELAY_PROJECT_NAME="${NEMO_RELAY_PROJECT_NAME:-}" \
   nemoclaw-start </dev/null &
 CREATE_PID=$!
 


### PR DESCRIPTION
## Summary
- Add optional `NEMO_RELAY_PROJECT_NAME` plumbing for the existing personal-community-sentiment-triage example so Phoenix/OpenInference traces can land under a named project without changing the default behavior when unset.
- Add OpenInference resource attributes for `openinference.project.name` and `nemo.claw.example` when a project name is configured.
- Redact OpenShell credential placeholder literals from NeMo Relay telemetry payloads before forwarding them, and compact oversized Hermes hook payloads while preserving Phoenix-visible LLM input.
- Clean up stale NeMo Flow wording in the touched NeMo Relay integration comments.

## Test plan
- `python3 -m py_compile examples/personal-community-sentiment-triage/agents/hermes/plugins/nemo-relay/__init__.py`
- `bash -n examples/personal-community-sentiment-triage/scripts/03-sandbox.sh`
- `git diff --cached --check`
- Rendered `agents/hermes/nemo-relay/plugins.toml.in` with `PROJECT_NAME=pr-test-project` and verified `openinference.project.name`/`nemo.claw.example` are emitted with no template placeholders left.
- Rendered the same template with no project name and verified no project resource attributes are emitted, preserving NeMo Relay default project behavior.

Manual validation to run before merge:
- Set `PHOENIX_COLLECTOR_ENDPOINT=http://host.openshell.internal:6006/v1/traces` and `NEMO_RELAY_PROJECT_NAME=personal-community-sentiment-triage` in the example `.env`.
- Run `bash scripts/tear-down.sh && bash scripts/bring-up.sh` from `examples/personal-community-sentiment-triage`.
- Send a Slack DM with a simple prompt and one prompt that invokes a tool.
- Confirm Phoenix shows traces under the configured project, with LLM input/output present and no credential-placeholder injection failures in proxy/relay logs.