### PR TITLE
fix(hermes-launchable): pin installer to v0.0.55

### DIFF
--- a/examples/hermes-launchable/hermes-brev-launchable.ipynb
+++ b/examples/hermes-launchable/hermes-brev-launchable.ipynb
@@ -82,6 +82,7 @@
         "    \"NEMOCLAW_PROVIDER\": PROVIDER,\n",
         "    \"NEMOCLAW_NON_INTERACTIVE\": \"1\",\n",
         "    \"NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE\": \"1\",\n",
+        "    \"NEMOCLAW_INSTALL_REF\": \"v0.0.55\",\n",
         "    \"NEMOCLAW_YES\": \"1\",\n",
         "    \"NEMOCLAW_NO_EXPRESS\": \"1\",\n",
         "    \"NEMOCLAW_SANDBOX_NAME\": SANDBOX_NAME,\n",


### PR DESCRIPTION
## Summary
Pin the NemoClaw installer to v0.0.55 in `examples/hermes-launchable/hermes-brev-launchable.ipynb` so the launchable installs a known release. Without this, the notebook always pulls whatever \`https://www.nvidia.com/nemoclaw.sh\` serves at deploy time, making behavior non-reproducible between deploys and between users running it minutes apart.

## Changes
- Cell 2 (env-building Python cell): add \`\"NEMOCLAW_INSTALL_REF\": \"v0.0.55\"\` to the \`env\` dict. The installer respects this env var and downloads the matching release tarball instead of latest-tip.

That's the entire diff:

\`\`\`json
+        \"    \\\"NEMOCLAW_INSTALL_REF\\\": \\\"v0.0.55\\\",\\n\",
\`\`\`

## Why
NemoClaw v0.0.55 ships with the dashboard / channel features QA needs to validate (per the slack thread today). Pinning lets QA exercise that exact surface against a stable target. Bump the pin on each release going forward, or move to the daily-build pattern (cf. brevdev/nemoclaw-image on the OpenClaw side) when feasible.

## Test plan
Once merged, deploying the Hermes launchable from brev.nvidia.com should install \`nemoclaw v0.0.55\` (and \`nemohermes v0.0.55\`) regardless of when it's run. Confirm via \`nemohermes --version\` after the install cell. Ashish's endpoint checks on \`127.0.0.1:8642/v1/health\` and \`127.0.0.1:9119/\` will then run against a known build.

cc @rstudio-sl @JR-Morgan