### PR TITLE
Agent auto heal steps

### DIFF
--- a/examples/personal-community-sentiment-triage/.env.example
+++ b/examples/personal-community-sentiment-triage/.env.example
@@ -23,7 +23,7 @@ NEMOCLAW_MODEL=nvidia/nemotron-3-super-120b-a12b
 # NEMOCLAW_ENDPOINT_URL=http://host.openshell.internal:18080/v1
 # Optional: required only when the endpoint above uses the host TLS proxy.
 # The proxy is installed separately after first bring-up; see docs/auto-heal.md.
-# NEMOCLAW_HOST_TLS_PROXY_UPSTREAM=https://inference-api.nvidia.com
+# NEMOCLAW_HOST_TLS_PROXY_UPSTREAM=https://your-openai-compatible-api.example.com
 # NEMOCLAW_HOST_TLS_PROXY_PORT=18080
 
 # ── Outlook (optional — recommended primary channel) ─────────────────────

--- a/examples/personal-community-sentiment-triage/.env.example
+++ b/examples/personal-community-sentiment-triage/.env.example
@@ -21,6 +21,10 @@ NEMOCLAW_MODEL=nvidia/nemotron-3-super-120b-a12b
 # — local vLLM, alternative NIM, or scripts/host-tls-proxy.py for
 # corporate VPNs (see docs/host-tls-proxy.md).
 # NEMOCLAW_ENDPOINT_URL=http://host.openshell.internal:18080/v1
+# Optional: required only when the endpoint above uses the host TLS proxy.
+# The proxy is installed separately after first bring-up; see docs/auto-heal.md.
+# NEMOCLAW_HOST_TLS_PROXY_UPSTREAM=https://inference-api.nvidia.com
+# NEMOCLAW_HOST_TLS_PROXY_PORT=18080
 
 # ── Outlook (optional — recommended primary channel) ─────────────────────
 # Outlook is opt-in: fill ALL FOUR OUTLOOK_* vars below to enable, or leave

