### PR TITLE
fix: truncate large hook payloads before forwarding to NeMo Relay

### DIFF
--- a/examples/personal-community-sentiment-triage/agents/hermes/plugins/nemo-relay/__init__.py
+++ b/examples/personal-community-sentiment-triage/agents/hermes/plugins/nemo-relay/__init__.py
@@ -207,6 +207,151 @@ def _serialize_response_object(response: Any) -> Optional[dict]:
 
 
 # ---------------------------------------------------------------------------
+# Payload truncation
+# ---------------------------------------------------------------------------
+
+# Axum's default Json<Value> extractor rejects bodies above ~2 MiB.
+# Stay safely under that limit so large-but-valid LLM turns still
+# produce telemetry.
+_MAX_PAYLOAD_BYTES = 1_500_000  # 1.5 MiB — headroom under Axum's ~2 MiB limit
+
+
+def _truncate_str(text: str, max_len: int = 4096) -> str:
+    """Truncate a string, appending a marker so consumers know it was cut."""
+    if len(text) <= max_len:
+        return text
+    return text[:max_len] + "...[truncated]"
+
+
+def _estimate_size(payload: dict) -> int:
+    """Fast serialized-size estimate (UTF-8 bytes of JSON)."""
+    try:
+        return len(json.dumps(payload, default=str, ensure_ascii=False).encode("utf-8"))
+    except Exception:
+        return 0
+
+
+def _truncate_payload(payload: dict) -> dict:
+    """Iteratively shrink a hook payload until it fits under the Axum body limit.
+
+    Truncation order (largest fields first):
+      1. message content strings in request.body.messages
+      2. response.raw_response deep content
+      3. response.assistant_message content
+      4. tool args / result strings
+
+    Correlation metadata (task_id, session_id, model, etc.) is never touched.
+    """
+    size = _estimate_size(payload)
+    if size <= _MAX_PAYLOAD_BYTES:
+        return payload
+
+    # Work on a mutable copy
+    payload = dict(payload)
+
+    # --- Phase 1: truncate LLM message content ---
+    request_body = (payload.get("request") or {}).get("body")
+    if isinstance(request_body, dict):
+        messages = request_body.get("messages")
+        if isinstance(messages, list):
+            budget_per_msg = max(512, _MAX_PAYLOAD_BYTES // max(len(messages), 1) // 4)
+            changed = False
+            for i, msg in enumerate(messages):
+                if isinstance(msg, dict):
+                    content = msg.get("content")
+                    if isinstance(content, str) and len(content) > budget_per_msg:
+                        messages[i] = {**msg, "content": _truncate_str(content, budget_per_msg)}
+                        changed = True
+                    elif isinstance(content, list):
+                        # multimodal content blocks
+                        for j, block in enumerate(content):
+                            if isinstance(block, dict):
+                                text = block.get("text")
+                                if isinstance(text, str) and len(text) > budget_per_msg:
+                                    content[j] = {**block, "text": _truncate_str(text, budget_per_msg)}
+                                    changed = True
+            if changed:
+                payload["request"] = {**payload.get("request", {}), "body": {**request_body, "messages": messages}}
+
+        size = _estimate_size(payload)
+        if size <= _MAX_PAYLOAD_BYTES:
+            return payload
+
+    # --- Phase 2: truncate response content ---
+    response = payload.get("response")
+    if isinstance(response, dict):
+        raw = response.get("raw_response")
+        if isinstance(raw, dict):
+            # Truncate choice text content
+            for key in ("choices", "output", "content"):
+                val = raw.get(key)
+                if isinstance(val, list):
+                    for i, choice in enumerate(val):
+                        if isinstance(choice, dict):
+                            msg = choice.get("message") or choice.get("text")
+                            if isinstance(msg, dict):
+                                c = msg.get("content")
+                                if isinstance(c, str) and len(c) > 2048:
+                                    msg = {**msg, "content": _truncate_str(c, 2048)}
+                                    raw[key][i] = {**choice, "message": msg}
+                            elif isinstance(msg, str) and len(msg) > 2048:
+                                raw[key][i] = {**choice, "text": _truncate_str(msg, 2048)}
+
+        assistant_msg = response.get("assistant_message")
+        if isinstance(assistant_msg, dict):
+            c = assistant_msg.get("content")
+            if isinstance(c, str) and len(c) > 2048:
+                response["assistant_message"] = {**assistant_msg, "content": _truncate_str(c, 2048)}
+
+        payload["response"] = response
+
+        size = _estimate_size(payload)
+        if size <= _MAX_PAYLOAD_BYTES:
+            return payload
+
+    # --- Phase 3: truncate tool args and results ---
+    for field in ("args", "result"):
+        val = payload.get(field)
+        if isinstance(val, str) and len(val) > 2048:
+            payload[field] = _truncate_str(val, 2048)
+        elif isinstance(val, dict):
+            s = json.dumps(val, default=str, ensure_ascii=False)
+            if len(s) > 4096:
+                # Truncate to a compact representation
+                payload[field] = _truncate_str(s, 4096)
+
+    size = _estimate_size(payload)
+    if size <= _MAX_PAYLOAD_BYTES:
+        return payload
+
+    # --- Phase 4: aggressive — truncate everything to a summary ---
+    # At this point the payload is still too large; strip all content to bare
+    # correlation metadata so the relay at least records the span exists.
+    if isinstance(payload.get("request"), dict):
+        body = payload["request"].get("body")
+        if isinstance(body, dict):
+            msgs = body.get("messages")
+            if isinstance(msgs, list):
+                body["messages"] = [
+                    {k: ("[truncated]" if k == "content" else v)
+                     for k, v in m.items()}
+                    if isinstance(m, dict) else m
+                    for m in msgs
+                ]
+    if isinstance(payload.get("response"), dict):
+        resp = payload["response"]
+        if isinstance(resp.get("raw_response"), dict):
+            resp["raw_response"] = "[truncated: payload exceeded body limit]"
+        if isinstance(resp.get("assistant_message"), dict):
+            am = resp["assistant_message"]
+            if isinstance(am.get("content"), str):
+                resp["assistant_message"] = {**am, "content": "[truncated]"}
+
+    payload["_truncated"] = True
+    return payload
+
+
+# ---------------------------------------------------------------------------
 # Forwarder
 # ---------------------------------------------------------------------------
 
@@ -218,6 +363,7 @@ def _forward(payload: dict) -> None:
     if client is None:
         return
     try:
+        payload = _truncate_payload(payload)
         client.post(f"{url}/hooks/hermes", json=payload)
     except Exception as exc:
         logger.debug("nemo-relay: forward to %s failed: %s", url, exc)


### PR DESCRIPTION
## Summary

The NeMo Relay Axum server applies a default ~2 MiB body limit on `/hooks/hermes`. Large but valid LLM turns silently return HTTP 413, so the interaction completes but Phoenix/ATIF telemetry is missing for that turn.

## Root Cause

`_forward()` sends the full serialized hook payload without checking size. When a Hermes turn produces a large payload (multi-message conversations, verbose tool outputs, long reasoning chains), the Axum `Json<Value>` extractor rejects it before `hermes::adapt(...)` runs.

## Change Made

**File:** `examples/personal-community-sentiment-triage/agents/hermes/plugins/nemo-relay/__init__.py`

Added a `_truncate_payload()` step in `_forward()` that progressively shrinks oversized payloads while preserving correlation metadata (`task_id`, `session_id`, `model`, etc.) and hook event structure:

- **Phase 1:** Truncate message content strings with a proportional per-message budget
- **Phase 2:** Truncate `response.raw_response` and `assistant_message` content
- **Phase 3:** Truncate tool `args` and `result` strings
- **Phase 4:** Aggressive — replace all content with `[truncated]` marker, set `_truncated: true`

Threshold is 1.5 MiB, safely under Axum's ~2 MiB limit. Small payloads pass through unchanged (identity return, zero overhead).

This is the client-side complement to any future server-side `DefaultBodyLimit` increase in NeMo Relay itself.

```
.../plugins/nemo-relay/__init__.py   | 146 ++++++++++++++++++++
 1 file changed, 146 insertions(+)
```

## Testing

- Verified small payloads pass through unchanged (identity return)
- Verified 2 MiB message content is truncated below 1.5 MiB
- Verified 10-message conversations get proportional truncation
- Verified correlation metadata (task_id, session_id, model) is preserved through all phases
- Verified response and tool call payloads are handled
- Python syntax validation passes

Fixes #22
