### PR TITLE
Add configurable Phoenix project name for trace routing

### DIFF
--- a/examples/personal-community-sentiment-triage/.env.example
+++ b/examples/personal-community-sentiment-triage/.env.example
@@ -109,6 +109,12 @@ GITHUB_READONLY_REPO=NVIDIA/OpenShell
 # sandbox at it through the OpenShell host bridge.
 # PHOENIX_COLLECTOR_ENDPOINT=http://host.openshell.internal:6006/v1/traces
 
+# Phoenix project name. Sets openinference.project.name on every exported
+# span so Phoenix routes traces to a named project (vs. falling back to
+# service.name). Defaults to "community-sentiment-triage" if unset; override
+# to keep multiple deployments separate in the same Phoenix instance.
+# PHOENIX_PROJECT_NAME=personal-community-sentiment-triage
+
 # ── Host-services security (TOKEN_CACHE_SALT is optional) ────────────────
 # Salt for encrypting the MS Graph token manager's MSAL session cache.
 # The compose default (in extras/docker-compose.yml) is shared across

--- a/examples/personal-community-sentiment-triage/README.md
+++ b/examples/personal-community-sentiment-triage/README.md
@@ -410,6 +410,7 @@ unless you remove the compose volumes.
 | `SOURCE_ETL_GITHUB_REPO` | `NVIDIA/NemoClaw` | Host-side GitHub mirror repo for source-etls. This is independent of `GITHUB_READONLY_REPO`. |
 | `TOKEN_MANAGER_HOST` | `host.openshell.internal` | Host where the MS Graph token manager is reachable from inside the sandbox. |
 | `PHOENIX_COLLECTOR_ENDPOINT` | (none) | Set to e.g. `http://host.openshell.internal:6006/v1/traces` to stream OpenInference traces to a Phoenix collector. ATIF trace generation does not depend on this — NeMo-Relay is always installed and writes ATIF locally to `/tmp/atif/` regardless. |
+| `PHOENIX_PROJECT_NAME` | `default` | Sets `openinference.project.name` on every exported span so Phoenix routes traces to a named project. Override per-build to keep multiple deployments separate in the same Phoenix instance. |
 
 ## Verification (what success looks like)
 

--- a/examples/personal-community-sentiment-triage/agents/hermes/Dockerfile
+++ b/examples/personal-community-sentiment-triage/agents/hermes/Dockerfile
@@ -64,6 +64,13 @@ FROM ${BASE_IMAGE}
 ARG PHOENIX_COLLECTOR_ENDPOINT=""
 ENV PHOENIX_COLLECTOR_ENDPOINT=${PHOENIX_COLLECTOR_ENDPOINT}
 
+# Phoenix project name — sets openinference.project.name on every exported
+# span via plugins.toml's resource_attributes. Default routes traces under
+# this example's name; override per-build to keep multiple deployments
+# separate in the same Phoenix instance.
+ARG PHOENIX_PROJECT_NAME="default"
+ENV PHOENIX_PROJECT_NAME=${PHOENIX_PROJECT_NAME}
+
 # Host address of the Outlook token manager (port 8765).
 # Baked at image build time using the same pattern as PHOENIX_COLLECTOR_ENDPOINT —
 # start.sh reads it as a real env var so the sidecar can open a TCP connection
@@ -234,6 +241,7 @@ RUN mkdir -p /etc/nemo-relay \
        fi \
     && sed -e "s|@@PHOENIX_ENABLED@@|${PHOENIX_ENABLED}|g" \
            -e "s|@@PHOENIX_ENDPOINT@@|${PHOENIX_ENDPOINT}|g" \
+           -e "s|@@PHOENIX_PROJECT_NAME@@|${PHOENIX_PROJECT_NAME}|g" \
        /tmp/nemo-relay-plugins.toml.in > /etc/nemo-relay/plugins.toml \
     && rm /tmp/nemo-relay-plugins.toml.in \
     && chmod 444 /etc/nemo-relay/plugins.toml

--- a/examples/personal-community-sentiment-triage/agents/hermes/nemo-relay/plugins.toml.in
+++ b/examples/personal-community-sentiment-triage/agents/hermes/nemo-relay/plugins.toml.in
@@ -2,7 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # NeMo-Relay gateway plugin config — installed at /etc/nemo-relay/plugins.toml.
-# Substituted at image build time from PHOENIX_COLLECTOR_ENDPOINT.
+# Tokens substituted at image build time (see Dockerfile):
+#   @@PHOENIX_ENABLED@@        — true if PHOENIX_COLLECTOR_ENDPOINT is set
+#   @@PHOENIX_ENDPOINT@@       — Phoenix OTLP collector URL
+#   @@PHOENIX_PROJECT_NAME@@   — openinference.project.name (Phoenix routing key;
+#                                falls back to service.name when absent)
 # Schema: nemo_relay.observability.ObservabilityConfig
 # (NeMo-Relay python/nemo_relay/observability.py).
 
