### PR TITLE
fix(sentiment-triage): pass GITHUB_TOKEN to nemo-relay-cli builder stage

### DIFF
--- a/examples/personal-community-sentiment-triage/agents/hermes/Dockerfile
+++ b/examples/personal-community-sentiment-triage/agents/hermes/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.7
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -20,18 +21,19 @@ ARG BASE_IMAGE=ghcr.io/nvidia/nemoclaw/hermes-sandbox-base@sha256:f76a2ed0509570
 # unconditionally via the cli crate's `object-store` feature.
 FROM ${BASE_IMAGE} AS nemo-relay-builder
 ARG NEMO_RELAY_CLI_VERSION=0.3.0
-# Authenticated GitHub API for cargo-binstall (avoids anonymous rate-limit 403
-# on shared egress IPs). Builder stage only; never reaches the final image.
-ARG GITHUB_TOKEN=
 # PATH includes cargo's bin dir so the install script's --self-install step
 # finds it (silences its cosmetic "path is missing /root/.cargo/bin" warning)
 # and cargo-binstall resolves by name on the next line.
-RUN export PATH="/root/.cargo/bin:$PATH" \
+RUN --mount=type=secret,id=github_token,required=false \
+    export PATH="/root/.cargo/bin:$PATH" \
     && apt-get update -qq \
     && apt-get install -y --no-install-recommends ca-certificates curl \
     && rm -rf /var/lib/apt/lists/* \
     && curl -L --proto '=https' --tlsv1.2 -sSf \
        https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash \
+    && if [ -s /run/secrets/github_token ]; then \
+         export GITHUB_TOKEN="$(cat /run/secrets/github_token)"; \
+       fi \
     && cargo-binstall --no-confirm --strategies crate-meta-data \
        --install-path /out/bin "nemo-relay-cli@${NEMO_RELAY_CLI_VERSION}"
 # --strategies crate-meta-data: only resolve the crate's own [metadata.binstall]

--- a/examples/personal-community-sentiment-triage/agents/hermes/Dockerfile
+++ b/examples/personal-community-sentiment-triage/agents/hermes/Dockerfile
@@ -20,6 +20,9 @@ ARG BASE_IMAGE=ghcr.io/nvidia/nemoclaw/hermes-sandbox-base@sha256:f76a2ed0509570
 # unconditionally via the cli crate's `object-store` feature.
 FROM ${BASE_IMAGE} AS nemo-relay-builder
 ARG NEMO_RELAY_CLI_VERSION=0.3.0
+# Authenticated GitHub API for cargo-binstall (avoids anonymous rate-limit 403
+# on shared egress IPs). Builder stage only; never reaches the final image.
+ARG GITHUB_TOKEN=
 # PATH includes cargo's bin dir so the install script's --self-install step
 # finds it (silences its cosmetic "path is missing /root/.cargo/bin" warning)
 # and cargo-binstall resolves by name on the next line.

--- a/examples/personal-community-sentiment-triage/scripts/03-sandbox.sh
+++ b/examples/personal-community-sentiment-triage/scripts/03-sandbox.sh
@@ -72,7 +72,6 @@ declare -A DOCKERFILE_ARGS=(
   [NEMOCLAW_BUILD_ID]="$(date +%s)"
 )
 # Optional patches — leave the Dockerfile default in place if unset.
-[[ -n "${GITHUB_TOKEN:-}" ]] && DOCKERFILE_ARGS[GITHUB_TOKEN]="$GITHUB_TOKEN"
 [[ -n "${NEMOCLAW_MODEL:-}" ]] && DOCKERFILE_ARGS[NEMOCLAW_MODEL]="$NEMOCLAW_MODEL"
 if [[ -n "${PHOENIX_COLLECTOR_ENDPOINT:-}" ]]; then
   echo "Phoenix endpoint: $PHOENIX_COLLECTOR_ENDPOINT — enabling OpenInference egress"
@@ -103,6 +102,24 @@ for arg in "${!DOCKERFILE_ARGS[@]}"; do
   sed -i -e "s|^ARG ${arg}=.*|ARG ${arg}=${value}|" "$STAGED_DOCKERFILE"
 done
 
+BUILD_FROM="$STAGED_DOCKERFILE"
+if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+  command -v docker >/dev/null || {
+    echo "docker not in PATH; required for authenticated sandbox image build" >&2
+    exit 1
+  }
+  safe_sandbox_name="$(printf '%s' "$SANDBOX_NAME" \
+    | tr '[:upper:]' '[:lower:]' \
+    | tr -c 'a-z0-9_.-' '-')"
+  BUILD_FROM="nemoclaw-hermes-sandbox:${safe_sandbox_name}-${DOCKERFILE_ARGS[NEMOCLAW_BUILD_ID]}"
+  echo "Building sandbox image $BUILD_FROM with BuildKit secret-backed GitHub authentication"
+  DOCKER_BUILDKIT=1 GITHUB_TOKEN="$GITHUB_TOKEN" docker build \
+    --secret id=github_token,env=GITHUB_TOKEN \
+    -t "$BUILD_FROM" \
+    -f "$STAGED_DOCKERFILE" \
+    "$EXAMPLE_DIR"
+fi
+
 # ── Stage policy and patch per-run repo scope ───────────────────────────
 cp "$EXAMPLE_DIR/policy.yaml" "$STAGED_POLICY"
 sed -i \
@@ -132,9 +149,9 @@ atif_remote_enabled && PROVIDER_FLAGS+=(--provider "$SANDBOX_NAME-atif-export-re
 # SIGTERM. If `pgrep -af openshell | grep -v grep` is empty after this
 # script returns on 0.0.50+, the bug is fixed and the `setsid` wrapper +
 # SIGKILL backstop below can be simplified to plain `&` + `kill -TERM $PID`.
-echo "Creating sandbox $SANDBOX_NAME (OpenShell will build the image)…"
+echo "Creating sandbox $SANDBOX_NAME from $BUILD_FROM…"
 setsid openshell sandbox create \
-  --from "$STAGED_DOCKERFILE" \
+  --from "$BUILD_FROM" \
   --name "$SANDBOX_NAME" \
   --policy "$STAGED_POLICY" \
   "${PROVIDER_FLAGS[@]}" \

--- a/examples/personal-community-sentiment-triage/scripts/03-sandbox.sh
+++ b/examples/personal-community-sentiment-triage/scripts/03-sandbox.sh
@@ -72,6 +72,7 @@ declare -A DOCKERFILE_ARGS=(
   [NEMOCLAW_BUILD_ID]="$(date +%s)"
 )
 # Optional patches — leave the Dockerfile default in place if unset.
+[[ -n "${GITHUB_TOKEN:-}" ]] && DOCKERFILE_ARGS[GITHUB_TOKEN]="$GITHUB_TOKEN"
 [[ -n "${NEMOCLAW_MODEL:-}" ]] && DOCKERFILE_ARGS[NEMOCLAW_MODEL]="$NEMOCLAW_MODEL"
 if [[ -n "${PHOENIX_COLLECTOR_ENDPOINT:-}" ]]; then
   echo "Phoenix endpoint: $PHOENIX_COLLECTOR_ENDPOINT — enabling OpenInference egress"


### PR DESCRIPTION
**Problem**

The first sandbox build fails on any fresh Omnistation install. The nemo-relay-builder stage installs nemo-relay-cli via cargo-binstall, which resolves the release through anonymous api.github.com calls. On a shared AWS egress IP those calls hit the 60 req/hr anonymous rate limit (403); the cargo-install fallback is disabled by design, so the build dies with exit 94 after several 120-second retries.

**Fix (4 lines)**

- `agents/hermes/Dockerfile`: optional `ARG GITHUB_TOKEN=` in the nemo-relay-builder stage. cargo-binstall reads it from the environment and gets the authenticated 5000 req/hr limit.
- `scripts/03-sandbox.sh`: wire the token from `.env` through the existing `DOCKERFILE_ARGS` map, same pattern as the other optional args.

The token only enters the throwaway builder stage, never the final sandbox image. With `GITHUB_TOKEN` unset, behavior is unchanged.

**Testing**

Three sandbox builds on a NemoClaw Omnistation with this patch, all passing the previously-failing step; one build without the token reproducing the original 403/exit-94 failure. Found during enterprise alpha testing; details in my setup-feedback doc (shared with the team), where @slopp requested this PR.