### PR TITLE
Fix Blender community E2E reproducibility

### DIFF
--- a/examples/blender-omniverse-dgx-station/docs/setup-dgx-station-arm64.md
+++ b/examples/blender-omniverse-dgx-station/docs/setup-dgx-station-arm64.md
@@ -508,7 +508,7 @@ env \
   OVRTX_ACTIVE_CUDA_GPUS=0 \
   blender "$DEMO_ROOT/scenes/thejunkshopsplashscreen.blend" \
   --python "$GUIDE_REPO/scripts/start_visible_blender_mcp.py" \
-  > "$DEMO_ROOT/out/visible-blender-mcp.log" 2>&1 &
+  > "$DEMO_ROOT/out/visible-blender-mcp.log" 2>&1 </dev/null &
 ```
 
 ### Validation

--- a/examples/blender-omniverse-dgx-station/scripts/ovphysx_host_helper.py
+++ b/examples/blender-omniverse-dgx-station/scripts/ovphysx_host_helper.py
@@ -422,6 +422,7 @@ def _replay(settings: Mapping[str, Any]) -> dict[str, Any]:
     completed = subprocess.run(
         [
             ffmpeg,
+            "-nostdin",
             "-y",
             "-framerate",
             str(gif_fps),
@@ -462,6 +463,39 @@ def _status(settings: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
+def _run_configured_demo(settings: Mapping[str, Any]) -> dict[str, Any]:
+    stages = (
+        ("preflight", _preflight, {"pass"}),
+        ("prepare", _prepare, {"pass", "not_required"}),
+        ("preview", _preview, {"pass"}),
+        ("simulate", _simulate, {"pass"}),
+        ("replay", _replay, {"pass"}),
+    )
+    results: dict[str, dict[str, Any]] = {}
+    for name, operation, accepted in stages:
+        result = operation(settings)
+        results[name] = result
+        if result.get("status") not in accepted:
+            return {
+                "status": "blocked" if name == "preflight" else "fail",
+                "failed_stage": name,
+                "receipt": result,
+            }
+
+    simulation = results["simulate"]
+    replay = results["replay"]
+    return {
+        "status": "pass",
+        "native_status": simulation.get("native_status"),
+        "physics_source": replay.get("physics_source"),
+        "render_class": replay.get("render_class"),
+        "sample_count": simulation.get("sample_count"),
+        "gif": replay.get("gif"),
+        "simulation_receipt": simulation.get("path"),
+        "replay_receipt": str(Path(settings["output_dir"]) / "replay-status.json"),
+    }
+
+
 def dispatch(request: Mapping[str, Any]) -> dict[str, Any]:
     action = str(request.get("action", "status"))
     settings = _settings(request)
@@ -472,6 +506,7 @@ def dispatch(request: Mapping[str, Any]) -> dict[str, Any]:
         "simulate": _simulate,
         "replay": _replay,
         "status": _status,
+        "run_configured_demo": _run_configured_demo,
     }
     if action not in actions:
         raise ValueError(f"unknown action {action!r}; expected one of {sorted(actions)}")

--- a/examples/blender-omniverse-dgx-station/scripts/preflight_dgx_station_arm64.sh
+++ b/examples/blender-omniverse-dgx-station/scripts/preflight_dgx_station_arm64.sh
@@ -173,7 +173,7 @@ section "Storage"
 target_model_serving=false
 if has_command curl; then
   model_response="$(curl -fsS --max-time 5 http://127.0.0.1:8000/v1/models 2>/dev/null || true)"
-  if grep -q 'nemotron-ultra' <<<"$model_response"; then
+  if grep -Eqi 'nemotron([_-]3)?[_-]ultra' <<<"$model_response"; then
     target_model_serving=true
   fi
 fi
@@ -379,9 +379,9 @@ if ! has_command ss; then
 else
   if port_is_listening 8000; then
     if $target_model_serving; then
-      pass "port 8000 already serves nemotron-ultra"
+      pass "port 8000 already serves the target Nemotron Ultra model"
     else
-      fail "port 8000 is occupied and does not report nemotron-ultra"
+      fail "port 8000 is occupied and does not report the target Nemotron Ultra model"
     fi
   else
     pass "port 8000 is available for Nemotron Ultra vLLM"

--- a/examples/blender-omniverse-dgx-station/scripts/test_ovphysx_host_helper.py
+++ b/examples/blender-omniverse-dgx-station/scripts/test_ovphysx_host_helper.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import unittest
+from unittest import mock
+
+
+MODULE_PATH = Path(__file__).with_name("ovphysx_host_helper.py")
+SPEC = importlib.util.spec_from_file_location("ovphysx_host_helper", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class ConfiguredDemoTests(unittest.TestCase):
+    def test_runs_each_stage_and_returns_compact_receipt(self) -> None:
+        settings = {"output_dir": "/tmp/stair-drop"}
+        with (
+            mock.patch.object(MODULE, "_preflight", return_value={"status": "pass"}),
+            mock.patch.object(MODULE, "_prepare", return_value={"status": "pass"}),
+            mock.patch.object(MODULE, "_preview", return_value={"status": "pass"}),
+            mock.patch.object(
+                MODULE,
+                "_simulate",
+                return_value={
+                    "status": "pass",
+                    "native_status": "pass-real",
+                    "sample_count": 25,
+                    "path": "/tmp/stair-drop/status.json",
+                },
+            ),
+            mock.patch.object(
+                MODULE,
+                "_replay",
+                return_value={
+                    "status": "pass",
+                    "physics_source": "native-ovphysx-readback",
+                    "render_class": "blender-replay",
+                    "gif": "/tmp/stair-drop/ovphysx-replay.gif",
+                },
+            ),
+        ):
+            result = MODULE._run_configured_demo(settings)
+
+        self.assertEqual(result["status"], "pass")
+        self.assertEqual(result["native_status"], "pass-real")
+        self.assertEqual(result["sample_count"], 25)
+        self.assertEqual(result["physics_source"], "native-ovphysx-readback")
+        self.assertEqual(result["render_class"], "blender-replay")
+        self.assertEqual(result["gif"], "/tmp/stair-drop/ovphysx-replay.gif")
+
+    def test_stops_when_preflight_is_blocked(self) -> None:
+        blocked = {"status": "blocked", "checks": {"runtime": False}}
+        with (
+            mock.patch.object(MODULE, "_preflight", return_value=blocked),
+            mock.patch.object(MODULE, "_prepare") as prepare,
+        ):
+            result = MODULE._run_configured_demo({"output_dir": "/tmp/stair-drop"})
+
+        self.assertEqual(
+            result,
+            {"status": "blocked", "failed_stage": "preflight", "receipt": blocked},
+        )
+        prepare.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/blender-omniverse-dgx-station/skills/ovphysx-host-runtime-boundary/SKILL.md
+++ b/examples/blender-omniverse-dgx-station/skills/ovphysx-host-runtime-boundary/SKILL.md
@@ -1,15 +1,37 @@
 ---
 name: ovphysx-host-runtime-boundary
-description: Route OVPhysX work correctly when Hermes runs in an OpenShell sandbox while the native OVRTX/OVPhysX runtime is installed beside a visible host Blender process.
+description: Run configured native OVPhysX demos and report host GIF/status receipts when Hermes is sandboxed but the OVRTX/OVPhysX runtime and visible Blender process are on the host.
 license: Apache-2.0
 metadata:
-  version: "0.3"
+  version: "0.4"
   domain: physical-ai
 ---
 # OVPhysX Host Runtime Boundary
 
 Use this skill together with the official `ovphysx-drop-contact-acceptance`
 skill for this guide's split deployment.
+
+When a task asks for the configured or guide-owned native OVPhysX demo, select
+this skill before generic scene-authoring skills. Use the installed helper and
+its defaults immediately; the currently open Blender scene is not the fixture
+and does not need to contain stairs or rigid bodies.
+
+For that configured-demo request, make one Blender MCP call with exactly this
+action and no overrides:
+
+```python
+import runpy
+from pathlib import Path
+helper = Path.home() / ".local/share/nemoclaw-blender/ovphysx_host_helper.py"
+runpy.run_path(
+    str(helper),
+    init_globals={"OVPHYSX_REQUEST": {"action": "run_configured_demo"}},
+)
+```
+
+Do not pass `fixture`, `output_dir`, `body_prims`, or the words from the user
+request as path overrides. The helper reads the configured absolute host paths
+and returns the final native simulation and GIF receipt in one bounded action.
 
 ## Topology
 
@@ -59,6 +81,8 @@ host helper. A successful helper action always appears as a
 
 Supported actions are:
 
+- `run_configured_demo`: run the complete configured demo and return its final
+  compact native simulation and GIF receipt. Prefer this for the guide demo.
 - `preflight`: inspect the installed host add-on and runtime.
 - `prepare`: run the configured fixture preparation script on the host.
 - `preview`: import the configured USD into visible Blender and render its


### PR DESCRIPTION
## Description

Make the Blender Omniverse DGX Station example reproducible during a fresh community E2E deployment.

This fixes three failures found while following the published guide on a QA DGX Station:

- accept the current `nvidia/nemotron-3-ultra-550b-a55b` model ID in preflight instead of reporting a false failure;
- detach visible Blender from terminal stdin and run FFmpeg with `-nostdin`, preventing native OVPhysX replay from being job-control stopped;
- give Hermes one bounded `run_configured_demo` operation that runs preflight, prepare, preview, native simulation, and replay in order and returns a compact verified receipt.

The existing low-level helper operations remain available. The source `.blend` is preserved, each stage still verifies its host artifact, and the bounded workflow stops at the first failed stage.

Regression tests cover the successful workflow receipt and early termination after a blocked preflight.

## Verification

- [x] `python scripts/check_license_headers.py --check` — 186 source files passed on macOS and the QA DGX Station
- [x] `git diff --check`
- [x] Relevant example setup or syntax checks
  - `bash -n examples/blender-omniverse-dgx-station/scripts/*.sh`
  - Python compilation for all example scripts
  - `python3 -m unittest discover -s examples/blender-omniverse-dgx-station/scripts -p 'test_*.py'` — 11 tests passed on macOS and DGX
  - patched DGX preflight — 43 PASS, 6 expected WARN, 0 FAIL, `RESULT=ready`
  - fresh official-repository setup — model inference, 43 skills, raw and bounded MCP profiles, and Blender handoff passed
  - OVRTX render — 1920 x 1080 PNG produced with no fallback
  - unchanged stair-drop prompt — native OVPhysX `pass-real`, 12 bodies, 25 samples, verified 640 x 360 host GIF; source `.blend` checksum unchanged

## Release And Compliance

- [x] No secrets, local `.env` files, private certificates, snapshots, or token caches are included.
- [x] Third-party dependency changes are reflected in `THIRD-PARTY-NOTICES` (no dependency changes).
- [x] Public documentation is free of internal-only links or private workspace details.
- [x] Commits include DCO sign-off (`git commit -s`).

Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>
