### PR TITLE
feat(personal-community-sentiment-triage): add opt-in Slack rich blocks

### DIFF
--- a/examples/personal-community-sentiment-triage/.env.example
+++ b/examples/personal-community-sentiment-triage/.env.example
@@ -59,6 +59,9 @@ OUTLOOK_ALLOWED_SENDERS=
 SLACK_BOT_TOKEN=
 SLACK_APP_TOKEN=
 SLACK_ALLOWED_IDS=
+# Optional native Slack Block Kit rendering for supported Markdown, including
+# tables. Accepted values are exactly true or false. Default: false.
+NEMOCLAW_SLACK_RICH_BLOCKS=false
 
 # ── GitHub (live read-only REST) ─────────────────────────────────────────
 # Resolved by the proxy on egress; policy.yaml constrains usage to read-only

--- a/examples/personal-community-sentiment-triage/README.md
+++ b/examples/personal-community-sentiment-triage/README.md
@@ -263,6 +263,7 @@ Now edit `.env` and fill in everything you already have:
     - `OUTLOOK_TARGET_MAILBOX`, `OUTLOOK_REPLY_TO` — the agent's mailbox and your personal mailbox
   - **Slack**: `SLACK_BOT_TOKEN` / `SLACK_APP_TOKEN` (both required) — see [docs/set-up-slack.md](docs/set-up-slack.md). Partial Outlook configuration (some vars set, some empty) is rejected at bring-up.
 - (optional) `SLACK_ALLOWED_IDS` — comma-separated Slack user IDs to restrict who can DM the agent; leave empty to allow anyone in the workspace
+- (optional) `NEMOCLAW_SLACK_RICH_BLOCKS=true` — render supported Markdown, including tables, with native Slack Block Kit. The default is `false`.
 - (optional) `OUTLOOK_ALLOWED_SENDERS` — comma-separated allowlist of email senders the agent will respond to; leave empty to fall back to OUTLOOK_REPLY_TO
 - (optional) `GITHUB_TOKEN` for authenticated sandbox read-only
   GitHub REST, `GITHUB_READONLY_REPO`,
@@ -507,6 +508,7 @@ unless you remove the compose volumes.
 | `OPENSHELL_GATEWAY` | `openshell` | Gateway name. The default matches the package-managed OpenShell installer. Use `snap-docker` when following the snap setup. |
 | `OPENSHELL_GATEWAY_ENDPOINT` | auto (`https://127.0.0.1:17670` for `openshell`, `http://127.0.0.1:17670` for `snap-docker`) | Override the local gateway endpoint if you registered it under a different URL. |
 | `NEMOCLAW_MODEL` | `nvidia/nemotron-3-super-120b-a12b` | Inference model passed to `openshell inference set`. |
+| `NEMOCLAW_SLACK_RICH_BLOCKS` | `false` | Set to `true` to render supported Markdown with Hermes's native Slack Block Kit renderer, including table blocks. Only `true` or `false` is accepted. Rebuild the sandbox after changing it. |
 | `NEMOCLAW_ENDPOINT_URL` | `https://integrate.api.nvidia.com/v1` | Upstream base URL for the `compatible-endpoint` provider. (`OPENAI_BASE_URL` is also accepted as a fallback.) |
 | `NEMOCLAW_HOST_TLS_PROXY_UPSTREAM` | (none) | Optional HTTPS origin for the host TLS proxy. Required when `NEMOCLAW_ENDPOINT_URL` uses `host.openshell.internal:18080` and auto-heal should manage that proxy. |
 | `NEMOCLAW_HOST_TLS_PROXY_PORT` | `18080` | Host listener port for the optional TLS proxy. |

--- a/examples/personal-community-sentiment-triage/README.md
+++ b/examples/personal-community-sentiment-triage/README.md
@@ -197,8 +197,11 @@ itself). The session UUID for Outlook gets produced *between* them, so the order
 
 ```console
 $ git clone https://github.com/NVIDIA/nemoclaw-community.git && cd examples/personal-community-sentiment-triage/
-$ curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | OPENSHELL_VERSION=v0.0.53 sh
+$ curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | OPENSHELL_VERSION=v0.0.72 sh
 ```
+
+OpenShell `v0.0.72` matches the supported version in the NemoClaw `v0.0.82`
+release that publishes this example's pinned Hermes sandbox base image.
 
 The package-managed installer starts a local gateway service for you. This
 example assumes that default path and targets the `openshell` gateway at
@@ -346,11 +349,12 @@ The example's Dockerfile drops the upstream `COPY nemoclaw-blueprint/` step —
 nothing in the Hermes runtime reads `/sandbox/.nemoclaw/blueprints/`, so this
 example is **fully self-contained** and never needs a NemoClaw checkout.
 
-The Dockerfile always installs NeMo-Relay: it fetches the pinned, prebuilt
-`nemo-relay-cli` release in a builder stage, upgrades Hermes to a version with
-rich plugin hook payloads, and runs a sidecar gateway at startup. That is
-enough for the agent to write ATIF trace records to `/tmp/atif/` — capture
-them with [`scripts/download-traces.sh`](scripts/download-traces.sh).
+The Dockerfile inherits Hermes from the pinned NemoClaw Hermes sandbox base
+image, fetches the pinned, prebuilt `nemo-relay-cli` release in a builder stage,
+and runs a sidecar gateway at startup. The pinned base is published by NemoClaw
+and includes a Hermes version with rich plugin hook payloads. That is enough for
+the agent to write ATIF trace records to `/tmp/atif/` — capture them with
+[`scripts/download-traces.sh`](scripts/download-traces.sh).
 
 Setting `PHOENIX_COLLECTOR_ENDPOINT` is a separate opt-in for live
 OpenInference egress: when present, `03-sandbox.sh` bakes the URL into the

