### PR TITLE
fix(outlook-bridge): use OUTLOOK_REPLY_TO as allowed-senders fallback

### DIFF
--- a/examples/personal-community-sentiment-triage/.env.example
+++ b/examples/personal-community-sentiment-triage/.env.example
@@ -45,7 +45,7 @@ OUTLOOK_TARGET_MAILBOX=
 OUTLOOK_REPLY_TO=
 
 # Optional: comma-separated allowlist of senders the agent will respond to.
-# Leave empty to accept any sender.
+# Leave empty to fall back to OUTLOOK_REPLY_TO.
 OUTLOOK_ALLOWED_SENDERS=
 
 # ── Slack ────────────────────────────────────────────────────────────────

--- a/examples/personal-community-sentiment-triage/.env.example.s3
+++ b/examples/personal-community-sentiment-triage/.env.example.s3
@@ -49,7 +49,7 @@ OUTLOOK_TARGET_MAILBOX=
 OUTLOOK_REPLY_TO=
 
 # Optional: comma-separated allowlist of senders the agent will respond to.
-# Leave empty to accept any sender.
+# Leave empty to fall back to OUTLOOK_REPLY_TO.
 OUTLOOK_ALLOWED_SENDERS=
 
 # ── Slack ────────────────────────────────────────────────────────────────

--- a/examples/personal-community-sentiment-triage/README.md
+++ b/examples/personal-community-sentiment-triage/README.md
@@ -246,7 +246,7 @@ Now edit `.env` and fill in everything you already have:
     - `OUTLOOK_TARGET_MAILBOX`, `OUTLOOK_REPLY_TO` — the agent's mailbox and your personal mailbox
   - **Slack**: `SLACK_BOT_TOKEN` / `SLACK_APP_TOKEN` (both required) — see [docs/set-up-slack.md](docs/set-up-slack.md). Partial Outlook configuration (some vars set, some empty) is rejected at bring-up.
 - (optional) `SLACK_ALLOWED_IDS` — comma-separated Slack user IDs to restrict who can DM the agent; leave empty to allow anyone in the workspace
-- (optional) `OUTLOOK_ALLOWED_SENDERS` — comma-separated allowlist of email senders the agent will respond to; leave empty to accept any sender
+- (optional) `OUTLOOK_ALLOWED_SENDERS` — comma-separated allowlist of email senders the agent will respond to; leave empty to fall back to OUTLOOK_REPLY_TO
 - (optional) `GITHUB_TOKEN` for authenticated sandbox read-only
   GitHub REST, `GITHUB_READONLY_REPO`,
   `PHOENIX_COLLECTOR_ENDPOINT`, `PHOENIX_PROJECT_NAME`

--- a/examples/personal-community-sentiment-triage/agents/hermes/bridges/outlook/outlook-bridge.py
+++ b/examples/personal-community-sentiment-triage/agents/hermes/bridges/outlook/outlook-bridge.py
@@ -166,7 +166,6 @@ BOOTSTRAP_RETRY_WINDOW_SECONDS = 300
 
 HERMES_HOME = os.environ.get("HERMES_HOME", "/sandbox/.hermes-data")
 JOBS_FILE = os.path.join(HERMES_HOME, "cron", "outlook-jobs.json")
-SENDER_POLL_INTERVAL = 30
 
 # ── Delta link persistence ───────────────────────────────────────────────────
 _DELTA_LINK_FILE = pathlib.Path(HERMES_HOME) / "outlook" / "delta-link.json"
@@ -271,9 +270,8 @@ async def graph_patch(path_or_url: str, payload: dict) -> None:
 async def resolve_allowed_senders() -> set[str]:
     """Return the set of allowed sender addresses.
 
-    Reads OUTLOOK_ALLOWED_SENDERS env var (comma-separated) if set.
-    Otherwise waits for the first email in the target inbox and uses
-    that sender — preserving the original "activate by sending a message" UX.
+    Reads OUTLOOK_ALLOWED_SENDERS (comma-separated) if set; otherwise falls
+    back to OUTLOOK_REPLY_TO. Raises RuntimeError if neither is configured.
     """
     configured = os.environ.get("OUTLOOK_ALLOWED_SENDERS", "").strip()
     if configured:
@@ -281,25 +279,14 @@ async def resolve_allowed_senders() -> set[str]:
         log.info("Allowed senders from OUTLOOK_ALLOWED_SENDERS: %s", senders)
         return senders
 
-    # Discover from inbox — wait for first email
-    logged_waiting = False
-    while True:
-        data = await graph_get(
-            f"{_mailbox_base()}/mailFolders/inbox/messages"
-            "?$top=10&$select=from&$orderby=receivedDateTime desc"
-        )
-        for msg in data.get("value", []):
-            address = msg.get("from", {}).get("emailAddress", {}).get("address", "").lower()
-            if "@" in address:
-                log.info("Allowed senders discovered via inbox: %s", address)
-                return {address}
-        if not logged_waiting:
-            log.info(
-                "Inbox empty — waiting for first email to activate the bridge. "
-                "Send a message or set OUTLOOK_ALLOWED_SENDERS to skip discovery."
-            )
-            logged_waiting = True
-        await asyncio.sleep(SENDER_POLL_INTERVAL)
+    reply_to = os.environ.get("OUTLOOK_REPLY_TO", "").strip()
+    if reply_to and "@" in reply_to:
+        log.info("Allowed senders from OUTLOOK_REPLY_TO: %s", reply_to)
+        return {reply_to.lower()}
+
+    raise RuntimeError(
+        "Cannot determine allowed senders: set OUTLOOK_ALLOWED_SENDERS or OUTLOOK_REPLY_TO."
+    )
 
 
 async def initialize_allowed_senders(shutdown: asyncio.Event) -> set[str]:

