### PR TITLE
Use canonical OpenShell provider placeholders

### DIFF
--- a/examples/personal-community-sentiment-triage/agents/hermes/refresh-placeholders.py
+++ b/examples/personal-community-sentiment-triage/agents/hermes/refresh-placeholders.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Rewrite Hermes's .env file with OpenShell provider-injected placeholders.
+"""Rewrite Hermes's .env file with OpenShell provider placeholders.
 
 Called by start.sh at sandbox boot. Reads NEMOCLAW_PROVIDER_PLACEHOLDER_KEYS
 (a space-separated list of env var names) and for each one whose value starts
-with `openshell:resolve:env:`, ensures the target env file has the latest
-placeholder string. Idempotent — no-op if values already match. Symlink
-guard lives in the bash caller.
+with `openshell:resolve:env:`, ensures the target env file has the canonical
+placeholder string. Idempotent — no-op if values already match. Symlink guard
+lives in the bash caller.
 """
 from __future__ import annotations
 
@@ -28,7 +28,10 @@ def main() -> int:
     for key in keys:
         value = os.environ.get(key, "")
         if value.startswith(prefix):
-            replacements[key] = value
+            # OpenShell may inject revision-pinned placeholders into process env
+            # (for example, openshell:resolve:env:v123_KEY). Hermes persists this
+            # file for long-running bridges, so store the stable provider lookup.
+            replacements[key] = f"{prefix}{key}"
 
     if not replacements:
         return 0

--- a/examples/personal-community-sentiment-triage/agents/hermes/skills/outlook-email-search/scripts/get_thread.py
+++ b/examples/personal-community-sentiment-triage/agents/hermes/skills/outlook-email-search/scripts/get_thread.py
@@ -22,9 +22,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 
-MS_GRAPH_ACCESS_TOKEN = os.environ.get(
-    "MS_GRAPH_ACCESS_TOKEN", "openshell:resolve:env:MS_GRAPH_ACCESS_TOKEN"
-)
+MS_GRAPH_ACCESS_TOKEN = "openshell:resolve:env:MS_GRAPH_ACCESS_TOKEN"
 GRAPH_BASE = "https://graph.microsoft.com/v1.0"
 
 

--- a/examples/personal-community-sentiment-triage/agents/hermes/skills/outlook-email-search/scripts/search_emails.py
+++ b/examples/personal-community-sentiment-triage/agents/hermes/skills/outlook-email-search/scripts/search_emails.py
@@ -28,9 +28,7 @@ class ClientFilters(NamedTuple):
     sender: str | None      # exact sender email (from --from)
     unread_only: bool       # from --unread
 
-MS_GRAPH_ACCESS_TOKEN = os.environ.get(
-    "MS_GRAPH_ACCESS_TOKEN", "openshell:resolve:env:MS_GRAPH_ACCESS_TOKEN"
-)
+MS_GRAPH_ACCESS_TOKEN = "openshell:resolve:env:MS_GRAPH_ACCESS_TOKEN"
 GRAPH_BASE = "https://graph.microsoft.com/v1.0"
 
 _WELL_KNOWN_FOLDERS = {


### PR DESCRIPTION
## Summary

- persist canonical OpenShell provider placeholders in Hermes's writable `.env` instead of revision-pinned injected placeholders
- make Outlook email search helpers emit the canonical Graph token placeholder directly
- avoid stale placeholder failures after provider-env refreshes while keeping provider registration unchanged

## Validation

- `python3 -m py_compile` on the changed Python files
- rebuilt the Omnistation Hermes sandbox with `scripts/tear-down.sh` and `scripts/bring-up.sh`
- verified Hermes health and Slack Socket Mode connection after rebuild
- verified `/sandbox/.hermes-data/.env` contains canonical Slack placeholders
- verified Outlook search succeeds against both agent mailbox and default human mailbox path
- forced Outlook provider refresh with `openshell provider refresh rotate hermes-direct-outlook --credential-key MS_GRAPH_ACCESS_TOKEN`; sandbox detected `provider_env_changed:true`, then Slack, Graph, and Outlook search probes still succeeded
- forced Slack provider revision with `openshell provider update hermes-direct-slack --credential SLACK_BOT_TOKEN --credential SLACK_APP_TOKEN`; sandbox detected `provider_env_changed:true`, then `apps.connections.open`, `auth.test`, and live gateway Slack calls succeeded without credential-injection failures