--- a/examples/personal-community-sentiment-triage/agents/hermes/Dockerfile
+++ b/examples/personal-community-sentiment-triage/agents/hermes/Dockerfile
@@ -9,7 +9,9 @@
 
 # ARGs that appear in FROM instructions must be declared before the first FROM
 # so Docker treats them as global build args (multi-stage scoping rule).
-ARG BASE_IMAGE=ghcr.io/nvidia/nemoclaw/hermes-sandbox-base@sha256:f76a2ed0509570b1ce5380327c7ebe2e120e97f524e9271e145d2ea34c83ba5e
+# Published by NVIDIA/NemoClaw v0.0.82. This base includes Hermes
+# v2026.7.1 (0.18.0), so this example does not reinstall Hermes separately.
+ARG BASE_IMAGE=ghcr.io/nvidia/nemoclaw/hermes-sandbox-base@sha256:fa05221f5c7bcafea7e263c84e5d06f87e37d1ccb78dc28c113f1a4066aa544c
 
 # ── Stage 0: fetch the pinned, prebuilt nemo-relay CLI (no source build) ──────
 # Upstream publishes musl-static CLI release assets (zero glibc linkage), so the
@@ -99,59 +101,6 @@ RUN mkdir -p /etc/apt/keyrings \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install --no-cache-dir --break-system-packages "httpx>=0.27" "markdown-it-py>=3" "aiohttp>=3.10,<4" "aiofiles>=23.2,<25"
-
-# ── Upgrade Hermes from base image's v0.11.0 to v0.14.0 ─────────────────
-# NemoClaw's base image (even at its latest tag) pins HERMES_VERSION=v2026.4.23
-# (Hermes v0.11.0). v0.11.0's plugin hooks ship metadata-only kwargs to
-# pre_api_request / post_api_request — no real messages, no real response —
-# so observability backends (Langfuse, NeMo-Relay's hermes adapter) cannot
-# emit LLM spans with full content. v0.14.0 (v2026.5.16, "The Foundation
-# Release") adds rich-kwargs hook delivery and ships the bundled Langfuse
-# plugin that depends on it.
-#
-# We mirror NemoClaw's tarball + uv-sync install pattern, but for a newer
-# version. /opt/hermes/.venv is preserved across the upgrade so uv can
-# incrementally reconcile dependencies against v0.14.0's uv.lock.
-ARG HERMES_UPGRADE_VERSION=v2026.5.16
-ARG HERMES_UPGRADE_TARBALL_SHA256=c0a554050a50ee9a62f3fa5cd288a167ba5640c42d647d100cdea084b7294143
-# messaging: slack-bolt + slack-sdk + aiohttp (and friends) for the Slack
-#   platform path.
-# web: fastapi + uvicorn for Hermes's web tools.
-# cli: simple-term-menu, used by `hermes chat` TUI menus. Without this the
-#   TUI banner path can try to lazy-install at runtime, which the
-#   locked-down sandbox can't satisfy.
-# edge-tts: edge-tts==7.2.7. The TTS check_fn fires during banner
-#   enumeration regardless of toolset config; pre-installing avoids the
-#   PyPI fetch attempt at runtime. HERMES_DISABLE_LAZY_INSTALLS=1 (set
-#   below + in start.sh) is the belt-and-suspenders fallback for any
-#   other lazy feature we haven't pre-installed.
-ARG HERMES_UV_EXTRAS="messaging web cli edge-tts"
-# Match the uv version NemoClaw uses for the base-image install.
-ARG UV_INSTALL_VERSION=0.11.8
-
-USER root
-RUN set -eu \
-    && curl -LsSf "https://astral.sh/uv/${UV_INSTALL_VERSION}/install.sh" \
-       | env INSTALLER_NO_MODIFY_PATH=1 sh \
-    && UV_BIN="" \
-    && for candidate in /root/.local/bin/uv /root/.cargo/bin/uv /usr/local/bin/uv; do \
-         if [ -x "$candidate" ]; then UV_BIN="$candidate"; break; fi; \
-       done \
-    && if [ -z "$UV_BIN" ]; then echo "uv installer did not produce a binary in any known location" >&2; exit 1; fi \
-    && install -m 755 "$UV_BIN" /usr/local/bin/uv \
-    && /usr/local/bin/uv --version \
-    && curl -fsSL "https://github.com/NousResearch/hermes-agent/archive/refs/tags/${HERMES_UPGRADE_VERSION}.tar.gz" \
-       -o /tmp/hermes.tgz \
-    && echo "${HERMES_UPGRADE_TARBALL_SHA256}  /tmp/hermes.tgz" | sha256sum -c - \
-    && find /opt/hermes -mindepth 1 -maxdepth 1 -not -name '.venv' -exec rm -rf {} + \
-    && tar -xzf /tmp/hermes.tgz -C /opt/hermes --strip-components=1 \
-    && rm /tmp/hermes.tgz \
-    && cd /opt/hermes \
-    && extras_args="" \
-    && for e in ${HERMES_UV_EXTRAS}; do extras_args="${extras_args} --extra ${e}"; done \
-    && UV_PROJECT_ENVIRONMENT=/opt/hermes/.venv /usr/local/bin/uv sync \
-       ${extras_args} --no-dev \
-    && chown -R sandbox:sandbox /opt/hermes
 
 # ── NeMo-Relay 0.3.0 sidecar gateway integration ─────────────────────────
 # Hermes stays unpatched (from BASE_IMAGE). start.sh launches a long-running

