### PR TITLE
Add GitHub PR review agent example for macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ docker-compose.override.yaml
 *.bak
 *.orig
 *~
+examples/github-pr-review-agent/.env

--- a/examples/github-pr-review-agent/.env.example
+++ b/examples/github-pr-review-agent/.env.example
@@ -1,0 +1,4 @@
+GITHUB_TOKEN=your_github_token_here
+GITHUB_REPO=owner/repo
+INFERENCE_URL=http://localhost:11434/api/chat
+MODEL=llama3.2

--- a/examples/github-pr-review-agent/README.md
+++ b/examples/github-pr-review-agent/README.md
@@ -1,3 +1,6 @@
+<!--- SPDX-FileCopyrightText: Copyright (c) 2026 munnamihir -->
+<!--- SPDX-License-Identifier: Apache-2.0 -->
+
 # GitHub PR Review Agent
 
 A NemoClaw community example that automatically reviews open GitHub pull requests

--- a/examples/github-pr-review-agent/README.md
+++ b/examples/github-pr-review-agent/README.md
@@ -1,0 +1,99 @@
+# GitHub PR Review Agent
+
+A NemoClaw community example that automatically reviews open GitHub pull requests
+using a local Ollama model — no API keys, no credits, runs entirely on your machine.
+
+Tested on macOS (Apple Silicon, Sonoma 14.x).
+
+## What it does
+
+- Fetches open PRs from a GitHub repo
+- Downloads the unified diff for each PR
+- Sends the diff to a local LLM for review
+- Posts a structured comment back to the PR on GitHub
+
+Inside an OpenShell sandbox, inference routes through `inference.local` to Nemotron
+automatically. For local development, it talks to Ollama instead.
+
+## Prerequisites
+
+- macOS 13+ (Apple Silicon or Intel)
+- Python 3.9+
+- Node.js 22+ (`nvm install 22`)
+- Docker Desktop running
+- OpenShell CLI v0.0.38+
+- Ollama (for local dev without sandbox)
+- A GitHub fine-grained personal access token
+
+## Setup
+
+### 1. Install Ollama
+
+Download from https://ollama.com and install, then pull a model:
+
+    ollama pull llama3.2
+
+### 2. Create a GitHub token
+
+Go to github.com -> Settings -> Developer settings -> Personal access tokens -> Fine-grained tokens
+
+Grant these permissions on your target repo:
+- Pull requests: Read and Write
+- Issues: Read and Write
+
+### 3. Configure environment
+
+    cp .env.example .env
+    # fill in GITHUB_TOKEN and GITHUB_REPO
+
+### 4. Run locally
+
+    # make sure ollama is running
+    ollama serve
+
+    # set env vars and run
+    export GITHUB_TOKEN=your_token
+    export GITHUB_REPO=owner/repo
+    python3 agent.py
+
+### 5. Run inside OpenShell sandbox
+
+    openshell gateway start
+    openshell sandbox create --from nemoclaw
+    openshell sandbox run --policy policy.yaml -- python3 agent.py
+
+Inside the sandbox, inference automatically routes to Nemotron via inference.local.
+No Ollama needed.
+
+## Environment variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| GITHUB_TOKEN | Yes | — | GitHub fine-grained personal access token |
+| GITHUB_REPO | Yes | — | Target repo in owner/repo format |
+| INFERENCE_URL | No | http://localhost:11434/api/chat | Ollama locally, or inference.local in sandbox |
+| MODEL | No | llama3.2 | Any model available in your Ollama install |
+
+## Security
+
+policy.yaml locks the sandbox to two egress targets only:
+- api.github.com:443 — GitHub REST API
+- inference.local:443 — OpenShell routed inference
+
+Nothing else can leave the sandbox. Your GitHub token and repo contents
+stay on your machine.
+
+## Example output
+
+    checking PRs for owner/repo
+
+    PR #1 by @devuser: Add retry logic to payment service
+      got diff, sending to model...
+      posting comment...
+      done
+
+    finished
+
+## Contributing
+
+See the nemoclaw-community contributing guide at ../../CONTRIBUTING.md

