### PR TITLE
fix(personal-community-sentiment-triage): update to NemoClaw Hermes 0.18 base

### DIFF
--- a/examples/personal-community-sentiment-triage/README.md
+++ b/examples/personal-community-sentiment-triage/README.md
@@ -197,8 +197,11 @@ itself). The session UUID for Outlook gets produced *between* them, so the order
 
 ```console
 $ git clone https://github.com/NVIDIA/nemoclaw-community.git && cd examples/personal-community-sentiment-triage/
-$ curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | OPENSHELL_VERSION=v0.0.53 sh
+$ curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | OPENSHELL_VERSION=v0.0.72 sh
 ```
+
+OpenShell `v0.0.72` matches the supported version in the NemoClaw `v0.0.82`
+release that publishes this example's pinned Hermes sandbox base image.
 
 The package-managed installer starts a local gateway service for you. This
 example assumes that default path and targets the `openshell` gateway at
@@ -346,11 +349,12 @@ The example's Dockerfile drops the upstream `COPY nemoclaw-blueprint/` step —
 nothing in the Hermes runtime reads `/sandbox/.nemoclaw/blueprints/`, so this
 example is **fully self-contained** and never needs a NemoClaw checkout.
 
-The Dockerfile always installs NeMo-Relay: it fetches the pinned, prebuilt
-`nemo-relay-cli` release in a builder stage, upgrades Hermes to a version with
-rich plugin hook payloads, and runs a sidecar gateway at startup. That is
-enough for the agent to write ATIF trace records to `/tmp/atif/` — capture
-them with [`scripts/download-traces.sh`](scripts/download-traces.sh).
+The Dockerfile inherits Hermes from the pinned NemoClaw Hermes sandbox base
+image, fetches the pinned, prebuilt `nemo-relay-cli` release in a builder stage,
+and runs a sidecar gateway at startup. The pinned base is published by NemoClaw
+and includes a Hermes version with rich plugin hook payloads. That is enough for
+the agent to write ATIF trace records to `/tmp/atif/` — capture them with
+[`scripts/download-traces.sh`](scripts/download-traces.sh).
 
 Setting `PHOENIX_COLLECTOR_ENDPOINT` is a separate opt-in for live
 OpenInference egress: when present, `03-sandbox.sh` bakes the URL into the

--- a/examples/personal-community-sentiment-triage/agents/hermes/Dockerfile
+++ b/examples/personal-community-sentiment-triage/agents/hermes/Dockerfile
@@ -9,7 +9,9 @@
 
 # ARGs that appear in FROM instructions must be declared before the first FROM
 # so Docker treats them as global build args (multi-stage scoping rule).
-ARG BASE_IMAGE=ghcr.io/nvidia/nemoclaw/hermes-sandbox-base@sha256:f76a2ed0509570b1ce5380327c7ebe2e120e97f524e9271e145d2ea34c83ba5e
+# Published by NVIDIA/NemoClaw v0.0.82. This base includes Hermes
+# v2026.7.1 (0.18.0), so this example does not reinstall Hermes separately.
+ARG BASE_IMAGE=ghcr.io/nvidia/nemoclaw/hermes-sandbox-base@sha256:fa05221f5c7bcafea7e263c84e5d06f87e37d1ccb78dc28c113f1a4066aa544c
 
 # ── Stage 0: fetch the pinned, prebuilt nemo-relay CLI (no source build) ──────
 # Upstream publishes musl-static CLI release assets (zero glibc linkage), so the
@@ -99,59 +101,6 @@ RUN mkdir -p /etc/apt/keyrings \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install --no-cache-dir --break-system-packages "httpx>=0.27" "markdown-it-py>=3" "aiohttp>=3.10,<4" "aiofiles>=23.2,<25"
-
-# ── Upgrade Hermes from base image's v0.11.0 to v0.14.0 ─────────────────
-# NemoClaw's base image (even at its latest tag) pins HERMES_VERSION=v2026.4.23
-# (Hermes v0.11.0). v0.11.0's plugin hooks ship metadata-only kwargs to
-# pre_api_request / post_api_request — no real messages, no real response —
-# so observability backends (Langfuse, NeMo-Relay's hermes adapter) cannot
-# emit LLM spans with full content. v0.14.0 (v2026.5.16, "The Foundation
-# Release") adds rich-kwargs hook delivery and ships the bundled Langfuse
-# plugin that depends on it.
-#
-# We mirror NemoClaw's tarball + uv-sync install pattern, but for a newer
-# version. /opt/hermes/.venv is preserved across the upgrade so uv can
-# incrementally reconcile dependencies against v0.14.0's uv.lock.
-ARG HERMES_UPGRADE_VERSION=v2026.5.16
-ARG HERMES_UPGRADE_TARBALL_SHA256=c0a554050a50ee9a62f3fa5cd288a167ba5640c42d647d100cdea084b7294143
-# messaging: slack-bolt + slack-sdk + aiohttp (and friends) for the Slack
-#   platform path.
-# web: fastapi + uvicorn for Hermes's web tools.
-# cli: simple-term-menu, used by `hermes chat` TUI menus. Without this the
-#   TUI banner path can try to lazy-install at runtime, which the
-#   locked-down sandbox can't satisfy.
-# edge-tts: edge-tts==7.2.7. The TTS check_fn fires during banner
-#   enumeration regardless of toolset config; pre-installing avoids the
-#   PyPI fetch attempt at runtime. HERMES_DISABLE_LAZY_INSTALLS=1 (set
-#   below + in start.sh) is the belt-and-suspenders fallback for any
-#   other lazy feature we haven't pre-installed.
-ARG HERMES_UV_EXTRAS="messaging web cli edge-tts"
-# Match the uv version NemoClaw uses for the base-image install.
-ARG UV_INSTALL_VERSION=0.11.8
-
-USER root
-RUN set -eu \
-    && curl -LsSf "https://astral.sh/uv/${UV_INSTALL_VERSION}/install.sh" \
-       | env INSTALLER_NO_MODIFY_PATH=1 sh \
-    && UV_BIN="" \
-    && for candidate in /root/.local/bin/uv /root/.cargo/bin/uv /usr/local/bin/uv; do \
-         if [ -x "$candidate" ]; then UV_BIN="$candidate"; break; fi; \
-       done \
-    && if [ -z "$UV_BIN" ]; then echo "uv installer did not produce a binary in any known location" >&2; exit 1; fi \
-    && install -m 755 "$UV_BIN" /usr/local/bin/uv \
-    && /usr/local/bin/uv --version \
-    && curl -fsSL "https://github.com/NousResearch/hermes-agent/archive/refs/tags/${HERMES_UPGRADE_VERSION}.tar.gz" \
-       -o /tmp/hermes.tgz \
-    && echo "${HERMES_UPGRADE_TARBALL_SHA256}  /tmp/hermes.tgz" | sha256sum -c - \
-    && find /opt/hermes -mindepth 1 -maxdepth 1 -not -name '.venv' -exec rm -rf {} + \
-    && tar -xzf /tmp/hermes.tgz -C /opt/hermes --strip-components=1 \
-    && rm /tmp/hermes.tgz \
-    && cd /opt/hermes \
-    && extras_args="" \
-    && for e in ${HERMES_UV_EXTRAS}; do extras_args="${extras_args} --extra ${e}"; done \
-    && UV_PROJECT_ENVIRONMENT=/opt/hermes/.venv /usr/local/bin/uv sync \
-       ${extras_args} --no-dev \
-    && chown -R sandbox:sandbox /opt/hermes
 
 # ── NeMo-Relay 0.3.0 sidecar gateway integration ─────────────────────────
 # Hermes stays unpatched (from BASE_IMAGE). start.sh launches a long-running