--- a/examples/personal-community-sentiment-triage/agents/hermes/Dockerfile
+++ b/examples/personal-community-sentiment-triage/agents/hermes/Dockerfile
@@ -141,6 +141,7 @@ COPY agents/hermes/refresh-placeholders.py /usr/local/lib/nemoclaw/refresh-place
 RUN chmod 755 /usr/local/lib/nemoclaw/refresh-placeholders.py
 
 COPY agents/hermes/patches/ /usr/local/lib/nemoclaw-patches/
+COPY agents/hermes/tests/verify-rich-block-renderer.py /tmp/verify-rich-block-renderer.py
 
 # Pin slack-bolt / python-telegram-bot / pyyaml / httpx into the system
 # python interpreter. slack-bolt is needed by the sitecustomize.py
@@ -152,6 +153,8 @@ RUN pip3 install --no-cache-dir --break-system-packages \
        "httpx>=0.27" \
        "slack-bolt>=1.19" \
     && hermes --version \
+    && /opt/hermes/.venv/bin/python /tmp/verify-rich-block-renderer.py \
+    && rm /tmp/verify-rich-block-renderer.py \
     && export PY_SITE_DIR="$(python3 -c 'import site; print(site.getsitepackages()[0])')" \
     && ln -sfn /usr/local/lib/nemoclaw-patches/sitecustomize.py "${PY_SITE_DIR}/sitecustomize.py"
 
@@ -283,6 +286,7 @@ ARG CHAT_UI_URL=http://127.0.0.1:8642
 # injected at sandbox-create time via `-- env` (scripts/03-sandbox.sh) so the
 # image stays generic and shareable.
 ARG NEMOCLAW_MESSAGING_CHANNELS_B64=W10=
+ARG NEMOCLAW_SLACK_RICH_BLOCKS=false
 ARG GITHUB_READONLY_REPO=NVIDIA/OpenShell
 ARG SOURCE_ETL_GITHUB_REPO=
 ARG SOURCE_ETL_FORUM_TAG=
@@ -297,6 +301,7 @@ ENV NEMOCLAW_MODEL=${NEMOCLAW_MODEL} \
     NEMOCLAW_INFERENCE_BASE_URL=${NEMOCLAW_INFERENCE_BASE_URL} \
     CHAT_UI_URL=${CHAT_UI_URL} \
     NEMOCLAW_MESSAGING_CHANNELS_B64=${NEMOCLAW_MESSAGING_CHANNELS_B64} \
+    NEMOCLAW_SLACK_RICH_BLOCKS=${NEMOCLAW_SLACK_RICH_BLOCKS} \
     GITHUB_READONLY_REPO=${GITHUB_READONLY_REPO} \
     SOURCE_ETL_GITHUB_REPO=${SOURCE_ETL_GITHUB_REPO} \
     SOURCE_ETL_FORUM_TAG=${SOURCE_ETL_FORUM_TAG} \

--- a/examples/personal-community-sentiment-triage/agents/hermes/generate-config.ts
+++ b/examples/personal-community-sentiment-triage/agents/hermes/generate-config.ts
@@ -43,9 +43,26 @@ const SOURCE_ETL_ENV = [
   "SOURCE_ETL_API_PORT",
 ] as const;
 