--- a/examples/personal-community-sentiment-triage/docs/collective-wisdom.md
+++ b/examples/personal-community-sentiment-triage/docs/collective-wisdom.md
@@ -39,7 +39,7 @@ The README's [§ Persistence: collective wisdom across restarts](../README.md#pe
 | Sandbox is `Ready` | `openshell sandbox list \| grep hermes-direct` |
 | Slack app handle | Note your bot's `@`-handle from the Slack app manifest (see [set-up-slack.md](set-up-slack.md)). The doc refers to it as `@<your-bot>` — substitute as you go. |
 | At least one Slack user authorized | `grep SLACK_ALLOWED_IDS .env` lists ≥1 `U…` ID. The cross-user step (7) wants ≥2 — if you only have one, run that step yourself from a different channel and the cross-channel claim still holds. |
-| Outlook bridge works | Send `ping` to `OUTLOOK_TARGET_MAILBOX` from any address in `OUTLOOK_ALLOWED_SENDERS` (or any sender if that var is empty); reply within ~30s. |
+| Outlook bridge works | Send `ping` to `OUTLOOK_TARGET_MAILBOX` from an address in `OUTLOOK_ALLOWED_SENDERS` (or from `OUTLOOK_REPLY_TO` if that var is empty); reply within ~30s. |
 | Live GitHub works | `openshell sandbox exec --name hermes-direct -- sh -lc '/usr/bin/python3 /sandbox/.hermes-data/skills/github-readonly-live/scripts/github_readonly.py rate-limit'` returns JSON without printing a token |
 | Discussion/forum mirror has data | `curl -sf http://localhost:3100/github_discussions?limit=1 \| head -c 200` or `curl -sf http://localhost:3100/forum_topics?limit=1 \| head -c 200` returns a non-empty array |
 | Skills dir is writable | `openshell sandbox exec --name hermes-direct -- ls -la /sandbox/.hermes-data/skills/` lists 6 baked-in skills, all owned by `sandbox` |
@@ -58,7 +58,7 @@ The demo has two roles. Whoever fills them is up to you and what's in your allow
 | **User A** | Slack DM | Iterates on a daily-update format, then expresses to the agent that they'd like the same format next time. |
 | **User B** | Outlook email | Never participated in User A's conversation. Asks for the same kind of update from a fresh session and gets the same format. |
 
-If you have a coworker whose Slack ID is in `SLACK_ALLOWED_IDS` and whose email is on the `OUTLOOK_ALLOWED_SENDERS` list (or who can send from any address if that variable is empty), they're a natural User B — the cross-user claim is fully proven. If you're running solo, you can play both roles on different channels (Slack DM in step 1, Outlook email in step 7); cross-channel still holds, and "cross-user" softens to "different sessions, same human."
+If you have a coworker whose Slack ID is in `SLACK_ALLOWED_IDS` and whose email is on the `OUTLOOK_ALLOWED_SENDERS` list (or matches `OUTLOOK_REPLY_TO` if that list is empty), they're a natural User B — the cross-user claim is fully proven. If you're running solo, you can play both roles on different channels (Slack DM in step 1, Outlook email in step 7); cross-channel still holds, and "cross-user" softens to "different sessions, same human."
 
 > **Note**: Throughout this doc, `@<your-bot>` is a placeholder for the handle of your Slack app — whatever name you set in the manifest (see [set-up-slack.md](set-up-slack.md)). Replace with your actual handle as you go.
 
@@ -234,7 +234,7 @@ The `on_session_start` hook in `plugin/__init__.py` auto-rescans on the next mes
 
 ### Step 7 — User B invokes the format from Outlook
 
-User B — who never participated in step 1's conversation, never saw the format negotiation, and is using a different channel — emails `OUTLOOK_TARGET_MAILBOX` from an address on the `OUTLOOK_ALLOWED_SENDERS` list. Note: the prompt below uses the same natural language User A would, never the skill's filename. The agent should match it against the skill via the skill's `description:` field.
+User B — who never participated in step 1's conversation, never saw the format negotiation, and is using a different channel — emails `OUTLOOK_TARGET_MAILBOX` from an address on the `OUTLOOK_ALLOWED_SENDERS` list (or from `OUTLOOK_REPLY_TO` if that list is empty). Note: the prompt below uses the same natural language User A would, never the skill's filename. The agent should match it against the skill via the skill's `description:` field.
 
 **Subject:** `Daily NemoClaw digest`
 


### PR DESCRIPTION
When OUTLOOK_ALLOWED_SENDERS is empty, the bridge previously polled the
inbox for the first email and used that sender — a footgun that could lock
the bridge to a newsletter or notification.

- Fall back to OUTLOOK_REPLY_TO (always required when Outlook is configured)
- Remove the inbox-discovery polling loop and SENDER_POLL_INTERVAL constant
- Fail fast with RuntimeError if neither variable is set