--- a/examples/personal-community-sentiment-triage/agents/hermes/patches/sitecustomize.py
+++ b/examples/personal-community-sentiment-triage/agents/hermes/patches/sitecustomize.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 """Patch Hermes's Slack adapter with a catch-all slash-command handler.
 
-Hermes registers only `/hermes` as its bolt command. Workspace-specific names
+Hermes registers its known slash commands with Bolt. Workspace-specific names
 (e.g. `/my-assistant`) produce an `Unhandled request` warning and no user
-feedback. This module patches `SlackAdapter.connect` so any other slash
-command gets a friendly "I don't recognize this" reply.
+feedback. This module patches `SlackAdapter.connect` so any other slash command
+gets a friendly "I don't recognize this" reply.
 
 Auto-loaded by Python's site initialization — the Dockerfile symlinks this
 file into the system site-packages dir, and start.sh prepends the patches
@@ -18,13 +18,22 @@ import re
 
 def _patch_slack_commands() -> None:
     try:
-        from gateway.platforms.slack import SlackAdapter
+        try:
+            # Hermes 0.18+ ships Slack as a bundled platform plugin.
+            from plugins.platforms.slack.adapter import SlackAdapter
+        except ImportError:
+            # Keep compatibility with older NemoClaw Hermes base images.
+            from gateway.platforms.slack import SlackAdapter
+
         _orig_connect = SlackAdapter.connect
 
-        async def _patched_connect(self):
-            result = await _orig_connect(self)
-            if getattr(self, "_app", None) is not None:
-                @self._app.command(re.compile(".+"))
+        async def _patched_connect(self, *args, **kwargs):
+            result = await _orig_connect(self, *args, **kwargs)
+            app = getattr(self, "_app", None)
+            if app is not None and getattr(
+                self, "_nemoclaw_unknown_command_app", None
+            ) is not app:
+                @app.command(re.compile(".+"))
                 async def _handle_unknown_command(ack, command, respond):
                     await ack()
                     cmd = command.get("command", "this command")
@@ -32,6 +41,8 @@ def _patch_slack_commands() -> None:
                         f"I don't recognize `{cmd}`. "
                         "Send me a *direct message* or @mention me to chat"
                     )
+
+                self._nemoclaw_unknown_command_app = app
             return result
 
         SlackAdapter.connect = _patched_connect


### PR DESCRIPTION
## Summary

- Update the pinned NemoClaw Hermes sandbox base to the image published with NemoClaw v0.0.82.
- Inherit Hermes v2026.7.1 (0.18.0) directly from that base.
- Remove the redundant Hermes v0.14.0 installation from the community example.
- Update the documented OpenShell prerequisite from v0.0.53 to v0.0.72.
- Support Hermes 0.18’s plugin-based Slack adapter and reconnect lifecycle.

## Why

Hermes is now maintained as part of NemoClaw core and included in its published Hermes sandbox base image. This community example was still using an older base and independently replacing Hermes during the image build.

That split ownership made the example harder to maintain and prevented it from automatically using the Hermes version validated and released by NemoClaw.

This change makes the NemoClaw base image the single source of truth while preserving the example’s NeMo Relay, Slack, Outlook, tracing, and skill customizations.

## Validation

- Verified the image digest against NemoClaw v0.0.82.
- Verified the base contains Hermes v2026.7.1 / 0.18.0.
- Verified NemoClaw v0.0.82’s supported OpenShell version is 0.0.72.
- Compiled the updated Python compatibility shim.
- Exercised both the Hermes 0.18 and legacy Slack import paths.
- Exercised reconnect argument forwarding and duplicate-handler prevention.
- Ran `git diff --check`.