### PR TITLE
Fix retail headers and examples README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,14 @@ The examples in this repository demonstrate complete blueprint patterns: they sh
 
 ## Reference Examples
 
-Some examples are included in this repository. Others currently live in [brevdev/nemoclaw-demos](https://github.com/brevdev/nemoclaw-demos) and are candidates for future consolidation here.
+The table below lists examples maintained in this repository. Additional NemoClaw examples are available in [brevdev/nemoclaw-demos](https://github.com/brevdev/nemoclaw-demos).
 
 | Example | Description | Link |
 | ---- | ----------- | ---- |
 | Personal Community Sentiment Triage | Pairs a Hermes harness with an OpenShell sandbox and community-signal integrations across Slack, Outlook, live read-only GitHub REST, GitHub discussion mirrors, and NVIDIA forum mirrors. | [Guide](examples/personal-community-sentiment-triage/README.md) |
 | Hermes Brev Launchable | Provides a notebook path from a fresh Brev CPU instance to a working NemoClaw-managed Hermes sandbox, including installation, onboarding, API verification, and terminal access. | [Guide](examples/hermes-launchable/README.md) |
 | Harness Engineering Playground | A CLI dev tool (not an OpenShell blueprint) for automated, eval-driven harness profile improvement, with pluggable target-framework adapters and optimization techniques. | [Guide](examples/harness-engineering-playground/README.md) |
-| OpenClaw Omni Example | Sets up a NemoClaw sandbox with a Nemotron Omni vision sub-agent, including reference OpenClaw configuration, policy, agent instructions, and verification scripts. | [Guide](https://github.com/brevdev/nemoclaw-demos/blob/main/openclaw-omni-demo/README.md) |
-| Hermes Omni Example | Builds a local multimodal Hermes agent that can inspect video, audio, images, and PDFs through Nemotron Omni while running inside an OpenShell-constrained sandbox. | [Guide](https://github.com/brevdev/nemoclaw-demos/blob/main/hermes-omni-demo/hermes-omni-guide.md) |
-| Flight Tracking Example | Adds a live airspace console with real-time aircraft data, map controls, aviation overlays, and an agent skill that operates through host-side proxies. | [Guide](https://github.com/brevdev/nemoclaw-demos/blob/main/flight-tracking-demo/flight-tracking-guide.md) |
-| Google Workspace Integration | Connects a NemoClaw agent to Gmail, Calendar, Drive, Docs, Sheets, Contacts, and Tasks through a host-side credential flow and sandbox-deployed tools. | [Guide](https://github.com/brevdev/nemoclaw-demos/blob/main/google-workspace-demo/google-workspace-guide.md) |
-| Planet Integration | Gives the agent read-only access to Planet imagery workflows, including catalog search, thumbnails, tasking estimates, pass availability, and account quota checks. | [Guide](https://github.com/brevdev/nemoclaw-demos/blob/main/planet-integration-demo/planet-integration-guide.md) |
-| Wakeup Example | Adds a host-controlled schedule that wakes the sandboxed agent at fixed intervals to follow a task list without letting the agent control its own timer. | [Guide](https://github.com/brevdev/nemoclaw-demos/blob/main/wakeup-demo/nemoclaw-wakeup-guide.md) |
+| Retail Assistant | Deploys a Telegram-based retail management assistant that maps users to store roles, queries retail data through a FastAPI service, and runs the agent inside an OpenShell sandbox. | [Guide](examples/retail-assistant/README.md) |
 
 ## Getting Started
 
@@ -38,7 +33,7 @@ git clone https://github.com/NVIDIA/nemoclaw-community.git
 cd nemoclaw-community
 ```
 
-For other examples, follow the linked guide in `brevdev/nemoclaw-demos`. Each example documents its own host requirements, credentials, setup steps, and OpenShell policy details.
+For examples maintained outside this repository, see [brevdev/nemoclaw-demos](https://github.com/brevdev/nemoclaw-demos). Each example documents its own host requirements, credentials, setup steps, and OpenShell policy details.
 
 ## Requirements
 

--- a/examples/retail-assistant/docker-compose/api/Dockerfile
+++ b/examples/retail-assistant/docker-compose/api/Dockerfile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 FROM python:3.12-slim
 
 WORKDIR /app

--- a/examples/retail-assistant/docker-compose/api/main.py
+++ b/examples/retail-assistant/docker-compose/api/main.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 NemoClaw Retail API
 -------------------

--- a/examples/retail-assistant/docker-compose/api/test_api.py
+++ b/examples/retail-assistant/docker-compose/api/test_api.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 NemoClaw Retail API — Integration Tests
 Runs against the live stack (retail_database + retail_api containers must be up).

--- a/examples/retail-assistant/docker-compose/docker-compose.yaml
+++ b/examples/retail-assistant/docker-compose/docker-compose.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 services:
   # ─── 1. PostgreSQL ──────────────────────────────────────────
   retail_database:

--- a/examples/retail-assistant/docker-compose/scripts/init/patch-openclaw.py
+++ b/examples/retail-assistant/docker-compose/scripts/init/patch-openclaw.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import json, hashlib, os, time, base64
 
 p   = '/sandbox/.openclaw/openclaw.json'

--- a/examples/retail-assistant/docker-compose/scripts/init/patch-sandboxes.js
+++ b/examples/retail-assistant/docker-compose/scripts/init/patch-sandboxes.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 const fs = require('fs');
 const crypto = require('crypto');
 const p = '/root/.nemoclaw/sandboxes.json';

--- a/examples/retail-assistant/docker-compose/scripts/init/seed.sh
+++ b/examples/retail-assistant/docker-compose/scripts/init/seed.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
 # ─── Database seed script ──────────────────────────────────────
 # Runs inside a postgres:17.3 container connected to retail_database.
 # Loads CSV data in FK-safe order with an idempotency guard.

--- a/examples/retail-assistant/docker-compose/scripts/init/startup.sh
+++ b/examples/retail-assistant/docker-compose/scripts/init/startup.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
 # NOTE: no "set -e" — the NemoClaw installer emits transient errors
 # (connection refused) during the gateway boot race. We handle errors
 # explicitly where needed.

--- a/examples/retail-assistant/docker-compose/scripts/policies/policy.yaml
+++ b/examples/retail-assistant/docker-compose/scripts/policies/policy.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1
 filesystem_policy:
   include_workdir: true

--- a/examples/retail-assistant/docker-compose/scripts/skills/retail-api/scripts/retail-api.js
+++ b/examples/retail-assistant/docker-compose/scripts/skills/retail-api/scripts/retail-api.js
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
 /**
  * retail-api.js — CLI wrapper for the Araz Retail API.
  *

--- a/examples/retail-assistant/helm/Chart.yaml
+++ b/examples/retail-assistant/helm/Chart.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v2
 name: nemoclaw
 description: A deployment for Nvidia Nemoclaw

--- a/examples/retail-assistant/helm/files/init/patch-openclaw.js
+++ b/examples/retail-assistant/helm/files/init/patch-openclaw.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 const fs = require('fs');
 const crypto = require('crypto');
 const p = '/sandbox/.openclaw/openclaw.json';

--- a/examples/retail-assistant/helm/files/init/patch-openclaw.py
+++ b/examples/retail-assistant/helm/files/init/patch-openclaw.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import json, hashlib, os, time, base64
 
 p   = '/sandbox/.openclaw/openclaw.json'

--- a/examples/retail-assistant/helm/files/init/patch-sandboxes.js
+++ b/examples/retail-assistant/helm/files/init/patch-sandboxes.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 const fs = require('fs');
 const crypto = require('crypto');
 const p = '/root/.nemoclaw/sandboxes.json';

--- a/examples/retail-assistant/helm/files/init/tcp-relay.py
+++ b/examples/retail-assistant/helm/files/init/tcp-relay.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import socket, threading
 def relay(src, dst):
     try:

--- a/examples/retail-assistant/helm/files/policies/retail-api-policy.yaml
+++ b/examples/retail-assistant/helm/files/policies/retail-api-policy.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 version: 1
 filesystem_policy:
   include_workdir: true

--- a/examples/retail-assistant/helm/files/skills/retail-api/scripts/retail-api.js
+++ b/examples/retail-assistant/helm/files/skills/retail-api/scripts/retail-api.js
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
 /**
  * retail-api.js — CLI wrapper for the Araz Retail API.
  *

--- a/examples/retail-assistant/helm/templates/nemoclaw-deployment.yaml
+++ b/examples/retail-assistant/helm/templates/nemoclaw-deployment.yaml
@@ -1,4 +1,7 @@
 ---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
 # NemoClaw on Kubernetes — Deployment
 # Uses official installer with Docker-in-Docker for sandbox isolation.
 # Prerequisites: kubectl create namespace nemoclaw

--- a/examples/retail-assistant/helm/templates/nemoclaw-ingress.yaml
+++ b/examples/retail-assistant/helm/templates/nemoclaw-ingress.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.ingress.enabled }}
 ---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/examples/retail-assistant/helm/templates/nemoclaw-service.yaml
+++ b/examples/retail-assistant/helm/templates/nemoclaw-service.yaml
@@ -1,4 +1,7 @@
 ---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/examples/retail-assistant/helm/templates/postgres-configmap.yaml
+++ b/examples/retail-assistant/helm/templates/postgres-configmap.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.postgres.enabled }}
 ---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/examples/retail-assistant/helm/templates/postgres-seed-configmap.yaml
+++ b/examples/retail-assistant/helm/templates/postgres-seed-configmap.yaml
@@ -1,4 +1,7 @@
 {{- if and .Values.postgres.enabled .Values.postgres.seedEnabled }}
+---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/examples/retail-assistant/helm/templates/postgres-seed-job.yaml
+++ b/examples/retail-assistant/helm/templates/postgres-seed-job.yaml
@@ -1,4 +1,7 @@
 {{- if and .Values.postgres.enabled .Values.postgres.seedEnabled }}
+---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/examples/retail-assistant/helm/templates/postgres.yaml
+++ b/examples/retail-assistant/helm/templates/postgres.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.postgres.enabled }}
 ---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 # PersistentVolumeClaim for Postgres data.
 # NOTE: init.sql only runs when this PVC is empty (first Postgres start).
 # To reinitialize the database, delete this PVC and re-deploy.

--- a/examples/retail-assistant/helm/templates/retail-api.yaml
+++ b/examples/retail-assistant/helm/templates/retail-api.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.retailApi.enabled }}
 ---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 # Retail API — FastAPI application with JWT auth and PostgreSQL-level RBAC.
 # Build the image from nvidia-hackathon-team4/api/ and set retailApi.image in values.yaml:
 #   docker build -t <your-registry>/retail-api:latest nvidia-hackathon-team4/api/

--- a/examples/retail-assistant/helm/templates/startup-configmap.yaml
+++ b/examples/retail-assistant/helm/templates/startup-configmap.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/examples/retail-assistant/helm/templates/telegram-secret.yaml
+++ b/examples/retail-assistant/helm/templates/telegram-secret.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.telegram.enabled }}
 ---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 # Secret holding the Telegram Bot Token.
 # The raw token is never exposed as a plain env var in the pod spec;
 # it is mounted via secretKeyRef so it only appears inside the container.

--- a/examples/retail-assistant/helm/values.yaml
+++ b/examples/retail-assistant/helm/values.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 workspace:
     openaiBaseUrl: "http://ip:port/v1"
     socatInferencePort: 8000


### PR DESCRIPTION
## Summary
- Add SPDX headers to retail assistant source, config, Docker, and Helm files covered by the license checker
- Refactor the root README examples table to enumerate only examples in this repository
- Refer readers to brevdev/nemoclaw-demos with a single link for other NemoClaw examples

## Verification
- python3 scripts/check_license_headers.py --check
- git diff --check
- helm lint examples/retail-assistant/helm
- helm template retail examples/retail-assistant/helm >/tmp/retail-helm-render.yaml