@@ -22,3 +26,6 @@ transport = "http_binary"
 endpoint = "@@PHOENIX_ENDPOINT@@"
 service_name = "hermes-agent"
 timeout_millis = 3000
+
+[components.config.openinference.resource_attributes]
+"openinference.project.name" = "@@PHOENIX_PROJECT_NAME@@"

--- a/examples/personal-community-sentiment-triage/scripts/03-sandbox.sh
+++ b/examples/personal-community-sentiment-triage/scripts/03-sandbox.sh
@@ -139,6 +139,12 @@ if [[ -n "${PHOENIX_COLLECTOR_ENDPOINT:-}" ]]; then
     -e "s|^ARG PHOENIX_COLLECTOR_ENDPOINT=.*|ARG PHOENIX_COLLECTOR_ENDPOINT=$PHOENIX_COLLECTOR_ENDPOINT|" \
     "$STAGED_DOCKERFILE"
 fi
+if [[ -n "${PHOENIX_PROJECT_NAME:-}" ]]; then
+  echo "Phoenix project: $PHOENIX_PROJECT_NAME"
+  sed -i \
+    -e "s|^ARG PHOENIX_PROJECT_NAME=.*|ARG PHOENIX_PROJECT_NAME=$PHOENIX_PROJECT_NAME|" \
+    "$STAGED_DOCKERFILE"
+fi
 
 # ── Stage policy and patch per-run repo scope ───────────────────────────
 cp "$EXAMPLE_DIR/policy.yaml" "$STAGED_POLICY"


### PR DESCRIPTION
## Summary

Adds `PHOENIX_PROJECT_NAME` as a configurable knob so users running multiple
deployments of this example against the same Phoenix instance can keep their
traces separated under named projects. Without this, every example's spans
fall back to `service.name` (`hermes-agent`) and route to the default bucket.

## How it works

Phoenix routes spans to a named project by reading the `openinference.project.name`
OpenTelemetry resource attribute. NeMo-Relay's `OtlpSectionConfig` exposes a
`resource_attributes` HashMap that attaches verbatim to the OTLP resource —
this PR templates a single entry into that block and plumbs the value through
the existing Dockerfile ARG → ENV → `@@TOKEN@@` sed-substitution pattern used
for `PHOENIX_COLLECTOR_ENDPOINT`.

## Changes (~23 lines across 4 files)

- **`agents/hermes/nemo-relay/plugins.toml.in`**: new
  `[components.config.openinference.resource_attributes]` table with
  `"openinference.project.name" = "@@PHOENIX_PROJECT_NAME@@"`. File header
  comment updated to list all three substitution tokens (was naming only
  `PHOENIX_COLLECTOR_ENDPOINT`).
- **`agents/hermes/Dockerfile`**: new `ARG PHOENIX_PROJECT_NAME="default"` /
  matching `ENV` near the existing `PHOENIX_COLLECTOR_ENDPOINT` block; sed
  expression extended with `-e "s|@@PHOENIX_PROJECT_NAME@@|...|g"`.
- **`.env.example`**: documents the override knob alongside the existing
  Phoenix block.
- **`README.md`**: one row added to the env-vars table.

## Defaults and overrides

- **Default**: `default` — the literal string, which is Phoenix's catch-all
  bucket name. Users who don't override see no behavior change from before
  this PR (traces still arrive; they just nominally land under `default`
  rather than under `service.name`).
- **Override**: set `PHOENIX_PROJECT_NAME=<name>` in `.env`, rebuild the
  sandbox. Useful for multiple-deployment workflows or A/B comparisons.

## Test plan

- [ ] `bash scripts/tear-down.sh && bash scripts/bring-up.sh` builds clean.
- [ ] `openshell sandbox exec --name <sandbox> -- cat /etc/nemo-relay/plugins.toml`
      shows the `[components.config.openinference.resource_attributes]` table
      with the project name substituted.
- [ ] Drive one Hermes turn with `PHOENIX_COLLECTOR_ENDPOINT` set; the
      resulting span appears under the project named `default` (or the
      override) in Phoenix's UI.
- [ ] Set `PHOENIX_PROJECT_NAME=test-override` in `.env`, rebuild, drive one
      turn — Phoenix project becomes `test-override`.
- [ ] Each span's `service.name` attribute still reads `hermes-agent`
      (separate from project routing).