+function booleanEnv(name: string, defaultValue: boolean): boolean {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") {
+    return defaultValue;
+  }
+
+  if (raw === "true") {
+    return true;
+  }
+  if (raw === "false") {
+    return false;
+  }
+
+  throw new Error(`${name} must be either true or false`);
+}
+
 function main(): void {
   const model = process.env.NEMOCLAW_MODEL!;
   const baseUrl = process.env.NEMOCLAW_INFERENCE_BASE_URL!;
+  const slackRichBlocks = booleanEnv("NEMOCLAW_SLACK_RICH_BLOCKS", false);
 
   const channelsB64 = process.env.NEMOCLAW_MESSAGING_CHANNELS_B64 || "W10=";
 
@@ -54,7 +71,7 @@ function main(): void {
   );
 
   const config: Record<string, unknown> = {
-    _config_version: 12,
+    _config_version: 32,
     model: {
       default: model,
       provider: "custom",
@@ -67,6 +84,10 @@ function main(): void {
     agent: {
       max_turns: 30,
       reasoning_effort: "medium",
+      // Config migration v30 -> v32 disables the previous implicit
+      // verify-on-stop behavior. Generated configs start at v32, so preserve
+      // that migrated value explicitly instead of inheriting "auto".
+      verify_on_stop: false,
     },
     memory: {
       memory_enabled: true,
@@ -120,9 +141,10 @@ function main(): void {
     //
     // pre_api_request / post_api_request and pre_tool_call / post_tool_call
     // are NOT shell-forwarded. The in-process nemo-relay plugin
-    // (plugins/nemo-relay/) owns those events under Hermes v0.14.0: it
-    // receives the real `request_messages` list and the real `response` SDK
-    // object as kwargs for api_request, and synthesizes stable tool_call_ids
+    // (plugins/nemo-relay/) owns those events under Hermes v0.18.0: it
+    // prefers the sanitized `request.body` / `response.assistant_message`
+    // hook payloads, retains the legacy rich-kwargs fallbacks, and synthesizes
+    // stable tool_call_ids
     // for tool_call events to work around NeMo-Relay's adapters/mod.rs
     // synthesizing a fresh UUID per call when Hermes' defensive
     // `tool_call_id or ""` strips the id. The plugin forwards everything to
@@ -159,7 +181,7 @@ function main(): void {
     // Enable in-process Hermes plugins. nemoclaw provides sandbox status
     // tools and the startup banner; nemo-relay owns the pre/post_api_request
     // events (see hooks comment above). Belt-and-suspenders against
-    // config-migration changes — v0.14.0 also auto-discovers plugins under
+    // config-migration changes — v0.18.0 also auto-discovers plugins under
     // $HERMES_HOME/plugins/, but explicit enablement survives schema bumps.
     plugins: {
       enabled: ["nemoclaw", "nemo-relay"],
@@ -178,6 +200,11 @@ function main(): void {
         enabled: true,
         token: tokenPlaceholder,
       };
+      if (ch === "slack") {
+        pCfg.extra = {
+          rich_blocks: slackRichBlocks,
+        };
+      }
       // allowed_users in config.yaml is not read by the gateway; it reads the
       // *_ALLOWED_USERS env vars (injected at sandbox-create, not written here).
       platformsConfig[ch] = pCfg;

--- a/examples/personal-community-sentiment-triage/agents/hermes/patches/sitecustomize.py
+++ b/examples/personal-community-sentiment-triage/agents/hermes/patches/sitecustomize.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 """Patch Hermes's Slack adapter with a catch-all slash-command handler.
 
-Hermes registers only `/hermes` as its bolt command. Workspace-specific names
+Hermes registers its known slash commands with Bolt. Workspace-specific names
 (e.g. `/my-assistant`) produce an `Unhandled request` warning and no user
-feedback. This module patches `SlackAdapter.connect` so any other slash
-command gets a friendly "I don't recognize this" reply.
+feedback. This module patches `SlackAdapter.connect` so any other slash command
+gets a friendly "I don't recognize this" reply.
 
 Auto-loaded by Python's site initialization — the Dockerfile symlinks this
 file into the system site-packages dir, and start.sh prepends the patches
@@ -18,13 +18,22 @@ import re
 
 def _patch_slack_commands() -> None:
     try:
-        from gateway.platforms.slack import SlackAdapter
+        try:
+            # Hermes 0.18+ ships Slack as a bundled platform plugin.
+            from plugins.platforms.slack.adapter import SlackAdapter
+        except ImportError:
+            # Keep compatibility with older NemoClaw Hermes base images.
+            from gateway.platforms.slack import SlackAdapter
+
         _orig_connect = SlackAdapter.connect
 
-        async def _patched_connect(self):
-            result = await _orig_connect(self)
-            if getattr(self, "_app", None) is not None:
-                @self._app.command(re.compile(".+"))
+        async def _patched_connect(self, *args, **kwargs):
+            result = await _orig_connect(self, *args, **kwargs)
+            app = getattr(self, "_app", None)
+            if app is not None and getattr(
+                self, "_nemoclaw_unknown_command_app", None
+            ) is not app:
+                @app.command(re.compile(".+"))
                 async def _handle_unknown_command(ack, command, respond):
                     await ack()
                     cmd = command.get("command", "this command")
@@ -32,6 +41,8 @@ def _patch_slack_commands() -> None:
                         f"I don't recognize `{cmd}`. "
                         "Send me a *direct message* or @mention me to chat"
                     )
+
+                self._nemoclaw_unknown_command_app = app
             return result
 
         SlackAdapter.connect = _patched_connect

--- a/examples/personal-community-sentiment-triage/agents/hermes/plugins/nemo-relay/__init__.py
+++ b/examples/personal-community-sentiment-triage/agents/hermes/plugins/nemo-relay/__init__.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 """In-process Hermes plugin that forwards pre/post_api_request and
 pre/post_tool_call hooks to the NeMo-Relay sidecar at
-`${NEMO_RELAY_GATEWAY_URL}/hooks/hermes` with the real request/response
-bodies attached. Wrapping the body as `{messages, model, max_tokens}`
-and synthesizing stable tool_call_ids are workarounds — see the inline
-comments at each call site for the upstream rationale.
+`${NEMO_RELAY_GATEWAY_URL}/hooks/hermes` with the sanitized Hermes 0.18
+request/response bodies attached. Legacy rich-kwargs payloads remain supported,
+and stable tool_call_ids are synthesized where Hermes does not supply one — see
+the inline comments at each call site for the upstream rationale.
 
 Fail-open: exceptions are logged at debug; Hermes turns must never break
 because the bridge can't reach NeMo-Relay. Modeled on Hermes's bundled
@@ -59,6 +59,7 @@ _PENDING_LOCK = threading.Lock()
 # Gateway URL + HTTP client
 # ---------------------------------------------------------------------------
 
+
 def _gateway_url() -> Optional[str]:
     global _GATEWAY_URL, _GATEWAY_LOOKED_UP, _DISABLED_LOGGED
     with _LOCK:
@@ -98,6 +99,7 @@ def _client():
 # ---------------------------------------------------------------------------
 # Value coercion
 # ---------------------------------------------------------------------------
+
 
 def _safe_jsonable(value: Any, _depth: int = 0) -> Any:
     """Recursively coerce any value into something json.dumps can serialize.
@@ -144,10 +146,11 @@ def _coerce_request_messages(
     conversation_history: Any = None,
     user_message: Any = None,
 ) -> list:
-    """Hermes v0.14.0 passes a real `request_messages` list of {role, content}
-    dicts. Fall back to conversation_history, then synthesize a single user
-    message from user_message — mirrors Langfuse's resolver at
-    plugins/observability/langfuse/__init__.py."""
+    """Resolve legacy rich-kwargs request messages.
+
+    Hermes 0.18 callers should use the sanitized ``request.body`` payload;
+    this fallback keeps older base images and test fixtures compatible.
+    """
     for candidate in (request_messages, conversation_history):
         if isinstance(candidate, list) and candidate:
             return candidate
@@ -156,6 +159,14 @@ def _coerce_request_messages(
     if isinstance(request_messages, list):
         return request_messages
     return []
+
+
+def _serialize_request_object(request: Any) -> Optional[dict]:
+    """Return Hermes 0.18's sanitized request object when it has a body."""
+    blob = _safe_jsonable(request)
+    if not isinstance(blob, dict) or not isinstance(blob.get("body"), dict):
+        return None
+    return blob
 
 
 def _serialize_tool_calls(tool_calls: Any) -> list:
@@ -169,11 +180,13 @@ def _serialize_tool_calls(tool_calls: Any) -> list:
         fn = getattr(tc, "function", None)
         name = getattr(fn, "name", None) if fn else None
         args = getattr(fn, "arguments", None) if fn else None
-        out.append({
-            "id": getattr(tc, "id", None),
-            "type": getattr(tc, "type", None) or "function",
-            "function": {"name": name, "arguments": _safe_jsonable(args)},
-        })
+        out.append(
+            {
+                "id": getattr(tc, "id", None),
+                "type": getattr(tc, "type", None) or "function",
+                "function": {"name": name, "arguments": _safe_jsonable(args)},
+            }
+        )
     return out
 
 
@@ -192,10 +205,12 @@ def _serialize_assistant_message(obj: Any) -> Optional[dict]:
 
 
 def _serialize_response_object(response: Any) -> Optional[dict]:
-    """Turn the v0.14.0 `response=` kwarg (a SimpleNamespace with
-    .choices/.usage/.model/.id) into a dict. The result has `choices` at
-    top-level, which adapters/hermes.rs recognizes as a real
-    provider response and uses to mark provider_payload_exact=true."""
+    """Serialize a legacy raw provider response when Hermes supplies one.
+
+    Hermes 0.18 instead supplies a sanitized mapping with
+    ``assistant_message`` at the top level. That mapping is handled separately
+    so it is not mislabeled as an exact raw provider response.
+    """
     if response is None:
         return None
     blob = _safe_jsonable(response)
@@ -209,6 +224,7 @@ def _serialize_response_object(response: Any) -> Optional[dict]:
 # ---------------------------------------------------------------------------
 # Forwarder
 # ---------------------------------------------------------------------------
+
 
 def _forward(payload: dict) -> None:
     url = _gateway_url()
@@ -271,33 +287,29 @@ def _stable_tool_call_id(
 # Hook handlers
 # ---------------------------------------------------------------------------
 
+
 def on_pre_api_request(**kwargs: Any) -> None:
     try:
         payload = _correlation(kwargs)
         payload["hook_event_name"] = "pre_api_request"
-        messages = _coerce_request_messages(
-            request_messages=kwargs.get("request_messages"),
-            conversation_history=kwargs.get("conversation_history"),
-            user_message=kwargs.get("user_message"),
-        )
-        # Wrap as {"messages": [...], "model": ..., ...} to match NeMo-Relay's
-        # documented LlmRequest.content convention
-        # (docs/integrate-frameworks/wrap-llm-calls.md, asserted by
-        # crates/core/tests/unit/observability/openinference_tests.rs). With
-        # this shape, openinference.rs:llm_input_display_value finds the
-        # messages list via content.get("messages") and renders each as
-        # "role: content", so Phoenix's input.value carries the full prompt
-        # rather than a lossy "Requested tools: ..." summary. ATIF's
-        # unwrap_llm_request surfaces the same dict at
-        # step.extra.llm_request, matching the documented shape.
-        payload["request"] = {
-            "body": {
-                "messages": _safe_jsonable(messages),
-                "model": kwargs.get("model"),
-                "max_tokens": kwargs.get("max_tokens"),
-            },
-            "api_mode": kwargs.get("api_mode"),
-        }
+        request = _serialize_request_object(kwargs.get("request"))
+        if request is None:
+            messages = _coerce_request_messages(
+                request_messages=kwargs.get("request_messages"),
+                conversation_history=kwargs.get("conversation_history"),
+                user_message=kwargs.get("user_message"),
+            )
+            # Legacy fallback matching NeMo-Relay's documented
+            # LlmRequest.content convention.
+            request = {
+                "body": {
+                    "messages": _safe_jsonable(messages),
+                    "model": kwargs.get("model"),
+                    "max_tokens": kwargs.get("max_tokens"),
+                },
+                "api_mode": kwargs.get("api_mode"),
+            }
+        payload["request"] = request
         _forward(payload)
     except Exception as exc:
         logger.debug("nemo-relay: on_pre_api_request failed: %s", exc)
@@ -307,22 +319,33 @@ def on_post_api_request(**kwargs: Any) -> None:
     try:
         payload = _correlation(kwargs)
         payload["hook_event_name"] = "post_api_request"
-        # Primary path: serialize the real response SimpleNamespace into a
-        # dict with `choices/usage/model/id`. The adapter's
-        # hermes_exact_response sees .choices and returns the whole dict,
-        # which OpenInference renders as input/output.value.
-        raw_response = _serialize_response_object(kwargs.get("response"))
-        # Redundant fallback path: include serialized assistant_message in
-        # case raw_response can't be extracted. Adapter has a separate
-        # branch for response.assistant_message.{content,tool_calls}.
-        assistant_message = _serialize_assistant_message(kwargs.get("assistant_message"))
+        response_value = kwargs.get("response")
+        response_blob = _safe_jsonable(response_value)
+        response_fields = response_blob if isinstance(response_blob, dict) else {}
+        # Older Hermes versions passed the raw SDK response. Hermes 0.18 passes
+        # a sanitized mapping instead; keep it out of raw_response and consume
+        # its explicit assistant/model/usage fields below.
+        raw_response = _serialize_response_object(response_value)
+        assistant_source = kwargs.get("assistant_message")
+        if assistant_source is None:
+            assistant_source = response_fields.get("assistant_message")
+        assistant_message = _serialize_assistant_message(assistant_source)
+        usage = kwargs.get("usage")
+        if usage is None:
+            usage = response_fields.get("usage")
         payload["response"] = {
             "raw_response": raw_response,
             "assistant_message": assistant_message,
-            "model": kwargs.get("response_model") or kwargs.get("model"),
-            "finish_reason": kwargs.get("finish_reason"),
+            "model": (
+                kwargs.get("response_model")
+                or response_fields.get("model")
+                or kwargs.get("model")
+            ),
+            "finish_reason": (
+                kwargs.get("finish_reason") or response_fields.get("finish_reason")
+            ),
             "api_duration": kwargs.get("api_duration"),
-            "usage": _safe_jsonable(kwargs.get("usage")),
+            "usage": _safe_jsonable(usage),
         }
         _forward(payload)
     except Exception as exc:
@@ -402,6 +425,7 @@ def on_post_tool_call(**kwargs: Any) -> None:
 # ---------------------------------------------------------------------------
 # Plugin entry-point
 # ---------------------------------------------------------------------------
+
 
 def register(ctx) -> None:
     """Wire pre/post_api_request and pre/post_tool_call to the in-process

--- a/examples/personal-community-sentiment-triage/agents/hermes/tests/test_generate_config.py
+++ b/examples/personal-community-sentiment-triage/agents/hermes/tests/test_generate_config.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Focused contracts for the Community-owned Hermes configuration generator."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+from typing import Optional, Tuple
+import unittest
+
+import yaml
+
+
+HERMES_DIR = Path(__file__).resolve().parents[1]
+EXAMPLE_DIR = Path(__file__).resolve().parents[3]
+GENERATOR = HERMES_DIR / "generate-config.ts"
+
+
+class GenerateConfigTest(unittest.TestCase):
+    def run_generator(
+        self,
+        *,
+        channels: list[str],
+        rich_blocks: Optional[str] = None,
+        expect_success: bool = True,
+    ) -> Tuple[subprocess.CompletedProcess, Optional[dict]]:
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            (home / ".hermes").mkdir()
+            env = os.environ.copy()
+            env.update(
+                {
+                    "HOME": str(home),
+                    "NEMOCLAW_MODEL": "test/model",
+                    "NEMOCLAW_INFERENCE_BASE_URL": "https://inference.local/v1",
+                    "NEMOCLAW_MESSAGING_CHANNELS_B64": base64.b64encode(
+                        json.dumps(channels).encode("utf-8")
+                    ).decode("ascii"),
+                }
+            )
+            if rich_blocks is None:
+                env.pop("NEMOCLAW_SLACK_RICH_BLOCKS", None)
+            else:
+                env["NEMOCLAW_SLACK_RICH_BLOCKS"] = rich_blocks
+
+            result = subprocess.run(
+                ["node", "--experimental-strip-types", str(GENERATOR)],
+                check=False,
+                capture_output=True,
+                env=env,
+                text=True,
+            )
+            if expect_success:
+                self.assertEqual(result.returncode, 0, result.stderr)
+                config = yaml.safe_load(
+                    (home / ".hermes" / "config.yaml").read_text(encoding="utf-8")
+                )
+                return result, config
+
+            self.assertNotEqual(result.returncode, 0)
+            return result, None
+
+    def test_default_is_schema_32_and_rich_blocks_off(self) -> None:
+        _, config = self.run_generator(channels=["slack"])
+        assert config is not None
+        self.assertEqual(config["_config_version"], 32)
+        self.assertIs(config["agent"]["verify_on_stop"], False)
+        self.assertIs(config["platforms"]["slack"]["extra"]["rich_blocks"], False)
+        self.assertIs(config["platforms"]["api_server"]["enabled"], True)
+
+    def test_explicit_boolean_values_are_preserved(self) -> None:
+        for raw, expected in (("false", False), ("true", True)):
+            with self.subTest(raw=raw):
+                _, config = self.run_generator(channels=["slack"], rich_blocks=raw)
+                assert config is not None
+                self.assertIs(
+                    config["platforms"]["slack"]["extra"]["rich_blocks"],
+                    expected,
+                )
+
+    def test_invalid_boolean_values_fail_closed(self) -> None:
+        for raw in ("TRUE", "1", "yes", " true "):
+            with self.subTest(raw=raw):
+                result, _ = self.run_generator(
+                    channels=["slack"],
+                    rich_blocks=raw,
+                    expect_success=False,
+                )
+                self.assertIn(
+                    "NEMOCLAW_SLACK_RICH_BLOCKS must be either true or false",
+                    result.stderr,
+                )
+
+    def test_setting_does_not_enable_slack(self) -> None:
+        _, config = self.run_generator(channels=[], rich_blocks="true")
+        assert config is not None
+        self.assertNotIn("slack", config["platforms"])
+        self.assertIs(config["platforms"]["api_server"]["enabled"], True)
+
+    def test_build_setting_is_propagated_to_the_generator(self) -> None:
+        dockerfile = (HERMES_DIR / "Dockerfile").read_text(encoding="utf-8")
+        sandbox_script = (EXAMPLE_DIR / "scripts" / "03-sandbox.sh").read_text(
+            encoding="utf-8"
+        )
+        env_example = (EXAMPLE_DIR / ".env.example").read_text(encoding="utf-8")
+
+        self.assertEqual(dockerfile.count("ARG NEMOCLAW_SLACK_RICH_BLOCKS=false"), 1)
+        self.assertIn(
+            "NEMOCLAW_SLACK_RICH_BLOCKS=${NEMOCLAW_SLACK_RICH_BLOCKS}",
+            dockerfile,
+        )
+        self.assertIn(
+            '[NEMOCLAW_SLACK_RICH_BLOCKS]="$NEMOCLAW_SLACK_RICH_BLOCKS"',
+            sandbox_script,
+        )
+        self.assertIn(
+            'NEMOCLAW_SLACK_RICH_BLOCKS="${NEMOCLAW_SLACK_RICH_BLOCKS:-false}"',
+            sandbox_script,
+        )
+        self.assertIn("NEMOCLAW_SLACK_RICH_BLOCKS=false", env_example)
+        self.assertIn("verify-rich-block-renderer.py", dockerfile)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/personal-community-sentiment-triage/agents/hermes/tests/test_nemo_relay_plugin.py
+++ b/examples/personal-community-sentiment-triage/agents/hermes/tests/test_nemo_relay_plugin.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Compatibility contracts for the example-owned NeMo Relay bridge."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+import unittest
+from unittest import mock
+
+
+PLUGIN_PATH = (
+    Path(__file__).resolve().parents[1] / "plugins" / "nemo-relay" / "__init__.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "community_nemo_relay_plugin", PLUGIN_PATH
+)
+assert SPEC is not None and SPEC.loader is not None
+PLUGIN = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(PLUGIN)
+
+
+class NemoRelayPluginTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.forwarded: list[dict] = []
+        self.forward_patch = mock.patch.object(
+            PLUGIN, "_forward", side_effect=self.forwarded.append
+        )
+        self.forward_patch.start()
+        PLUGIN._PENDING_PRE.clear()
+
+    def tearDown(self) -> None:
+        self.forward_patch.stop()
+        PLUGIN._PENDING_PRE.clear()
+
+    def test_prefers_hermes_018_sanitized_request(self) -> None:
+        request = {
+            "method": "POST",
+            "body": {
+                "messages": [{"role": "user", "content": "hello"}],
+                "model": "test/model",
+                "max_tokens": 128,
+                "tools": [{"type": "function"}],
+            },
+        }
+
+        PLUGIN.on_pre_api_request(
+            task_id="task-1",
+            request=request,
+            request_messages=[{"role": "user", "content": "legacy"}],
+        )
+
+        self.assertEqual(len(self.forwarded), 1)
+        self.assertEqual(self.forwarded[0]["request"], request)
+
+    def test_reads_hermes_018_sanitized_response_fields(self) -> None:
+        PLUGIN.on_post_api_request(
+            task_id="task-1",
+            response={
+                "model": "test/model-resolved",
+                "finish_reason": "stop",
+                "assistant_message": {
+                    "role": "assistant",
+                    "content": "hello back",
+                    "tool_calls": [],
+                },
+                "usage": {
+                    "prompt_tokens": 7,
+                    "completion_tokens": 3,
+                    "total_tokens": 10,
+                },
+            },
+        )
+
+        self.assertEqual(len(self.forwarded), 1)
+        response = self.forwarded[0]["response"]
+        self.assertIsNone(response["raw_response"])
+        self.assertEqual(response["assistant_message"]["content"], "hello back")
+        self.assertEqual(response["model"], "test/model-resolved")
+        self.assertEqual(response["finish_reason"], "stop")
+        self.assertEqual(response["usage"]["total_tokens"], 10)
+
+    def test_retains_legacy_raw_provider_response(self) -> None:
+        raw_response = SimpleNamespace(
+            id="response-1",
+            model="legacy/model",
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="legacy response"),
+                    finish_reason="stop",
+                )
+            ],
+            usage=SimpleNamespace(total_tokens=4),
+        )
+
+        PLUGIN.on_post_api_request(task_id="task-1", response=raw_response)
+
+        response = self.forwarded[0]["response"]
+        self.assertEqual(response["raw_response"]["id"], "response-1")
+        self.assertEqual(
+            response["raw_response"]["choices"][0]["message"]["content"],
+            "legacy response",
+        )
+
+    def test_pre_and_post_tool_events_share_one_id(self) -> None:
+        PLUGIN.on_pre_tool_call(
+            task_id="task-1",
+            tool_name="search",
+            args={"query": "tables"},
+            tool_call_id="",
+        )
+        PLUGIN.on_post_tool_call(
+            task_id="task-1",
+            tool_name="search",
+            args={"query": "tables"},
+            result={"ok": True},
+            tool_call_id="provider-id",
+        )
+
+        self.assertEqual(len(self.forwarded), 2)
+        self.assertEqual(
+            self.forwarded[0]["tool_call_id"],
+            self.forwarded[1]["tool_call_id"],
+        )
+        self.assertEqual(PLUGIN._PENDING_PRE, {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/personal-community-sentiment-triage/agents/hermes/tests/verify-rich-block-renderer.py
+++ b/examples/personal-community-sentiment-triage/agents/hermes/tests/verify-rich-block-renderer.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Fail the image build if the pinned Hermes base lacks native table blocks."""
+
+from __future__ import annotations
+
+import sys
+
+
+sys.path.insert(0, "/opt/hermes")
+
+from plugins.platforms.slack.block_kit import render_blocks  # noqa: E402
+
+
+MARKDOWN = """# Product prioritization
+
+| Segment | Core Problem | Evidence Needed |
+|---|---|---|
+| New users | Slow time to value | Onboarding drop-off |
+"""
+
+blocks = render_blocks(MARKDOWN)
+tables = [block for block in blocks if block.get("type") == "table"]
+if len(tables) != 1:
+    raise SystemExit(f"expected exactly one native table block, got {blocks!r}")
+
+rows = tables[0].get("rows")
+if not isinstance(rows, list) or len(rows) != 2:
+    raise SystemExit(f"expected a header and one data row, got {rows!r}")
+if any(not isinstance(row, list) or len(row) != 3 for row in rows):
+    raise SystemExit(f"expected three columns in every table row, got {rows!r}")

--- a/examples/personal-community-sentiment-triage/docs/set-up-slack.md
+++ b/examples/personal-community-sentiment-triage/docs/set-up-slack.md
@@ -105,9 +105,18 @@ SLACK_BOT_TOKEN=xoxb-<your bot token from OAuth & Permissions>
 SLACK_APP_TOKEN=xapp-<your app-level token from Socket Mode>
 # Optional — leave empty to allow anyone in the workspace
 SLACK_ALLOWED_IDS=U0887Q5UVV4
+# Optional — native Block Kit rendering for supported Markdown tables
+NEMOCLAW_SLACK_RICH_BLOCKS=false
 ```
 
 Leaving `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN` unset disables Slack entirely — the example runs Outlook-only. If you set the tokens, a single `<sandbox>-slack` provider is upserted by [scripts/02-providers.sh](../scripts/02-providers.sh) with both credentials attached.
+
+Set `NEMOCLAW_SLACK_RICH_BLOCKS=true` to have Hermes render supported Markdown
+with Slack Block Kit, including native table blocks. The setting accepts only
+`true` or `false` and defaults to `false`, preserving the existing plain-text
+behavior. It uses the existing Slack credentials and does not require additional
+OAuth scopes or reinstalling the Slack app. Rebuild the sandbox after changing
+the setting.
 
 ## Run `bring-up.sh`
 

--- a/examples/personal-community-sentiment-triage/scripts/03-sandbox.sh
+++ b/examples/personal-community-sentiment-triage/scripts/03-sandbox.sh
@@ -60,12 +60,23 @@ if [[ ! "$GITHUB_READONLY_REPO" =~ ^[A-Za-z0-9][A-Za-z0-9-]{0,38}/[A-Za-z0-9._-]
 fi
 echo "GitHub read-only repo scope: $GITHUB_READONLY_REPO"
 
+NEMOCLAW_SLACK_RICH_BLOCKS="${NEMOCLAW_SLACK_RICH_BLOCKS:-false}"
+case "$NEMOCLAW_SLACK_RICH_BLOCKS" in
+  true|false) ;;
+  *)
+    echo "Invalid NEMOCLAW_SLACK_RICH_BLOCKS '$NEMOCLAW_SLACK_RICH_BLOCKS' — expected true or false" >&2
+    exit 1
+    ;;
+esac
+echo "Slack rich blocks: $NEMOCLAW_SLACK_RICH_BLOCKS"
+
 # ── Stage the Dockerfile and patch ARG defaults ────────────────────────
 # Build args go through sed substitution because `openshell sandbox create
 # --from <Dockerfile>` doesn't expose --build-arg passthrough. Values must
 # not contain `|` (the sed delimiter).
 declare -A DOCKERFILE_ARGS=(
   [NEMOCLAW_MESSAGING_CHANNELS_B64]="$CHANNELS_B64"
+  [NEMOCLAW_SLACK_RICH_BLOCKS]="$NEMOCLAW_SLACK_RICH_BLOCKS"
   [GITHUB_READONLY_REPO]="$GITHUB_READONLY_REPO"
   [SOURCE_ETL_API_HOST]="$SOURCE_ETL_HOST"
   [SOURCE_ETL_API_PORT]="$SOURCE_ETL_PORT"


### PR DESCRIPTION
## Description

Depends on #53.

This is a stacked draft based on #53's Hermes 0.18 upgrade. While #53 remains
open, GitHub will show its dependency changes in this PR; after #53 merges, the
diff will reduce to this follow-up.

Hermes 0.18 includes optional Slack Block Kit rendering, but this example owns
its configuration generator and does not inherit NemoClaw's Slack manifest.
Upgrading the base image alone therefore leaves rich-block rendering disabled.

This change completes the Community-side integration:

- Advance generated Hermes configuration to schema 32 and preserve
  `agent.verify_on_stop: false`.
- Add `NEMOCLAW_SLACK_RICH_BLOCKS`, accepting only `true` or `false` and
  defaulting to `false`.
- Pass the setting through `.env.example`, the staged Dockerfile arguments, and
  `generate-config.ts`.
- Render the resolved value as `platforms.slack.extra.rich_blocks` when Slack is
  configured.
- Add a build-time smoke test for Hermes 0.18's native three-column table
  renderer.
- Prefer Hermes 0.18's sanitized `request.body` and
  `response.assistant_message` NeMo Relay hook payloads while retaining the
  legacy rich-kwargs fallbacks.
- Document how to opt in and refresh remaining Hermes 0.14-specific comments.

The default remains backward-compatible. Existing deployments retain
plain-text Slack responses unless they explicitly set
`NEMOCLAW_SLACK_RICH_BLOCKS=true`.

No additional Slack OAuth scopes or app reinstall are required.

## Verification

- [x] `python scripts/check_license_headers.py --check`
- [x] `git diff --check`
- [x] All example shell scripts pass `bash -n`.
- [x] All example Python files compile successfully.
- [x] Focused generator and NeMo Relay unit suite passes (9 tests).
- [x] Changed Python files pass Ruff lint and formatting checks.
- [x] Tests cover schema 32, `verify_on_stop: false`, default-off, explicit
  true/false, invalid-value rejection, and Slack-disabled behavior.
- [x] Tests cover Hermes 0.18 sanitized request/response payloads, legacy raw
  provider responses, and paired tool-call IDs.
- [x] The renderer smoke uses the Hermes v2026.7.1
  `plugins.platforms.slack.block_kit.render_blocks` API and requires one native
  three-column `table` block.
- [ ] Full sandbox image build and live Slack table canary. Docker is unavailable
  in the authoring environment; every image build now executes the renderer
  smoke automatically.
- [ ] Live NeMo Relay ATIF/Phoenix finalization check.

## Release And Compliance

- [x] No secrets, local `.env` files, private certificates, snapshots, or token
  caches are included.
- [x] No third-party dependencies are added.
- [x] Public documentation is free of internal-only links or private workspace
  details.
- [x] Commit includes DCO sign-off (`git commit -s`).
