### PR TITLE
fix: Phoenix span is missing when telemetry contains OpenShell env placeho...

### DIFF
--- a/examples/personal-community-sentiment-triage/agents/hermes/plugins/nemo-relay/__init__.py
+++ b/examples/personal-community-sentiment-triage/agents/hermes/plugins/nemo-relay/__init__.py
@@ -22,6 +22,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import threading
 from collections import deque
 from types import SimpleNamespace
@@ -207,6 +208,31 @@ def _serialize_response_object(response: Any) -> Optional[dict]:
 
 
 # ---------------------------------------------------------------------------
+# OpenShell placeholder sanitization
+# ---------------------------------------------------------------------------
+
+# NeMo Relay resolves openshell:resolve:env:VARNAME strings at ingest time.
+# If a literal placeholder appears in LLM content or tool output it triggers
+# a failed resolution and the span is silently dropped before reaching
+# Phoenix. Redact any such strings before forwarding.
+_OPENSHELL_RE = re.compile(r"openshell:resolve:[^\s\"'<>\\]*", re.IGNORECASE)
+_OPENSHELL_REDACTED = "<redacted:openshell-placeholder>"
+
+
+def _sanitize(value: Any, _depth: int = 0) -> Any:
+    """Recursively replace openshell:resolve:* placeholders in strings."""
+    if _depth > 12:
+        return value
+    if isinstance(value, str):
+        return _OPENSHELL_RE.sub(_OPENSHELL_REDACTED, value)
+    if isinstance(value, dict):
+        return {k: _sanitize(v, _depth + 1) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_sanitize(v, _depth + 1) for v in value]
+    return value
+
+
+# ---------------------------------------------------------------------------
 # Forwarder
 # ---------------------------------------------------------------------------
 
@@ -218,7 +244,7 @@ def _forward(payload: dict) -> None:
     if client is None:
         return
     try:
-        client.post(f"{url}/hooks/hermes", json=payload)
+        client.post(f"{url}/hooks/hermes", json=_sanitize(payload))
     except Exception as exc:
         logger.debug("nemo-relay: forward to %s failed: %s", url, exc)
 


### PR DESCRIPTION
## Summary

## Root Cause

NeMo Relay resolves strings matching `openshell:resolve:*` at ingest time. When LLM content, tool output, or prompt text contained a literal placeholder-shaped string (e.g. `openshell:resolve:env:FAKE_TOKEN`), the plugin forwarded it unchanged to NeMo Relay via `client.post(..., json=payload)`. NeMo Relay attempted to resolve the placeholder, failed (since the env var doesn't exist), and silently dropped the span — so it never reached Phoenix.

## Change Made

**File:** `examples/personal-community-sentiment-triage/agents/hermes/plugins/nemo-relay/__init__.py`

Added a `_sanitize()` function that recursively walks the payload and replaces any string matching `openshell:resolve:*` with `<redacted:openshell-placeholder>` using a compiled regex. Applied it in `_forward()` before calling `client.post(...)`:

```python
# Before
client.post(f"{url}/hooks/hermes", json=payload)

# After
client.post(f"{url}/hooks/hermes", json=_sanitize(payload))
```

The regex `openshell:resolve:[^\s"'<>\\]*` (case-insensitive) covers all `openshell:resolve:` sub-types, not just `env:`, matching the full placeholder syntax.



## Issue

Fixes #23

**Issue URL:** https://github.com/NVIDIA/nemoclaw-community/issues/23


## Changes

```
.../agents/hermes/plugins/nemo-relay/__init__.py   | 28 +++++++++++++++++++++-
 1 file changed, 27 insertions(+), 1 deletion(-)
```


## Testing


- Agent ran relevant tests during development

- Linting checks passed

- Changes are minimal and focused on the issue


## AI Assistance Disclosure


This pull request was prepared with the assistance of AI coding tools (GitHub Copilot). The change has been read, understood, and is owned by the human contributor submitting it, who will respond to review feedback.