--- a/examples/github-pr-review-agent/agent.py
+++ b/examples/github-pr-review-agent/agent.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+# Quick script to auto-review GitHub PRs using a local llama model via Ollama.
+# Runs inside NemoClaw/OpenShell sandbox - only talks to github and inference.local
+#
+# Usage:
+#   export GITHUB_TOKEN=...
+#   export GITHUB_REPO=owner/repo
+#   python3 agent.py
+#
+# For local testing without sandbox, make sure ollama is running first:
+#   ollama serve
+#   ollama pull llama3.2
+
+import os
+import sys
+import json
+import urllib.request
+import urllib.error
+
+GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
+GITHUB_REPO = os.environ.get("GITHUB_REPO")
+
+# inside openshell sandbox this gets overridden to inference.local automatically
+INFERENCE_URL = os.environ.get("INFERENCE_URL", "http://localhost:11434/api/chat")
+MODEL = os.environ.get("MODEL", "llama3.2")
+
+if not GITHUB_TOKEN or not GITHUB_REPO:
+    print("need GITHUB_TOKEN and GITHUB_REPO set")
+    sys.exit(1)
+
+
+def gh(path, method="GET", body=None):
+    # wrapper around github api calls so I don't repeat headers everywhere
+    req = urllib.request.Request(
+        f"https://api.github.com{path}",
+        data=json.dumps(body).encode() if body else None,
+        headers={
+            "Authorization": f"Bearer {GITHUB_TOKEN}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "Content-Type": "application/json",
+            "User-Agent": "pr-review-bot",
+        },
+        method=method,
+    )
+    with urllib.request.urlopen(req) as r:
+        return json.loads(r.read())
+
+
+def get_prs():
+    return gh(f"/repos/{GITHUB_REPO}/pulls?state=open&per_page=10")
+
+
+def get_diff(pr_number):
+    # github needs a different accept header to return raw diff
+    req = urllib.request.Request(
+        f"https://api.github.com/repos/{GITHUB_REPO}/pulls/{pr_number}",
+        headers={
+            "Authorization": f"Bearer {GITHUB_TOKEN}",
+            "Accept": "application/vnd.github.diff",
+            "User-Agent": "pr-review-bot",
+        },
+    )
+    with urllib.request.urlopen(req) as r:
+        return r.read().decode("utf-8", errors="replace")
+
+
+def ask_model(pr_title, diff):
+    # truncate diff so we don't blow up context window
+    truncated = diff[:3000]
+    if len(diff) > 3000:
+        truncated += "\n... (diff truncated)"
+
+    prompt = f"""You are reviewing a pull request as a senior engineer.
+
+PR: {pr_title}
+
+{truncated}
+
+Give a short review covering:
+- what this PR does (1 sentence)
+- what looks good
+- anything you'd change or flag
+- your verdict: APPROVE, REQUEST_CHANGES, or COMMENT
+
+Keep it under 250 words, be direct."""
+
+    req = urllib.request.Request(
+        INFERENCE_URL,
+        data=json.dumps({
+            "model": MODEL,
+            "messages": [{"role": "user", "content": prompt}],
+            "stream": False,
+        }).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req) as r:
+        return json.loads(r.read())["message"]["content"]
+
+
+def post_comment(pr_number, review):
+    gh(
+        f"/repos/{GITHUB_REPO}/issues/{pr_number}/comments",
+        method="POST",
+        body={"body": f"**NemoClaw PR Review Agent**\n\n{review}"},
+    )
+
+
+def main():
+    print(f"checking PRs for {GITHUB_REPO}")
+    prs = get_prs()
+
+    if not prs:
+        print("no open PRs")
+        return
+
+    for pr in prs:
+        num = pr["number"]
+        title = pr["title"]
+        author = pr["user"]["login"]
+        print(f"\nPR #{num} by @{author}: {title}")
+
+        diff = get_diff(num)
+        print("  got diff, sending to model...")
+
+        review = ask_model(title, diff)
+        print("  posting comment...")
+
+        post_comment(num, review)
+        print(f"  done")
+
+    print("\nfinished")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/github-pr-review-agent/agent.py
+++ b/examples/github-pr-review-agent/agent.py
@@ -1,5 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 munnamihir
 # SPDX-License-Identifier: Apache-2.0
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 munnamihir
+# SPDX-License-Identifier: Apache-2.0
 #!/usr/bin/env python3
 # Quick script to auto-review GitHub PRs using a local llama model via Ollama.
 # Runs inside NemoClaw/OpenShell sandbox - only talks to github and inference.local

--- a/examples/github-pr-review-agent/agent.py
+++ b/examples/github-pr-review-agent/agent.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 munnamihir
+# SPDX-License-Identifier: Apache-2.0
 #!/usr/bin/env python3
 # Quick script to auto-review GitHub PRs using a local llama model via Ollama.
 # Runs inside NemoClaw/OpenShell sandbox - only talks to github and inference.local

--- a/examples/github-pr-review-agent/policy.yaml
+++ b/examples/github-pr-review-agent/policy.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 munnamihir
+# SPDX-License-Identifier: Apache-2.0
+
 version: "1"
 name: github-pr-review-agent
 description: Allow agent to access GitHub API only

--- a/examples/github-pr-review-agent/policy.yaml
+++ b/examples/github-pr-review-agent/policy.yaml
@@ -1,0 +1,18 @@
+version: "1"
+name: github-pr-review-agent
+description: Allow agent to access GitHub API only
+
+network:
+  egress:
+    - hostname: api.github.com
+      ports: [443]
+      comment: GitHub REST API for PR reads and comment writes
+    - hostname: inference.local
+      ports: [443]
+      comment: Routed inference endpoint (Nemotron via OpenShell)
+
+filesystem:
+  read:
+    - /workspace
+  write:
+    - /workspace/output


### PR DESCRIPTION
## What this adds:

A new community example: `examples/github-pr-review-agent/`

An agent that automatically reviews open GitHub pull requests using a local Ollama model and posts structured review comments back to GitHub.

## Why it's useful:

- No API keys or credits needed — runs fully local via Ollama
- First Mac-native example in the community repo (tested on Apple Silicon, Sonoma 14.x)
- Inside OpenShell sandbox, inference routes to Nemotron via `inference.local` automatically
- `policy.yaml` locks egress to `api.github.com` and `inference.local` only — nothing else leaves the sandbox

## Files added:

- `agent.py` — main agent logic
- `policy.yaml` — OpenShell network policy
- `.env.example` — environment variable template
- `README.md` — setup and usage guide

## Tested:

- Fetches open PRs from a GitHub repo 
- Downloads unified diff 
- Reviews with local LLM 
- Posts comment back to GitHub 
- OpenShell policy enforced 