--- a/examples/personal-community-sentiment-triage/README.md
+++ b/examples/personal-community-sentiment-triage/README.md
@@ -185,6 +185,7 @@ Skills are loaded on demand by the agent when relevant to a task. They live in [
 | `slack-channel-summarizer` | Resolve Slack channels by name or ID and read message history via the Slack Web API. |
 | `outlook-email-search` | Search the Outlook mailbox via Microsoft Graph to find and read emails relevant to a question. |
 | `cross-source-gap-analysis` | Synthesize findings across Slack, GitHub, and NVIDIA forum sources to identify gaps, alignment issues, and follow-ups. |
+| `nemoclaw-autoheal` | Guide users through sandbox health checks and optional host-side auto-heal setup. |
 
 ## Intended user journey
 
@@ -302,6 +303,25 @@ regardless of Phoenix config. If `PHOENIX_COLLECTOR_ENDPOINT` is set, `03-sandbo
 additionally bakes the endpoint into the image so OpenInference traces stream into
 Phoenix at `http://localhost:6006`.
 
+### Optional Phase 5 — Install auto-heal after first bring-up
+
+After the sandbox is Ready and the normal verification passes, you can opt in
+to user-level monitoring that keeps the host proxy, Hermes gateway forward, and
+Slack response path healthy. It is deliberately separate from `bring-up.sh` so
+first-time setup stays predictable and operators retain control over systemd.
+
+```console
+$ bash scripts/autoheal/install.sh --check
+$ bash scripts/autoheal/install.sh
+$ bash scripts/autoheal/sanity-check.sh
+```
+
+For a host TLS proxy, first set the explicit upstream origin in `.env`. For
+example, `NEMOCLAW_ENDPOINT_URL=http://host.openshell.internal:18080/v1` pairs
+with `NEMOCLAW_HOST_TLS_PROXY_UPSTREAM=https://inference-api.nvidia.com`.
+See [docs/auto-heal.md](docs/auto-heal.md) for manual checks, logs, repair, and
+uninstall instructions.
+
 ## What this example owns
 
 - **Owns** (in this directory): `agents/hermes/` (the full Hermes asset tree, staged
@@ -314,6 +334,8 @@ Phoenix at `http://localhost:6006`.
   - `snapshot.sh` / `restore.sh` — explicit Hermes state preservation across tear-down/bring-up cycles.
   - `download-traces.sh` — pull ATIF trace records from `/tmp/atif/` inside the sandbox into a host-side tarball. See [Capturing ATIF traces](#capturing-atif-traces) for the env knobs.
   - `host-tls-proxy.py` — optional plain-HTTP forwarder for hosts where the sandbox can't validate the inference endpoint's TLS chain (corporate VPN, split-horizon DNS, mkcert). See [docs/host-tls-proxy.md](docs/host-tls-proxy.md).
+  - `autoheal/` — optional user-systemd installer, watchdog, response monitor,
+    sanity checker, and unit templates. See [docs/auto-heal.md](docs/auto-heal.md).
 - **Generates and discards**: sed-patched `.Dockerfile.staged` and
   `.policy.staged.yaml` files at the example dir root. OpenShell does the actual
   build; we patch ARG defaults beforehand because `openshell sandbox create`
@@ -482,6 +504,8 @@ unless you remove the compose volumes.
 | `OPENSHELL_GATEWAY_ENDPOINT` | auto (`https://127.0.0.1:17670` for `openshell`, `http://127.0.0.1:17670` for `snap-docker`) | Override the local gateway endpoint if you registered it under a different URL. |
 | `NEMOCLAW_MODEL` | `nvidia/nemotron-3-super-120b-a12b` | Inference model passed to `openshell inference set`. |
 | `NEMOCLAW_ENDPOINT_URL` | `https://integrate.api.nvidia.com/v1` | Upstream base URL for the `compatible-endpoint` provider. (`OPENAI_BASE_URL` is also accepted as a fallback.) |
+| `NEMOCLAW_HOST_TLS_PROXY_UPSTREAM` | (none) | Optional HTTPS origin for the host TLS proxy. Required when `NEMOCLAW_ENDPOINT_URL` uses `host.openshell.internal:18080` and auto-heal should manage that proxy. |
+| `NEMOCLAW_HOST_TLS_PROXY_PORT` | `18080` | Host listener port for the optional TLS proxy. |
 | `COMPATIBLE_API_KEY` | (none) | Inference API key. Mirrors NemoClaw's `REMOTE_PROVIDER_CONFIG.custom`. (`OPENAI_API_KEY` is also accepted.) |
 | `GITHUB_TOKEN` | (none) | Optional GitHub token for authenticated live REST reads. Also feeds the optional host GitHub mirror. |
 | `GITHUB_READONLY_REPO` | `NVIDIA/OpenShell` | The only repo allowed by the live GitHub REST policy, formatted as `owner/repo`. Recreate the sandbox after changing it. |

--- a/examples/personal-community-sentiment-triage/agents/hermes/Dockerfile
+++ b/examples/personal-community-sentiment-triage/agents/hermes/Dockerfile
@@ -11,34 +11,29 @@
 # so Docker treats them as global build args (multi-stage scoping rule).
 ARG BASE_IMAGE=ghcr.io/nvidia/nemoclaw/hermes-sandbox-base@sha256:f76a2ed0509570b1ce5380327c7ebe2e120e97f524e9271e145d2ea34c83ba5e
 
-# ── Stage 0: binstall the pinned, prebuilt nemo-relay CLI (no source build) ────
+# ── Stage 0: fetch the pinned, prebuilt nemo-relay CLI (no source build) ──────
 # Upstream publishes musl-static CLI release assets (zero glibc linkage), so the
-# binary loads on the glibc-2.35 runtime regardless of build host — no in-base-
-# image compile needed. cargo-binstall auto-detects host arch + libc and resolves
-# the matching release asset, so no architecture is named here; the build is
-# always native (openshell builds with no --platform), so host arch == target.
+# binary loads on the glibc-2.35 runtime regardless of build host. The image
+# selects the native Docker architecture explicitly and downloads its release.
 # 0.3.0 includes the S3 ATIF export plugin (NVIDIA/NeMo-Relay#163), pulled in
 # unconditionally via the cli crate's `object-store` feature.
 FROM ${BASE_IMAGE} AS nemo-relay-builder
 ARG NEMO_RELAY_CLI_VERSION=0.3.0
-# PATH includes cargo's bin dir so the install script's --self-install step
-# finds it (silences its cosmetic "path is missing /root/.cargo/bin" warning)
-# and cargo-binstall resolves by name on the next line.
-RUN --mount=type=secret,id=github_token,required=false \
-    export PATH="/root/.cargo/bin:$PATH" \
+RUN mkdir -p /out/bin \
     && apt-get update -qq \
     && apt-get install -y --no-install-recommends ca-certificates curl \
     && rm -rf /var/lib/apt/lists/* \
+    && ARCH="$(uname -m)" \
+    && case "$ARCH" in \
+         x86_64) TARGET=x86_64-unknown-linux-musl ;; \
+         aarch64) TARGET=aarch64-unknown-linux-musl ;; \
+         *) echo "unsupported arch: $ARCH" >&2; exit 1 ;; \
+       esac \
     && curl -L --proto '=https' --tlsv1.2 -sSf \
-       https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash \
-    && if [ -s /run/secrets/github_token ]; then \
-         export GITHUB_TOKEN="$(cat /run/secrets/github_token)"; \
-       fi \
-    && cargo-binstall --no-confirm --strategies crate-meta-data \
-       --install-path /out/bin "nemo-relay-cli@${NEMO_RELAY_CLI_VERSION}"
-# --strategies crate-meta-data: only resolve the crate's own [metadata.binstall]
-# release asset; fail loud (no silent source recompile) if none matches the host.
-# Produces /out/bin/nemo-relay (musl-static; runs on any glibc/musl Linux)
+       "https://github.com/NVIDIA/NeMo-Relay/releases/download/${NEMO_RELAY_CLI_VERSION}/nemo-relay-cli-${TARGET}-${NEMO_RELAY_CLI_VERSION}" \
+       -o /out/bin/nemo-relay \
+    && chmod 755 /out/bin/nemo-relay
+# Produces /out/bin/nemo-relay (musl-static; runs on any glibc/musl Linux).
 
 # ── Main sandbox image ────────────────────────────────────────────────────────
 FROM ${BASE_IMAGE}

--- a/examples/personal-community-sentiment-triage/agents/hermes/Dockerfile
+++ b/examples/personal-community-sentiment-triage/agents/hermes/Dockerfile
@@ -19,7 +19,11 @@ ARG BASE_IMAGE=ghcr.io/nvidia/nemoclaw/hermes-sandbox-base@sha256:f76a2ed0509570
 # unconditionally via the cli crate's `object-store` feature.
 FROM ${BASE_IMAGE} AS nemo-relay-builder
 ARG NEMO_RELAY_CLI_VERSION=0.3.0
-RUN mkdir -p /out/bin \
+# If the caller provides a github_token BuildKit secret, use it for the release
+# asset request to avoid anonymous GitHub rate limits on shared egress IPs. The
+# token is not an ARG/ENV and does not persist into the final image.
+RUN --mount=type=secret,id=github_token,required=false \
+    mkdir -p /out/bin \
     && apt-get update -qq \
     && apt-get install -y --no-install-recommends ca-certificates curl \
     && rm -rf /var/lib/apt/lists/* \
@@ -29,9 +33,14 @@ RUN mkdir -p /out/bin \
          aarch64) TARGET=aarch64-unknown-linux-musl ;; \
          *) echo "unsupported arch: $ARCH" >&2; exit 1 ;; \
        esac \
-    && curl -L --proto '=https' --tlsv1.2 -sSf \
-       "https://github.com/NVIDIA/NeMo-Relay/releases/download/${NEMO_RELAY_CLI_VERSION}/nemo-relay-cli-${TARGET}-${NEMO_RELAY_CLI_VERSION}" \
-       -o /out/bin/nemo-relay \
+    && RELEASE_URL="https://github.com/NVIDIA/NeMo-Relay/releases/download/${NEMO_RELAY_CLI_VERSION}/nemo-relay-cli-${TARGET}-${NEMO_RELAY_CLI_VERSION}" \
+    && if [ -s /run/secrets/github_token ]; then \
+         curl -L --proto '=https' --tlsv1.2 -sSf \
+           -H "Authorization: Bearer $(cat /run/secrets/github_token)" \
+           "$RELEASE_URL" -o /out/bin/nemo-relay; \
+       else \
+         curl -L --proto '=https' --tlsv1.2 -sSf "$RELEASE_URL" -o /out/bin/nemo-relay; \
+       fi \
     && chmod 755 /out/bin/nemo-relay
 # Produces /out/bin/nemo-relay (musl-static; runs on any glibc/musl Linux).
 

--- a/examples/personal-community-sentiment-triage/agents/hermes/SOUL.md
+++ b/examples/personal-community-sentiment-triage/agents/hermes/SOUL.md
@@ -57,6 +57,8 @@ Examples of requests and matching skills:
 - Cross-source comparison or gap analysis across Slack, GitHub, forums,
   or Outlook -> `cross-source-gap-analysis`, plus whichever source
   skills are needed
+- Agent availability, Slack response failures, first-time auto-heal setup, or
+  host proxy troubleshooting -> `nemoclaw-autoheal`
 
 ### Default Skills
 

--- a/examples/personal-community-sentiment-triage/agents/hermes/generate-config.ts
+++ b/examples/personal-community-sentiment-triage/agents/hermes/generate-config.ts
@@ -105,7 +105,7 @@ function main(): void {
       },
     },
     approvals: {
-      mode: "smart",
+      mode: "off",
       timeout: 60,
     },
     // NeMo-Relay shell hooks — each event spawns `nemo-relay hook-forward hermes`,

--- a/examples/personal-community-sentiment-triage/agents/hermes/skills/nemoclaw-autoheal/SKILL.md
+++ b/examples/personal-community-sentiment-triage/agents/hermes/skills/nemoclaw-autoheal/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: nemoclaw-autoheal
+description: Guide users through Hermes availability checks and the optional host-side auto-heal setup without crossing the sandbox-to-host boundary.
+---
+
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# nemoclaw-autoheal
+
+Use this skill when a user says the Slack bot is not responding, asks whether
+Hermes is healthy, reports inference `503`/`504` failures, asks about Outlook
+connectivity, or wants to install the optional auto-heal services.
+
+## Boundary
+
+You run inside the OpenShell sandbox. Do not run `systemctl`, recreate the
+sandbox, inspect credentials, or try to install host services. Those actions
+belong to the host operator. You may call `nemoclaw_status` to inspect the
+local Hermes gateway, then give the operator the exact commands below.
+
+## Diagnose
+
+1. Call `nemoclaw_status` first. If the gateway is stopped, say that the
+   sandbox gateway is unhealthy.
+2. For an inference error, explain that `503`, `504`, or a timeout can be an
+   upstream service or host-proxy failure.
+3. For a Slack failure, distinguish an unavailable gateway from an allowlist,
+   Socket Mode, or Slack API issue. Do not claim the bot received a message
+   unless the user supplied evidence.
+4. For Outlook, explain that a Graph connection closure may be sandbox egress
+   or a temporary proxy failure; it is not proof that the mailbox settings are
+   wrong.
+
+## Tell the host operator
+
+Run these commands from the cloned example directory, not inside the sandbox:
+
+```bash
+bash scripts/autoheal/sanity-check.sh
+bash scripts/autoheal/sanity-check.sh --repair
+```
+
+If auto-heal is not installed yet, first run:
+
+```bash
+bash scripts/autoheal/install.sh --check
+bash scripts/autoheal/install.sh
+```
+
+For status and logs:
+
+```bash
+systemctl --user status nemoclaw-hermes-gateway-forward.service
+systemctl --user list-timers 'nemoclaw-*'
+journalctl --user -u nemoclaw-hermes-watchdog.service -n 80 --no-pager
+```
+
+If the user runs an inference endpoint through
+`http://host.openshell.internal:18080`, remind them to set
+`NEMOCLAW_HOST_TLS_PROXY_UPSTREAM` in the host `.env` before installing the
+auto-heal services. The value is the HTTPS origin, for example
+`https://inference-api.nvidia.com`.
+
+## Response style
+
+Start with the current status or likely failure class, then give only the next
+one or two host commands. Do not print or request Slack, Outlook, GitHub, or
+inference credentials.

--- a/examples/personal-community-sentiment-triage/docs/auto-heal.md
+++ b/examples/personal-community-sentiment-triage/docs/auto-heal.md
@@ -1,0 +1,120 @@
+---
+title:
+  page: "Optional Hermes Auto-Heal"
+  nav: "Auto-Heal"
+description:
+  main: "Install optional user-level systemd monitoring for the personal-community-sentiment-triage Hermes sandbox after a successful first bring-up."
+  agent: "Explains first-time installation, manual health checks, repair, logs, and removal for the optional host-side Hermes auto-heal services."
+keywords: ["nemoclaw auto-heal", "hermes watchdog", "slack response monitor", "host tls proxy"]
+topics: ["generative_ai", "ai_agents"]
+tags: ["hermes", "openshell", "slack", "outlook", "systemd"]
+content:
+  type: how_to
+  difficulty: intermediate
+  audience: ["developer", "engineer"]
+status: published
+---
+
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Optional Hermes Auto-Heal
+
+This is an opt-in reliability add-on for a running Hermes sandbox. It is not a
+replacement for the normal first-time setup. Finish the README's OpenShell,
+`.env`, and `bash scripts/bring-up.sh` steps first, including the one-time
+Outlook device login when Outlook is enabled. The first image build can take
+several minutes.
+
+The add-on installs only **user-level** systemd units. It never copies API
+keys into unit files and it does not need a root-owned service. On a headless
+host, enable linger once so your user services continue after logout:
+
+```console
+$ sudo loginctl enable-linger "$USER"
+```
+
+## First-time installation
+
+From the example directory, run the read-only preflight first:
+
+```console
+$ bash scripts/autoheal/install.sh --check
+```
+
+It checks the user systemd manager, Docker, OpenShell, Python, `.env`, a Ready
+sandbox, and the Hermes gateway. Fix any failed check, then install:
+
+```console
+$ bash scripts/autoheal/install.sh
+$ bash scripts/autoheal/sanity-check.sh
+```
+
+The installer enables a host gateway forward, a watchdog timer, and a Slack
+response-monitor timer. It also enables a TLS proxy service when you configured
+one.
+
+## Optional Inference Hub proxy
+
+Use this only when the sandbox endpoint is routed through the host proxy:
+
+```bash
+NEMOCLAW_ENDPOINT_URL=http://host.openshell.internal:18080/v1
+NEMOCLAW_HOST_TLS_PROXY_UPSTREAM=https://inference-api.nvidia.com
+NEMOCLAW_HOST_TLS_PROXY_PORT=18080
+```
+
+`NEMOCLAW_HOST_TLS_PROXY_UPSTREAM` is intentionally explicit. It is the HTTPS
+origin that the host proxy reaches; the sandbox-facing endpoint stays the
+`host.openshell.internal` URL. The installer refuses to manage this proxy when
+the sandbox endpoint uses port `18080` but the upstream is missing.
+
+## What runs
+
+| Unit | Purpose |
+|---|---|
+| `nemoclaw-hermes-proxy.service` | Keeps the optional host TLS inference proxy running. |
+| `nemoclaw-hermes-gateway-forward.service` | Keeps `127.0.0.1:8642` forwarded to the sandbox Hermes gateway. |
+| `nemoclaw-hermes-watchdog.timer` | Runs health checks every minute and performs bounded recovery. |
+| `nemoclaw-slack-response-monitor.timer` | Detects unanswered allowed-user Slack DMs and recent transport errors every minute. |
+
+Recovery first restarts the affected host service or Hermes gateway. It rebuilds
+the sandbox only after a live Slack Socket Mode or Microsoft Graph probe confirms
+that sandbox egress is failing. Locks and cooldowns prevent repeated rebuilds.
+
+## Manual operation
+
+```console
+$ bash scripts/autoheal/sanity-check.sh
+$ bash scripts/autoheal/sanity-check.sh --repair
+$ systemctl --user status nemoclaw-hermes-gateway-forward.service
+$ systemctl --user list-timers 'nemoclaw-*'
+$ journalctl --user -u nemoclaw-hermes-watchdog.service -n 80 --no-pager
+$ journalctl --user -u nemoclaw-slack-response-monitor.service -n 80 --no-pager
+```
+
+`sanity-check.sh` only reports health by default. `--repair` runs the watchdog
+after reporting failures. It does not print credentials.
+
+To stop and remove the optional add-on without touching the sandbox, providers,
+or host data services:
+
+```console
+$ bash scripts/autoheal/uninstall.sh
+```
+
+## Troubleshooting
+
+- **`install.sh --check` says the user manager is unavailable:** reconnect to
+  the host after enabling linger, or export `XDG_RUNTIME_DIR=/run/user/$(id -u)`
+  in the current shell.
+- **The proxy service is absent:** configure
+  `NEMOCLAW_HOST_TLS_PROXY_UPSTREAM` only when you intentionally use the host
+  proxy, then rerun the installer.
+- **A Slack message still receives no reply:** run the sanity check, then share
+  the non-secret watchdog and response-monitor log lines with the operator.
+- **Outlook Graph remains unavailable after recovery:** confirm normal Outlook
+  delegate access and provider setup using the README; auto-heal cannot repair
+  an expired sign-in or missing mailbox permissions.

--- a/examples/personal-community-sentiment-triage/scripts/03-sandbox.sh
+++ b/examples/personal-community-sentiment-triage/scripts/03-sandbox.sh
@@ -103,21 +103,33 @@ for arg in "${!DOCKERFILE_ARGS[@]}"; do
 done
 
 BUILD_FROM="$STAGED_DOCKERFILE"
-if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+# BuildKit-only Dockerfile features, such as secret mounts, must be built by
+# Docker before handing the result to OpenShell. OpenShell accepts an image ref
+# in --from, so this preserves the normal sandbox-create flow while ensuring
+# token-backed GitHub release downloads work when GITHUB_TOKEN is supplied.
+if [[ -n "${GITHUB_TOKEN:-}" ]] || grep -q -- "--mount=type=secret" "$STAGED_DOCKERFILE"; then
   command -v docker >/dev/null || {
-    echo "docker not in PATH; required for authenticated sandbox image build" >&2
+    echo "docker not in PATH; required for BuildKit sandbox image build" >&2
     exit 1
   }
   safe_sandbox_name="$(printf '%s' "$SANDBOX_NAME" \
     | tr '[:upper:]' '[:lower:]' \
     | tr -c 'a-z0-9_.-' '-')"
   BUILD_FROM="nemoclaw-hermes-sandbox:${safe_sandbox_name}-${DOCKERFILE_ARGS[NEMOCLAW_BUILD_ID]}"
-  echo "Building sandbox image $BUILD_FROM with BuildKit secret-backed GitHub authentication"
-  DOCKER_BUILDKIT=1 GITHUB_TOKEN="$GITHUB_TOKEN" docker build \
-    --secret id=github_token,env=GITHUB_TOKEN \
-    -t "$BUILD_FROM" \
-    -f "$STAGED_DOCKERFILE" \
-    "$EXAMPLE_DIR"
+  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    echo "Building sandbox image $BUILD_FROM with BuildKit secret-backed GitHub authentication"
+    DOCKER_BUILDKIT=1 GITHUB_TOKEN="$GITHUB_TOKEN" docker build \
+      --secret id=github_token,env=GITHUB_TOKEN \
+      -t "$BUILD_FROM" \
+      -f "$STAGED_DOCKERFILE" \
+      "$EXAMPLE_DIR"
+  else
+    echo "Building sandbox image $BUILD_FROM with BuildKit"
+    DOCKER_BUILDKIT=1 docker build \
+      -t "$BUILD_FROM" \
+      -f "$STAGED_DOCKERFILE" \
+      "$EXAMPLE_DIR"
+  fi
 fi
 
 # ── Stage policy and patch per-run repo scope ───────────────────────────

--- a/examples/personal-community-sentiment-triage/scripts/autoheal/install.sh
+++ b/examples/personal-community-sentiment-triage/scripts/autoheal/install.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Install the optional auto-heal services for the current user. Run this only
+# after scripts/bring-up.sh has created a healthy sandbox.
+
+set -euo pipefail
+AUTOHEAL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$AUTOHEAL_DIR/lib.sh"
+
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/nemoclaw-autoheal"
+UNIT_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+RUNTIME_ENV="$CONFIG_DIR/runtime.env"
+TEMPLATE_DIR="$AUTOHEAL_DIR/systemd"
+CHECK_ONLY=false
+
+usage() {
+  cat <<'EOF'
+Usage: bash scripts/autoheal/install.sh [--check]
+
+  --check  Validate first-time setup prerequisites without installing services.
+
+The installer creates user-level systemd services. For a headless host, enable
+linger once so they survive logout: sudo loginctl enable-linger "$USER"
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check) CHECK_ONLY=true ;;
+    -h|--help) usage; exit 0 ;;
+    *) printf 'Unknown option: %s\n' "$1" >&2; usage >&2; exit 2 ;;
+  esac
+  shift
+done
+
+failures=0
+check() {
+  local label="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    printf 'PASS  %s\n' "$label"
+  else
+    printf 'FAIL  %s\n' "$label" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+check "Python 3 is available" command -v python3
+check "curl is available" command -v curl
+check "Docker is available" command -v docker
+check "OpenShell CLI is available" command -v openshell
+check "systemd user manager is available" systemctl --user show-environment
+check "example .env exists" test -f "$EXAMPLE_DIR/.env"
+check "Docker daemon is reachable" docker info
+check "sandbox ${AUTOHEAL_SANDBOX_NAME} is Ready" sandbox_ready
+check "sandbox gateway is healthy" sandbox_gateway_ok
+
+if [[ "${NEMOCLAW_ENDPOINT_URL:-}" == "http://host.openshell.internal:${AUTOHEAL_PROXY_PORT}"* ]]; then
+  if proxy_is_configured; then
+    printf 'PASS  configured host TLS proxy upstream\n'
+  else
+    printf 'FAIL  NEMOCLAW_HOST_TLS_PROXY_UPSTREAM is required when NEMOCLAW_ENDPOINT_URL uses host.openshell.internal:%s\n' "$AUTOHEAL_PROXY_PORT" >&2
+    failures=$((failures + 1))
+  fi
+fi
+
+if (( failures > 0 )); then
+  printf '\nFix the failed checks before installing auto-heal.\n' >&2
+  exit 1
+fi
+
+if "$CHECK_ONLY"; then
+  printf '\nAll checks passed. Run this script without --check to install auto-heal.\n'
+  exit 0
+fi
+
+mkdir -p "$CONFIG_DIR" "$UNIT_DIR"
+umask 077
+cat >"$RUNTIME_ENV" <<EOF
+EXAMPLE_DIR=$EXAMPLE_DIR
+SANDBOX_NAME=$AUTOHEAL_SANDBOX_NAME
+NEMOCLAW_HOST_TLS_PROXY_UPSTREAM=$AUTOHEAL_PROXY_UPSTREAM
+NEMOCLAW_HOST_TLS_PROXY_PORT=$AUTOHEAL_PROXY_PORT
+EOF
+chmod 600 "$RUNTIME_ENV"
+
+render_unit() {
+  local template="$1" destination="$2" escaped_dir escaped_env
+  escaped_dir="$(printf '%s' "$EXAMPLE_DIR" | sed 's/[&|]/\\&/g')"
+  escaped_env="$(printf '%s' "$RUNTIME_ENV" | sed 's/[&|]/\\&/g')"
+  sed -e "s|@EXAMPLE_DIR@|$escaped_dir|g" -e "s|@RUNTIME_ENV@|$escaped_env|g" \
+    "$TEMPLATE_DIR/$template" >"$UNIT_DIR/$destination"
+}
+
+render_unit nemoclaw-hermes-gateway-forward.service.in nemoclaw-hermes-gateway-forward.service
+render_unit nemoclaw-hermes-watchdog.service.in nemoclaw-hermes-watchdog.service
+render_unit nemoclaw-hermes-watchdog.timer.in nemoclaw-hermes-watchdog.timer
+render_unit nemoclaw-slack-response-monitor.service.in nemoclaw-slack-response-monitor.service
+render_unit nemoclaw-slack-response-monitor.timer.in nemoclaw-slack-response-monitor.timer
+
+if proxy_is_configured; then
+  render_unit nemoclaw-hermes-proxy.service.in nemoclaw-hermes-proxy.service
+else
+  systemctl --user disable --now nemoclaw-hermes-proxy.service >/dev/null 2>&1 || true
+  rm -f "$UNIT_DIR/nemoclaw-hermes-proxy.service"
+fi
+
+systemctl --user daemon-reload
+systemctl --user enable --now nemoclaw-hermes-gateway-forward.service
+systemctl --user enable --now nemoclaw-hermes-watchdog.timer
+systemctl --user enable --now nemoclaw-slack-response-monitor.timer
+if proxy_is_configured; then
+  systemctl --user enable --now nemoclaw-hermes-proxy.service
+fi
+
+printf '\nAuto-heal is enabled for sandbox %s.\n' "$AUTOHEAL_SANDBOX_NAME"
+printf 'Run: bash scripts/autoheal/sanity-check.sh\n'
+printf 'For a headless host: sudo loginctl enable-linger "$USER"\n'

--- a/examples/personal-community-sentiment-triage/scripts/autoheal/lib.sh
+++ b/examples/personal-community-sentiment-triage/scripts/autoheal/lib.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Shared host-side helpers for the optional auto-heal package.
+
+AUTOHEAL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$AUTOHEAL_DIR/.." && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPTS_DIR/_lib.sh"
+
+load_env
+
+AUTOHEAL_SANDBOX_NAME="${SANDBOX_NAME:-hermes-direct}"
+AUTOHEAL_PROXY_UPSTREAM="${NEMOCLAW_HOST_TLS_PROXY_UPSTREAM:-}"
+AUTOHEAL_PROXY_PORT="${NEMOCLAW_HOST_TLS_PROXY_PORT:-18080}"
+AUTOHEAL_STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/nemoclaw-autoheal"
+AUTOHEAL_RECREATE_COOLDOWN_SECS="${NEMOCLAW_AUTOHEAL_RECREATE_COOLDOWN_SECS:-900}"
+
+autoheal_log() {
+  printf '[nemoclaw-autoheal] %s\n' "$*" >&2
+}
+
+proxy_is_configured() {
+  [[ -n "$AUTOHEAL_PROXY_UPSTREAM" ]]
+}
+
+sandbox_ready() {
+  openshell sandbox list 2>/dev/null | grep -E "^[[:space:]]*${AUTOHEAL_SANDBOX_NAME}[[:space:]]" | grep -qi ready
+}
+
+sandbox_gateway_ok() {
+  openshell sandbox exec --name "$AUTOHEAL_SANDBOX_NAME" -- bash -lc \
+    'curl -fsS --max-time 5 http://127.0.0.1:8642/health >/dev/null' >/dev/null 2>&1
+}
+
+host_gateway_ok() {
+  curl -fsS --max-time 5 http://127.0.0.1:8642/health >/dev/null 2>&1
+}
+
+sandbox_container() {
+  docker ps --format '{{.Names}}' | grep "^openshell-${AUTOHEAL_SANDBOX_NAME}" | head -n1 || true
+}
+
+unit_is_installed() {
+  systemctl --user cat "$1" >/dev/null 2>&1
+}
+
+start_or_restart_unit() {
+  local unit="$1"
+  if unit_is_installed "$unit"; then
+    systemctl --user restart "$unit"
+  else
+    autoheal_log "unit is not installed: $unit"
+    return 1
+  fi
+}
+
+state_timestamp() {
+  local name="$1"
+  local file="$AUTOHEAL_STATE_DIR/$name"
+  [[ -f "$file" ]] && cat "$file" || printf '0\n'
+}
+
+set_state_timestamp() {
+  local name="$1"
+  mkdir -p "$AUTOHEAL_STATE_DIR"
+  printf '%s\n' "$(date +%s)" >"$AUTOHEAL_STATE_DIR/$name"
+}
+
+cooldown_elapsed() {
+  local name="$1" cooldown="$2" now last
+  now="$(date +%s)"
+  last="$(state_timestamp "$name")"
+  [[ "$last" =~ ^[0-9]+$ ]] || last=0
+  (( now - last >= cooldown ))
+}

--- a/examples/personal-community-sentiment-triage/scripts/autoheal/sanity-check.sh
+++ b/examples/personal-community-sentiment-triage/scripts/autoheal/sanity-check.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Print a compact, non-secret health report. --repair runs the watchdog after it.
+
+set -euo pipefail
+AUTOHEAL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$AUTOHEAL_DIR/lib.sh"
+
+REPAIR=false
+case "${1:-}" in
+  "") ;;
+  --repair) REPAIR=true ;;
+  -h|--help)
+    printf 'Usage: bash scripts/autoheal/sanity-check.sh [--repair]\n'
+    exit 0
+    ;;
+  *) printf 'Unknown option: %s\n' "$1" >&2; exit 2 ;;
+esac
+
+failures=0
+report() {
+  local label="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    printf 'PASS  %s\n' "$label"
+  else
+    printf 'FAIL  %s\n' "$label"
+    failures=$((failures + 1))
+  fi
+}
+
+slack_socket_probe() {
+  openshell sandbox exec --name "$AUTOHEAL_SANDBOX_NAME" -- bash -lc '
+    source /sandbox/.hermes-data/.env >/dev/null 2>&1 || source /sandbox/.hermes/.env >/dev/null 2>&1
+    body="$(curl -sS --max-time 12 -X POST -H "Authorization: Bearer ${SLACK_APP_TOKEN}" https://slack.com/api/apps.connections.open)" || exit 1
+    python3 -c "import json,sys; raise SystemExit(0 if json.loads(sys.argv[1]).get(\"ok\") else 1)" "$body"
+  ' >/dev/null 2>&1
+}
+
+report "sandbox ${AUTOHEAL_SANDBOX_NAME} is Ready" sandbox_ready
+report "sandbox Hermes gateway" sandbox_gateway_ok
+report "host gateway forward" host_gateway_ok
+
+if proxy_is_configured; then
+  report "host TLS proxy service" systemctl --user is-active --quiet nemoclaw-hermes-proxy.service
+  report "host TLS proxy listener" curl -sS -o /dev/null --max-time 5 "http://127.0.0.1:${AUTOHEAL_PROXY_PORT}/"
+fi
+
+if [[ -n "${COMPATIBLE_API_KEY:-${OPENAI_API_KEY:-}}" ]] && sandbox_ready; then
+  report "Hermes inference" openshell sandbox exec --name "$AUTOHEAL_SANDBOX_NAME" -- bash -lc \
+    'HERMES_HOME=/sandbox/.hermes-data hermes -z "Reply with OK." >/dev/null'
+fi
+
+if [[ -n "${SLACK_APP_TOKEN:-}" ]] && sandbox_ready; then
+  report "Slack Socket Mode" slack_socket_probe
+fi
+
+if [[ -n "${OUTLOOK_CLIENT_ID:-}" ]] && sandbox_ready; then
+  report "Outlook Graph search" openshell sandbox exec --name "$AUTOHEAL_SANDBOX_NAME" -- bash -lc \
+    '/usr/bin/python3 /sandbox/.hermes-data/skills/outlook-email-search/scripts/search_emails.py --since 1d --top 1 >/dev/null'
+fi
+
+if "$REPAIR" && (( failures > 0 )); then
+  printf '\nRunning watchdog repair after %s failed check(s).\n' "$failures"
+  bash "$AUTOHEAL_DIR/watchdog.sh"
+fi
+
+if (( failures > 0 )); then
+  printf '\nSanity check found %s failed check(s).\n' "$failures" >&2
+  exit 1
+fi
+printf '\nSanity check passed.\n'

--- a/examples/personal-community-sentiment-triage/scripts/autoheal/slack-response-monitor.py
+++ b/examples/personal-community-sentiment-triage/scripts/autoheal/slack-response-monitor.py
@@ -165,7 +165,7 @@ def recent_gateway_failures() -> set[str]:
 def remediate(reason: str, dry_run: bool) -> None:
     log(f"recovery requested: {reason}")
     if not dry_run:
-        subprocess.run([str(WATCHDOG)], check=False)
+        subprocess.run(["bash", str(WATCHDOG)], check=False)
 
 
 def main() -> int:

--- a/examples/personal-community-sentiment-triage/scripts/autoheal/slack-response-monitor.py
+++ b/examples/personal-community-sentiment-triage/scripts/autoheal/slack-response-monitor.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Detect Slack response failures and request bounded host-side recovery."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+EXAMPLE_DIR = Path(os.environ.get("EXAMPLE_DIR", Path(__file__).resolve().parents[2]))
+ENV_FILE = EXAMPLE_DIR / ".env"
+STATE_FILE = Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local/state")) / "nemoclaw-autoheal/response-monitor.json"
+WATCHDOG = Path(__file__).with_name("watchdog.sh")
+LOG_PREFIX = "[nemoclaw-response-monitor]"
+
+
+def log(message: str) -> None:
+    print(f"{LOG_PREFIX} {message}", file=sys.stderr, flush=True)
+
+
+def read_env(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    if not path.exists():
+        return values
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip().strip('"').strip("'")
+    return values
+
+
+def split_allowed_ids(raw: str) -> tuple[list[str], list[str]]:
+    users: list[str] = []
+    channels: list[str] = []
+    for item in (part.strip() for part in raw.split(",")):
+        if not item:
+            continue
+        if item.startswith(("U", "W")):
+            users.append(item)
+        elif item.startswith(("D", "C", "G")):
+            channels.append(item)
+    return users, channels
+
+
+def classify_log_text(text: str) -> set[str]:
+    lower = text.lower()
+    failures: set[str] = set()
+    if any(marker in lower for marker in ("http 503", "http 504", "gateway time-out", "inference service unavailable")):
+        failures.add("inference_proxy")
+    if any(marker in lower for marker in ("serverdisconnectederror", "server disconnected", "slackapierror")):
+        failures.add("slack_gateway")
+    graph_net_failure = re.search(r"net:fail.*graph\.microsoft\.com:443|graph\.microsoft\.com:443.*net:fail", lower)
+    if graph_net_failure or any(marker in lower for marker in ("remote end closed connection without response", "microsoft graph api")):
+        failures.add("outlook_graph")
+    return failures
+
+
+def should_remediate(last_action: float, now: float, cooldown_secs: int) -> bool:
+    return now - last_action >= cooldown_secs
+
+
+def slack_api(token: str, method: str, params: dict[str, Any] | None = None, post: bool = False) -> dict[str, Any]:
+    params = params or {}
+    url = f"https://slack.com/api/{method}"
+    headers = {"Authorization": f"Bearer {token}"}
+    data = None
+    if post:
+        headers["Content-Type"] = "application/json; charset=utf-8"
+        data = json.dumps(params).encode()
+    elif params:
+        url += "?" + urllib.parse.urlencode(params)
+    request = urllib.request.Request(url, data=data, headers=headers, method="POST" if post else "GET")
+    with urllib.request.urlopen(request, timeout=12) as response:
+        return json.loads(response.read().decode())
+
+
+def run(command: list[str], timeout: int = 30) -> tuple[int, str]:
+    try:
+        result = subprocess.run(command, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=timeout)
+        return result.returncode, result.stdout.strip()
+    except subprocess.TimeoutExpired:
+        return 124, "timed out"
+
+
+def load_state() -> dict[str, Any]:
+    try:
+        return json.loads(STATE_FILE.read_text())
+    except (OSError, ValueError):
+        return {}
+
+
+def save_state(state: dict[str, Any]) -> None:
+    STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    temporary = STATE_FILE.with_suffix(".tmp")
+    temporary.write_text(json.dumps(state, sort_keys=True, indent=2))
+    temporary.replace(STATE_FILE)
+
+
+def resolve_channels(token: str, allowed_users: list[str], explicit_channels: list[str]) -> list[str]:
+    channels = list(dict.fromkeys(explicit_channels))
+    for user_id in allowed_users:
+        try:
+            response = slack_api(token, "users.conversations", {"user": user_id, "types": "im", "limit": 20})
+            if not response.get("ok"):
+                response = slack_api(token, "conversations.open", {"users": user_id}, post=True)
+                channel_id = (response.get("channel") or {}).get("id")
+                if channel_id:
+                    channels.append(channel_id)
+                continue
+            channels.extend(channel["id"] for channel in response.get("channels", []) if channel.get("id"))
+        except Exception as exc:  # Network/API failure is itself a recovery signal.
+            log(f"could not resolve Slack DM: {exc.__class__.__name__}")
+    return list(dict.fromkeys(channels))
+
+
+def is_bot_message(message: dict[str, Any], bot_user_id: str, bot_id: str | None) -> bool:
+    return message.get("user") == bot_user_id or (bot_id is not None and message.get("bot_id") == bot_id)
+
+
+def latest_unanswered(token: str, channel_id: str, bot_user_id: str, bot_id: str | None, allowed_users: set[str], window_secs: int, grace_secs: int) -> str | None:
+    response = slack_api(token, "conversations.history", {"channel": channel_id, "limit": 30, "oldest": str(time.time() - window_secs), "inclusive": "true"})
+    if not response.get("ok"):
+        log(f"history unavailable for {channel_id}: {response.get('error', 'unknown')}")
+        return None
+    messages = sorted(response.get("messages", []), key=lambda item: float(item.get("ts", "0")), reverse=True)
+    now = time.time()
+    for index, message in enumerate(messages):
+        sender = message.get("user")
+        if message.get("type") != "message" or message.get("subtype") or not sender or sender == bot_user_id:
+            continue
+        if allowed_users and sender not in allowed_users:
+            continue
+        if now - float(message.get("ts", "0")) < grace_secs:
+            return None
+        newer = messages[:index]
+        if not any(is_bot_message(candidate, bot_user_id, bot_id) for candidate in newer):
+            return f"{channel_id}:{message.get('ts')}"
+        return None
+    return None
+
+
+def recent_gateway_failures() -> set[str]:
+    sandbox = os.environ.get("SANDBOX_NAME", "hermes-direct")
+    command = [
+        "bash", "-lc",
+        "container=$(docker ps --format '{{.Names}}' | grep '^openshell-" + sandbox + "' | head -n1); "
+        "[ -n \"$container\" ] && docker logs --since=15m --tail=5000 \"$container\" 2>&1",
+    ]
+    _, output = run(command, timeout=12)
+    return classify_log_text(output)
+
+
+def remediate(reason: str, dry_run: bool) -> None:
+    log(f"recovery requested: {reason}")
+    if not dry_run:
+        subprocess.run([str(WATCHDOG)], check=False)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--window-secs", type=int, default=int(os.environ.get("NEMOCLAW_SLACK_MONITOR_WINDOW_SECS", "900")))
+    parser.add_argument("--grace-secs", type=int, default=int(os.environ.get("NEMOCLAW_SLACK_MONITOR_GRACE_SECS", "90")))
+    parser.add_argument("--cooldown-secs", type=int, default=int(os.environ.get("NEMOCLAW_SLACK_MONITOR_COOLDOWN_SECS", "300")))
+    args = parser.parse_args()
+
+    env = read_env(ENV_FILE)
+    state = load_state()
+    now = time.time()
+    failures = recent_gateway_failures()
+
+    token = env.get("SLACK_BOT_TOKEN", "")
+    if token:
+        try:
+            auth = slack_api(token, "auth.test")
+            if not auth.get("ok"):
+                failures.add("slack_auth")
+            else:
+                users, channels = split_allowed_ids(env.get("SLACK_ALLOWED_IDS", ""))
+                for channel_id in resolve_channels(token, users, channels):
+                    unanswered = latest_unanswered(token, channel_id, auth["user_id"], auth.get("bot_id"), set(users), args.window_secs, args.grace_secs)
+                    if unanswered:
+                        failures.add("unanswered_slack_message")
+                        state["last_unanswered_key"] = unanswered
+                        break
+        except Exception as exc:
+            log(f"Slack API check failed: {exc.__class__.__name__}")
+            failures.add("slack_api")
+
+    if not failures:
+        log("ok: no response or transport failures detected")
+        return 0
+
+    last_action = float(state.get("last_action_time", 0))
+    if not should_remediate(last_action, now, args.cooldown_secs):
+        log("recovery cooldown is active")
+        return 0
+    remediate(",".join(sorted(failures)), args.dry_run)
+    if not args.dry_run:
+        state["last_action_time"] = now
+        save_state(state)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/personal-community-sentiment-triage/scripts/autoheal/systemd/nemoclaw-hermes-gateway-forward.service.in
+++ b/examples/personal-community-sentiment-triage/scripts/autoheal/systemd/nemoclaw-hermes-gateway-forward.service.in
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+[Unit]
+Description=NemoClaw Hermes host gateway forward
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=@RUNTIME_ENV@
+WorkingDirectory=@EXAMPLE_DIR@
+ExecStart=/usr/bin/openshell forward service ${SANDBOX_NAME} --target-port 8642 --local 127.0.0.1:8642
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/examples/personal-community-sentiment-triage/scripts/autoheal/systemd/nemoclaw-hermes-proxy.service.in
+++ b/examples/personal-community-sentiment-triage/scripts/autoheal/systemd/nemoclaw-hermes-proxy.service.in
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+[Unit]
+Description=NemoClaw host TLS proxy for inference
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=@RUNTIME_ENV@
+WorkingDirectory=@EXAMPLE_DIR@
+ExecStart=/usr/bin/python3 @EXAMPLE_DIR@/scripts/host-tls-proxy.py --upstream ${NEMOCLAW_HOST_TLS_PROXY_UPSTREAM} --listen 0.0.0.0 --port ${NEMOCLAW_HOST_TLS_PROXY_PORT}
+Restart=always
+RestartSec=5
+KillSignal=SIGINT
+TimeoutStopSec=15
+
+[Install]
+WantedBy=default.target

--- a/examples/personal-community-sentiment-triage/scripts/autoheal/systemd/nemoclaw-hermes-watchdog.service.in
+++ b/examples/personal-community-sentiment-triage/scripts/autoheal/systemd/nemoclaw-hermes-watchdog.service.in
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+[Unit]
+Description=NemoClaw Hermes watchdog
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=@RUNTIME_ENV@
+WorkingDirectory=@EXAMPLE_DIR@
+ExecStart=/usr/bin/env bash @EXAMPLE_DIR@/scripts/autoheal/watchdog.sh

--- a/examples/personal-community-sentiment-triage/scripts/autoheal/systemd/nemoclaw-hermes-watchdog.timer.in
+++ b/examples/personal-community-sentiment-triage/scripts/autoheal/systemd/nemoclaw-hermes-watchdog.timer.in
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+[Unit]
+Description=Run the NemoClaw Hermes watchdog every minute
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=1min
+AccuracySec=10s
+Persistent=true
+Unit=nemoclaw-hermes-watchdog.service
+
+[Install]
+WantedBy=timers.target

--- a/examples/personal-community-sentiment-triage/scripts/autoheal/systemd/nemoclaw-slack-response-monitor.service.in
+++ b/examples/personal-community-sentiment-triage/scripts/autoheal/systemd/nemoclaw-slack-response-monitor.service.in
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+[Unit]
+Description=NemoClaw Slack response monitor
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=@RUNTIME_ENV@
+WorkingDirectory=@EXAMPLE_DIR@
+ExecStart=/usr/bin/python3 @EXAMPLE_DIR@/scripts/autoheal/slack-response-monitor.py

--- a/examples/personal-community-sentiment-triage/scripts/autoheal/systemd/nemoclaw-slack-response-monitor.timer.in
+++ b/examples/personal-community-sentiment-triage/scripts/autoheal/systemd/nemoclaw-slack-response-monitor.timer.in
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+[Unit]
+Description=Run the NemoClaw Slack response monitor every minute
+
+[Timer]
+OnBootSec=3min
+OnUnitActiveSec=1min
+AccuracySec=10s
+Persistent=true
+Unit=nemoclaw-slack-response-monitor.service
+
+[Install]
+WantedBy=timers.target

--- a/examples/personal-community-sentiment-triage/scripts/autoheal/tests/test_slack_response_monitor.py
+++ b/examples/personal-community-sentiment-triage/scripts/autoheal/tests/test_slack_response_monitor.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).parents[1] / "slack-response-monitor.py"
+SPEC = importlib.util.spec_from_file_location("slack_response_monitor", MODULE_PATH)
+assert SPEC and SPEC.loader
+MONITOR = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MONITOR)
+
+
+class SlackResponseMonitorTest(unittest.TestCase):
+    def test_split_allowed_ids(self) -> None:
+        users, channels = MONITOR.split_allowed_ids("U123,D456,C789,W321,invalid")
+        self.assertEqual(users, ["U123", "W321"])
+        self.assertEqual(channels, ["D456", "C789"])
+
+    def test_classifies_transport_errors(self) -> None:
+        failures = MONITOR.classify_log_text("HTTP 503 inference service unavailable; Server disconnected; graph.microsoft.com:443 NET:FAIL")
+        self.assertEqual(failures, {"inference_proxy", "slack_gateway", "outlook_graph"})
+
+    def test_does_not_treat_normal_graph_traffic_as_a_failure(self) -> None:
+        self.assertEqual(MONITOR.classify_log_text("ALLOWED graph.microsoft.com:443 GET /v1.0/me"), set())
+
+    def test_cooldown(self) -> None:
+        self.assertFalse(MONITOR.should_remediate(100.0, 200.0, 300))
+        self.assertTrue(MONITOR.should_remediate(100.0, 400.0, 300))
+
+    def test_reads_quoted_environment_values(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / ".env"
+            path.write_text("SLACK_ALLOWED_IDS='U123,D456'\n# ignored\n")
+            self.assertEqual(MONITOR.read_env(path)["SLACK_ALLOWED_IDS"], "U123,D456")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/personal-community-sentiment-triage/scripts/autoheal/tests/test_slack_response_monitor.py
+++ b/examples/personal-community-sentiment-triage/scripts/autoheal/tests/test_slack_response_monitor.py
@@ -4,6 +4,7 @@
 import importlib.util
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
 
@@ -36,6 +37,11 @@ class SlackResponseMonitorTest(unittest.TestCase):
             path = Path(directory) / ".env"
             path.write_text("SLACK_ALLOWED_IDS='U123,D456'\n# ignored\n")
             self.assertEqual(MONITOR.read_env(path)["SLACK_ALLOWED_IDS"], "U123,D456")
+
+    def test_remediate_invokes_watchdog_with_bash(self) -> None:
+        with mock.patch.object(MONITOR.subprocess, "run") as run:
+            MONITOR.remediate("validation", dry_run=False)
+        run.assert_called_once_with(["bash", str(MONITOR.WATCHDOG)], check=False)
 
 
 if __name__ == "__main__":

--- a/examples/personal-community-sentiment-triage/scripts/autoheal/uninstall.sh
+++ b/examples/personal-community-sentiment-triage/scripts/autoheal/uninstall.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Remove only the optional user-level auto-heal services.
+
+set -euo pipefail
+case "${1:-}" in
+  "") ;;
+  -h|--help)
+    printf 'Usage: bash scripts/autoheal/uninstall.sh\n\nRemoves only the optional NemoClaw auto-heal user services.\n'
+    exit 0
+    ;;
+  *) printf 'Unknown option: %s\n' "$1" >&2; exit 2 ;;
+esac
+
+UNIT_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/nemoclaw-autoheal"
+units=(
+  nemoclaw-hermes-proxy.service
+  nemoclaw-hermes-gateway-forward.service
+  nemoclaw-hermes-watchdog.service
+  nemoclaw-hermes-watchdog.timer
+  nemoclaw-slack-response-monitor.service
+  nemoclaw-slack-response-monitor.timer
+)
+
+for unit in "${units[@]}"; do
+  systemctl --user disable --now "$unit" >/dev/null 2>&1 || true
+  rm -f "$UNIT_DIR/$unit"
+done
+systemctl --user daemon-reload
+rm -rf "$CONFIG_DIR"
+printf 'NemoClaw auto-heal user services were removed.\n'

--- a/examples/personal-community-sentiment-triage/scripts/autoheal/watchdog.sh
+++ b/examples/personal-community-sentiment-triage/scripts/autoheal/watchdog.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Recover the optional host services and Hermes gateway without printing secrets.
+
+set -euo pipefail
+AUTOHEAL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$AUTOHEAL_DIR/lib.sh"
+
+mkdir -p "$AUTOHEAL_STATE_DIR"
+exec 9>"$AUTOHEAL_STATE_DIR/watchdog.lock"
+flock -n 9 || exit 0
+
+gateway_has_allowlist() {
+  local container expected
+  container="$(sandbox_container)"
+  expected="${SLACK_ALLOWED_IDS:-}"
+  [[ -z "${SLACK_BOT_TOKEN:-}" ]] && return 0
+  # An empty configured allowlist intentionally enables Slack's allow-all mode.
+  [[ -z "$expected" ]] && return 0
+  [[ -n "$container" ]] || return 1
+  docker exec "$container" bash -lc '
+    pid="$(pgrep -f "hermes gateway run" | head -n1 || true)"
+    [ -n "$pid" ] || exit 1
+    tr "\0" "\n" < "/proc/$pid/environ" | grep -Fx "SLACK_ALLOWED_USERS='"$expected"'"
+  ' >/dev/null 2>&1
+}
+
+recent_log_match() {
+  local pattern="$1" container logs
+  container="$(sandbox_container)"
+  [[ -n "$container" ]] || return 1
+  logs="$(docker logs --since=15m --tail=5000 "$container" 2>&1 || true)"
+  grep -Eiq "$pattern" <<<"$logs"
+}
+
+slack_socket_ok() {
+  [[ -n "${SLACK_APP_TOKEN:-}" ]] || return 0
+  openshell sandbox exec --name "$AUTOHEAL_SANDBOX_NAME" -- bash -lc '
+    source /sandbox/.hermes-data/.env >/dev/null 2>&1 || source /sandbox/.hermes/.env >/dev/null 2>&1
+    body="$(curl -sS --max-time 12 -X POST -H "Authorization: Bearer ${SLACK_APP_TOKEN}" https://slack.com/api/apps.connections.open)" || exit 1
+    python3 -c "import json,sys; raise SystemExit(0 if json.loads(sys.argv[1]).get(\"ok\") else 1)" "$body"
+  ' >/dev/null 2>&1
+}
+
+outlook_graph_ok() {
+  [[ -n "${OUTLOOK_CLIENT_ID:-}" ]] || return 0
+  openshell sandbox exec --name "$AUTOHEAL_SANDBOX_NAME" -- bash -lc \
+    '/usr/bin/python3 /sandbox/.hermes-data/skills/outlook-email-search/scripts/search_emails.py --since 1d --top 1 >/dev/null' \
+    >/dev/null 2>&1
+}
+
+restart_gateway() {
+  local container
+  container="$(sandbox_container)"
+  [[ -n "$container" ]] || return 1
+  autoheal_log "restarting Hermes gateway in ${AUTOHEAL_SANDBOX_NAME}"
+  docker exec "$container" bash -lc '
+    set +e
+    pkill -f "[h]ermes gateway run" 2>/dev/null
+    pkill -f "[s]ocat TCP-LISTEN:8642" 2>/dev/null
+    pkill -f "[n]emo-relay --bind" 2>/dev/null
+    pkill -f "[o]utlook-bridge.py" 2>/dev/null
+    sleep 2
+    nohup /usr/local/bin/nemoclaw-start >/tmp/nemoclaw-autoheal-restart.log 2>&1 < /dev/null &
+  ' >/dev/null
+
+  for _ in $(seq 1 45); do
+    if sandbox_gateway_ok && gateway_has_allowlist; then
+      autoheal_log "Hermes gateway recovered"
+      return 0
+    fi
+    sleep 2
+  done
+  autoheal_log "Hermes gateway did not recover within 90 seconds"
+  return 1
+}
+
+recreate_sandbox() {
+  if ! cooldown_elapsed sandbox-recreate "$AUTOHEAL_RECREATE_COOLDOWN_SECS"; then
+    autoheal_log "sandbox recreation cooldown is active"
+    return 0
+  fi
+  autoheal_log "recreating ${AUTOHEAL_SANDBOX_NAME} after a confirmed sandbox egress failure"
+  set_state_timestamp sandbox-recreate
+  (
+    cd "$EXAMPLE_DIR"
+    openshell sandbox delete "$AUTOHEAL_SANDBOX_NAME" >/dev/null 2>&1 || true
+    SANDBOX_READY_TIMEOUT_SECS=900 bash scripts/03-sandbox.sh
+  )
+}
+
+main() {
+  local needs_gateway_restart=false
+
+  if proxy_is_configured && ! systemctl --user is-active --quiet nemoclaw-hermes-proxy.service; then
+    autoheal_log "starting configured host TLS proxy"
+    start_or_restart_unit nemoclaw-hermes-proxy.service || true
+  fi
+
+  if ! sandbox_ready; then
+    autoheal_log "sandbox ${AUTOHEAL_SANDBOX_NAME} is not Ready; waiting for normal bring-up"
+    return 0
+  fi
+
+  if ! sandbox_gateway_ok; then
+    autoheal_log "sandbox gateway health check failed"
+    needs_gateway_restart=true
+  fi
+  if ! gateway_has_allowlist; then
+    autoheal_log "Slack gateway allowlist is missing or incorrect"
+    needs_gateway_restart=true
+  fi
+
+  if recent_log_match 'ServerDisconnectedError|Server disconnected|NET:FAIL.*(slack\.com:443|apps\.connections\.open)|(slack\.com:443|apps\.connections\.open).*NET:FAIL'; then
+    if slack_socket_ok; then
+      autoheal_log "Slack gateway failure detected; Socket Mode is reachable"
+      needs_gateway_restart=true
+    else
+      recreate_sandbox
+      needs_gateway_restart=false
+    fi
+  fi
+
+  if recent_log_match 'NET:FAIL.*graph\.microsoft\.com:443|graph\.microsoft\.com:443.*NET:FAIL|Remote end closed connection without response'; then
+    if outlook_graph_ok; then
+      autoheal_log "Outlook bridge failure detected; Graph is reachable"
+      needs_gateway_restart=true
+    else
+      recreate_sandbox
+      needs_gateway_restart=false
+    fi
+  fi
+
+  if "$needs_gateway_restart"; then
+    restart_gateway || true
+  fi
+
+  if ! host_gateway_ok && sandbox_gateway_ok; then
+    autoheal_log "restoring the host gateway forward"
+    start_or_restart_unit nemoclaw-hermes-gateway-forward.service || true
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
## Description

this is for Personal Community sentiment triage, the systemd continuously monitors the proxy, Hermes gateway, and sandbox connectivity, automatically restarting components when failures are detected

## Verification

- [ ] `python scripts/check_license_headers.py --check`
- [ ] `git diff --check`
- [ ] Relevant example setup or syntax checks

## Release And Compliance

- [x] No secrets, local `.env` files, private certificates, snapshots, or token caches are included.
- [x] Third-party dependency changes are reflected in `THIRD-PARTY-NOTICES`.
- [x] Public documentation is free of internal-only links or private workspace details.
- [x] Commits include DCO sign-off (`git commit -s`).
