### PR TITLE
fix(hermes-launchable): enable Hermes dashboard by default

### DIFF
--- a/examples/hermes-launchable/hermes-brev-launchable.ipynb
+++ b/examples/hermes-launchable/hermes-brev-launchable.ipynb
@@ -83,6 +83,7 @@
         "    \"NEMOCLAW_NON_INTERACTIVE\": \"1\",\n",
         "    \"NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE\": \"1\",\n",
         "    \"NEMOCLAW_INSTALL_REF\": \"v0.0.55\",\n",
+        "    \"NEMOCLAW_HERMES_DASHBOARD\": \"1\",\n",
         "    \"NEMOCLAW_YES\": \"1\",\n",
         "    \"NEMOCLAW_NO_EXPRESS\": \"1\",\n",
         "    \"NEMOCLAW_SANDBOX_NAME\": SANDBOX_NAME,\n",


### PR DESCRIPTION
## Summary
Add `NEMOCLAW_HERMES_DASHBOARD=1` to the env dict in cell 2 so this launchable starts the Hermes dashboard (port 9119) by default.

## Why
The Brev launchable is the primary "click to try NemoClaw + Hermes" path for users, and the dashboard is the most visible piece of the UX. With the flag unset, onboarding succeeds but port 9119 has no listener, so `curl http://127.0.0.1:9119/` returns nothing and QA cannot validate dashboard functionality without hand-editing the notebook.

Caught during v0.0.55 validation today: sandbox and API came up fine, but the dashboard endpoint had to be enabled by hand to satisfy Ashish's test plan. Sibling launchable improvement to #26.

Users who do not want the dashboard can still disable it by overriding `NEMOCLAW_HERMES_DASHBOARD=0` in their shell env before running cell 2.

## Changes
- Cell 2: add `"NEMOCLAW_HERMES_DASHBOARD": "1",` to the `env` dict.

## Test plan
- Deploy launchable on a Brev CPU instance.
- Run cells 2 → 4 → 6 → 8 unmodified.
- `curl http://127.0.0.1:9119/` returns `HTTP 200` (uvicorn).