### PR TITLE
docs: improve community contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,90 +1,235 @@
-# Contributing To NemoClaw Community
+# Contributing to NemoClaw Community
 
 Thank you for your interest in improving NemoClaw Community.
 
-## Ways To Contribute
+This repository contains independently deployable examples and developer tools
+built around NemoClaw. By participating, you agree to follow our
+[Code of Conduct](CODE_OF_CONDUCT.md).
 
-- Improve NemoClaw example documentation.
-- Fix setup, teardown, or sandbox lifecycle bugs.
-- Add or improve agent skills inside an example.
-- Improve source ETL, bridge, or policy configuration.
-- Report reproducible issues with environment details.
+Do not report security vulnerabilities in public issues or pull requests.
+Follow [SECURITY.md](SECURITY.md) instead.
 
-## Signing Your Work 
+## Ways to Contribute
 
-* We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license. Any contribution which contains commits that are not Signed-Off will not be accepted.
-  
-* To sign off on a commit you simply use the `--signoff` (or `-s`) option when committing your changes:
-  
-  ```bash
-  $ git commit -s -m "Add cool feature."
-  ```
-  
-  This will append the following to your commit message:
-  
-  ```
-  Signed-off-by: Your Name <your@email.com>
-  ```
-  
-* Full text of the DCO (https://developercertificate.org/):
-  
-  ```
-    Developer Certificate of Origin
-    Version 1.1
-    Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
-    Everyone is permitted to copy and distribute verbatim copies of this
-    license document, but changing it is not allowed.
-    Developer's Certificate of Origin 1.1
-    By making a contribution to this project, I certify that:
-    (a) The contribution was created in whole or in part by me and I
-        have the right to submit it under the open source license
-        indicated in the file; or
-    (b) The contribution is based upon previous work that, to the best
-        of my knowledge, is covered under an appropriate open source
-        license and I have the right under that license to submit that
-        work with modifications, whether created in whole or in part
-        by me, under the same open source license (unless I am
-        permitted to submit under a different license), as indicated
-        in the file; or
-    (c) The contribution was provided directly to me by some other
-        person who certified (a), (b) or (c) and I have not modified
-        it.
-    (d) I understand and agree that this project and the contribution
-        are public and that a record of the contribution (including all
-        personal information I submit with it, including my sign-off) is
-        maintained indefinitely and may be redistributed consistent with
-        this project or the open source license(s) involved.
-  ```
+- Improve an existing example or its documentation.
+- Fix setup, verification, teardown, or sandbox lifecycle problems.
+- Add or improve agent skills, policies, integrations, or developer tools.
+- Contribute a new example.
+- Report a reproducible problem with the affected example and environment
+  details.
 
-## Development Setup
+Choose a project from the [reference examples](README.md#reference-examples).
+Follow that example's README and any linked setup and verification
+instructions.
+
+Before implementing a major feature, new dependency, distribution change,
+container publication, or compliance-sensitive change, discuss it with the
+maintainers. See [GOVERNANCE.md](GOVERNANCE.md).
+
+## Prerequisites
+
+Repository-level checks require:
+
+- Git.
+- Python 3.10 or newer, invoked as `python3`.
+
+Individual examples may require newer Python versions or additional tools such
+as Docker, `uv`, Helm, Bash, credentials, or access to external services.
+Follow the prerequisites documented by each example you modify.
+
+## Fork and Create a Branch
+
+External contributors should first fork the repository on GitHub.
+
+Clone your fork and add the NVIDIA repository as `upstream`:
 
 ```bash
-git clone https://github.com/NVIDIA/nemoclaw-community.git
+git clone https://github.com/<your-github-user>/nemoclaw-community.git
 cd nemoclaw-community
-git checkout -b my-feature
+git remote add upstream https://github.com/NVIDIA/nemoclaw-community.git
+git fetch upstream main
+git checkout -b <short-branch-name> upstream/main
 ```
 
-For the current example, follow [examples/personal-community-sentiment-triage/README.md](examples/personal-community-sentiment-triage/README.md).
-
-## Local Checks
-
-Run the lightweight repository checks before opening a pull request:
+Push your branch to your fork:
 
 ```bash
-python scripts/check_license_headers.py --check
-git diff --check
-bash -n examples/personal-community-sentiment-triage/scripts/*.sh
-python -m py_compile $(find examples/personal-community-sentiment-triage -name '*.py' -print)
+git push -u origin <short-branch-name>
 ```
 
-## Pull Request Guidelines
+Before opening or updating a pull request, refresh the upstream reference:
 
-- Keep each pull request focused on one feature, fix, or documentation update.
-- Update documentation when setup, configuration, policy, or user-visible behavior changes.
-- Add third-party dependencies only when needed, and update [THIRD-PARTY-NOTICES](THIRD-PARTY-NOTICES).
-- Do not commit secrets, local `.env` files, generated snapshots, private certificates, or token caches.
-- Do not report security issues in public pull requests or issues. Follow [SECURITY.md](SECURITY.md).
+```bash
+git fetch upstream main
+```
+
+If the selected example uses a Git submodule, follow that example's README to
+initialize it. Recursive submodule checkout is not required for contributors
+working on unrelated examples.
+
+## Work Within an Example
+
+This repository does not have one shared runtime setup. Each example owns its
+development and verification workflow.
+
+Follow the selected example's instructions for:
+
+- Prerequisites and supported environments.
+- Credentials and secret handling.
+- Setup and configuration.
+- Sandbox, network, and policy permissions.
+- Startup and shutdown.
+- Verification and tests.
+- Cleanup and teardown.
+- Known limitations.
+
+Keep examples independently deployable. Do not introduce dependencies on
+private files, internal systems, or another example's local state.
+
+## Contribution Requirements
+
+Keep each pull request focused on one feature, fix, documentation update, or
+coordinated migration.
+
+When applicable:
+
+- Add or update tests for changed behavior.
+- Update documentation when setup, configuration, policy, permissions, or
+  user-visible behavior changes.
+- Update [THIRD-PARTY-NOTICES](THIRD-PARTY-NOTICES) when dependencies or
+  distributed third-party content change.
+- Preserve partner and community attribution.
+- Use placeholders in public configuration and documentation.
+- Do not commit secrets, populated `.env` files, private certificates, token
+  caches, generated runtime state, or private workspace details.
+- Do not add internal-only links to public documentation.
+- Do not contact external systems or start live services during verification
+  unless the change requires it and suitable credentials and authorization are
+  available.
+
+## Run Repository Checks
+
+After committing your changes, run the repository-wide checks from the
+repository root:
+
+```bash
+python3 scripts/check_license_headers.py --check
+git fetch upstream main
+git diff --check upstream/main...HEAD
+```
+
+If you have staged but uncommitted changes, also run:
+
+```bash
+git diff --cached --check
+```
+
+These checks do not replace example-specific validation. Run the setup, syntax,
+unit, configuration, and teardown-safe checks documented by every example
+modified in the pull request. Use the smallest stable check that demonstrates
+the changed behavior.
+
+In the pull request description, record:
+
+- The exact commands you ran.
+- Their results.
+- Any verification you did not run and why.
+- Any required live, hardware-specific, credentialed, or external-system
+  validation that remains.
+
+Do not describe a check as passing unless you ran it against the final relevant
+change set.
+
+## Add a New Example
+
+Discuss the intended placement, name, and contributor or organizational
+provenance with the maintainers before implementation.
+
+A new example must document:
+
+- Its purpose, intended users, and support boundary.
+- Contributor or organizational provenance.
+- Prerequisites and supported environments.
+- Architecture and major components.
+- Credentials and secret handling.
+- Setup and configuration.
+- Sandbox, network, and policy permissions.
+- Startup behavior.
+- Verification steps and expected results.
+- Teardown and cleanup.
+- Known limitations.
+- Third-party dependencies and licensing obligations.
+
+Add the example to the [reference examples](README.md#reference-examples).
+
+## Move or Rename an Example
+
+Before beginning a move:
+
+- Search the repository and open pull requests for the old path and name.
+- Identify affected pull requests and downstream documentation.
+- Record the intended merge order.
+- Coordinate rebases for dependent pull requests.
+- Separate path changes from unrelated runtime or dependency changes.
+
+The migration pull request must:
+
+- Provide an old-to-new path table.
+- Update links, commands, ownership, notices, and `.gitmodules` entries.
+- Document compatibility-sensitive identifiers that retain an old name.
+- Include instructions for existing clones when submodules move.
+- Verify every moved example from its new location.
+- Confirm that obsolete paths are gone after dependent branches are rebased.
+
+## Sign Off Every Commit
+
+Every commit in a pull request must include a
+[`Signed-off-by:` trailer](https://developercertificate.org/) for Developer
+Certificate of Origin (DCO) compliance. A sign-off in the pull request
+description does not satisfy this requirement.
+
+Create a signed-off commit with:
+
+```bash
+git commit -s -m "Describe the change"
+```
+
+Git appends a trailer in this form:
+
+```text
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+Use your own name and email address. If you amend, rebase, squash, or
+cherry-pick commits, confirm that every resulting commit still contains a valid
+trailer. DCO sign-off is a commit-message declaration; it is separate from
+cryptographic commit signing.
+
+Commits without the required sign-off will not be accepted.
+
+## Open a Pull Request
+
+Complete [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md).
+
+Your pull request should include:
+
+- The problem and intended outcome.
+- The examples or repository surfaces affected.
+- Exact verification commands and results.
+- An explanation for applicable checks that were not run.
+- Documentation and dependency changes.
+- Migration details and downstream follow-ups, when applicable.
+- Confirmation that every commit includes DCO sign-off.
+
+Submit all changes to `main` through a pull request. Maintainers merge only
+after the DCO and license-header requirements are satisfied, review
+conversations are resolved, and a maintainer approves the change.
+
+Maintainers review and merge contributions according to
+[GOVERNANCE.md](GOVERNANCE.md). Major scope, distribution, dependency, or
+compliance changes may require additional review before merge.
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the Apache 2.0 License.
+By contributing, you agree that your contributions will be licensed under the
+[Apache License 2.0](LICENSE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,10 @@
 
 Thank you for your interest in improving NemoClaw Community.
 
-This repository contains independently deployable examples and developer tools
-built around NemoClaw. By participating, you agree to follow our
+This repository contains NemoClaw examples and developer tools. You can deploy
+each example independently.
+
+By participating, you agree to follow our
 [Code of Conduct](CODE_OF_CONDUCT.md).
 
 Do not report security vulnerabilities in public issues or pull requests.
@@ -11,37 +13,49 @@ Follow [SECURITY.md](SECURITY.md) instead.
 
 ## Ways to Contribute
 
-- Improve an existing example or its documentation.
-- Fix setup, verification, teardown, or sandbox lifecycle problems.
+Use one of these methods to contribute:
+
+- Improve an example or its documentation.
+- Fix setup, checks, teardown, or sandbox lifecycle problems.
 - Add or improve agent skills, policies, integrations, or developer tools.
 - Contribute a new example.
-- Report a reproducible problem with the affected example and environment
-  details.
+- Report a reproducible problem.
 
-Choose a project from the [reference examples](README.md#reference-examples).
-Follow that example's README and any linked setup and verification
-instructions.
+For a problem report, identify the example. Give the environment details.
 
-Before implementing a major feature, new dependency, distribution change,
-container publication, or compliance-sensitive change, discuss it with the
-maintainers. See [GOVERNANCE.md](GOVERNANCE.md).
+Select an example from the
+[reference examples](README.md#reference-examples). Read the example's README.
+Follow all linked setup and check instructions.
+
+Discuss each of these changes with maintainers before implementation:
+
+- A major feature or scope change.
+- A new dependency.
+- A distribution change.
+- Publication of a container image.
+- A change to the project license or compliance requirements.
+
+For more information, read [GOVERNANCE.md](GOVERNANCE.md).
 
 ## Prerequisites
 
-Repository-level checks require:
+Install these tools before you run repository checks:
 
 - Git.
-- Python 3.10 or newer, invoked as `python3`.
+- Python 3.10 or newer. Use the `python3` command.
 
-Individual examples may require newer Python versions or additional tools such
-as Docker, `uv`, Helm, Bash, credentials, or access to external services.
-Follow the prerequisites documented by each example you modify.
+Some examples require a newer Python version, additional software, credentials,
+or external service access. The software can include Docker, `uv`, Helm, or
+Bash.
 
-## Fork and Create a Branch
+Follow the prerequisites in the README for each example that you modify.
 
-External contributors should first fork the repository on GitHub.
+## Create a Fork and Branch
 
-Clone your fork and add the NVIDIA repository as `upstream`:
+If you do not have write access to the NVIDIA repository, first create a fork
+on GitHub.
+
+Use these commands to clone your fork and create a branch:
 
 ```bash
 git clone https://github.com/<your-github-user>/nemoclaw-community.git
@@ -51,28 +65,28 @@ git fetch upstream main
 git checkout -b <short-branch-name> upstream/main
 ```
 
-Push your branch to your fork:
+Use this command to push the branch to your fork:
 
 ```bash
 git push -u origin <short-branch-name>
 ```
 
-Before opening or updating a pull request, refresh the upstream reference:
+Before you open or update a pull request, refresh the upstream reference:
 
 ```bash
 git fetch upstream main
 ```
 
-If the selected example uses a Git submodule, follow that example's README to
-initialize it. Recursive submodule checkout is not required for contributors
-working on unrelated examples.
+If the example uses a Git submodule, initialize the submodule as specified in
+the example's README. You do not need to initialize submodules for unrelated
+examples.
 
 ## Work Within an Example
 
-This repository does not have one shared runtime setup. Each example owns its
-development and verification workflow.
+This repository does not have one shared runtime setup. Each example defines
+its own development and verification workflow.
 
-Follow the selected example's instructions for:
+Follow the selected example's instructions for these items:
 
 - Prerequisites and supported environments.
 - Credentials and secret handling.
@@ -83,34 +97,45 @@ Follow the selected example's instructions for:
 - Cleanup and teardown.
 - Known limitations.
 
-Keep examples independently deployable. Do not introduce dependencies on
-private files, internal systems, or another example's local state.
+Keep each example independently deployable. Do not make an example depend on
+private files, internal systems, or local state from another example.
 
 ## Contribution Requirements
 
-Keep each pull request focused on one feature, fix, documentation update, or
+Limit each pull request to one feature, fix, documentation update, or
 coordinated migration.
 
-When applicable:
+Apply these conditional requirements:
 
-- Add or update tests for changed behavior.
-- Update documentation when setup, configuration, policy, permissions, or
-  user-visible behavior changes.
-- Update [THIRD-PARTY-NOTICES](THIRD-PARTY-NOTICES) when dependencies or
-  distributed third-party content change.
-- Preserve partner and community attribution.
-- Use placeholders in public configuration and documentation.
-- Do not commit secrets, populated `.env` files, private certificates, token
-  caches, generated runtime state, or private workspace details.
+- When behavior changes, add or update tests.
+- When setup, configuration, policy, permissions, or user-visible behavior
+  changes, update the documentation.
+- If the change does not require a third-party dependency, do not add one.
+- When dependencies or distributed third-party content change, update
+  [THIRD-PARTY-NOTICES](THIRD-PARTY-NOTICES).
+
+Apply these requirements to all pull requests:
+
+- Preserve partner and community attribution, including names and credits.
+- Use placeholders for private values in public configuration and
+  documentation.
+- Do not commit secrets, local `.env` files, private certificates, token
+  caches, generated snapshots, generated runtime state, or private workspace
+  details.
 - Do not add internal-only links to public documentation.
-- Do not contact external systems or start live services during verification
-  unless the change requires it and suitable credentials and authorization are
-  available.
 
-## Run Repository Checks
+Use these rules during checks:
 
-After committing your changes, run the repository-wide checks from the
-repository root:
+- If the change does not require an external system for a check, do not contact
+  that system.
+- If the change does not require a live service for a check, do not start that
+  service.
+- Before you contact an external system or start a live service, confirm that
+  you have the required credentials and authorization.
+
+## Check Your Changes
+
+After you commit your changes, run these commands from the repository root:
 
 ```bash
 python3 scripts/check_license_headers.py --check
@@ -118,68 +143,88 @@ git fetch upstream main
 git diff --check upstream/main...HEAD
 ```
 
-If you have staged but uncommitted changes, also run:
+If you have unstaged changes, also run this command:
+
+```bash
+git diff --check
+```
+
+If you have staged but uncommitted changes, also run this command:
 
 ```bash
 git diff --cached --check
 ```
 
-These checks do not replace example-specific validation. Run the setup, syntax,
-unit, configuration, and teardown-safe checks documented by every example
-modified in the pull request. Use the smallest stable check that demonstrates
-the changed behavior.
+These commands do not replace example-specific verification. For each changed
+example, run the checks that its README specifies.
 
-In the pull request description, record:
+Run the documented setup, syntax, unit, configuration, and teardown-safe checks.
+A stable check gives the same result when its inputs do not change. A
+teardown-safe check does not leave services or temporary resources active.
 
-- The exact commands you ran.
-- Their results.
-- Any verification you did not run and why.
-- Any required live, hardware-specific, credentialed, or external-system
-  validation that remains.
+Use the smallest stable check that shows the changed behavior.
 
-Do not describe a check as passing unless you ran it against the final relevant
-change set.
+In the pull request description, include this check information:
+
+- The exact commands that you ran.
+- The result of each command.
+- The verification that you did not complete and the reason.
+- The required live, hardware-specific, credentialed, or external-system
+  verification that remains.
+
+Before you report that a check passed, run it after the last change that can
+affect its result.
 
 ## Add a New Example
 
-Discuss the intended placement, name, and contributor or organizational
-provenance with the maintainers before implementation.
+Before implementation, discuss the example's location, name, and provenance
+with the maintainers. Provenance identifies the example's origin, history,
+contributors, and contributor organizations.
 
-A new example must document:
+Document this information for a new example:
 
 - Its purpose, intended users, and support boundary.
-- Contributor or organizational provenance.
-- Prerequisites and supported environments.
-- Architecture and major components.
-- Credentials and secret handling.
-- Setup and configuration.
-- Sandbox, network, and policy permissions.
-- Startup behavior.
-- Verification steps and expected results.
-- Teardown and cleanup.
-- Known limitations.
-- Third-party dependencies and licensing obligations.
+- Its contributor or organizational provenance.
+- Its prerequisites and supported environments.
+- Its architecture and major components.
+- Its credential and secret handling.
+- Its setup and configuration.
+- Its sandbox, network, and policy permissions.
+- Its startup behavior.
+- Its verification steps and expected results.
+- Its teardown and cleanup.
+- Its known limitations.
+- Its third-party dependencies and license obligations.
 
-Add the example to the [reference examples](README.md#reference-examples).
+Add the example to the
+[reference examples](README.md#reference-examples).
 
 ## Move or Rename an Example
 
-Before beginning a move:
+Before you move or rename an example, complete these steps:
 
-- Search the repository and open pull requests for the old path and name.
+- Search the repository for the old path and name.
+- Search open pull requests for the old path and name.
 - Identify affected pull requests and downstream documentation.
-- Record the intended merge order.
-- Coordinate rebases for dependent pull requests.
-- Separate path changes from unrelated runtime or dependency changes.
+- Record the merge order.
+- Coordinate the rebase sequence with owners of dependent pull requests.
+- Keep path changes separate from unrelated runtime or dependency changes.
 
-The migration pull request must:
+In the pull request for the move, complete these steps:
 
-- Provide an old-to-new path table.
+- Add a table that maps each old path to its new path.
 - Update links, commands, ownership, notices, and `.gitmodules` entries.
-- Document compatibility-sensitive identifiers that retain an old name.
-- Include instructions for existing clones when submodules move.
-- Verify every moved example from its new location.
-- Confirm that obsolete paths are gone after dependent branches are rebased.
+- List identifiers that must keep an old name for compatibility.
+- Give instructions for existing clones if a submodule moves.
+- Verify each moved example from its new location.
+- Remove obsolete paths.
+
+After the migration merges, owners of dependent pull requests must fetch the
+updated `main` branch from `upstream`. Then, each owner must rebase the pull
+request branch onto `upstream/main`.
+
+After each rebase, confirm that the pull request does not restore an obsolete
+path.
 
 ## Sign Off Every Commit
 
@@ -188,24 +233,26 @@ Every commit in a pull request must include a
 Certificate of Origin (DCO) compliance. A sign-off in the pull request
 description does not satisfy this requirement.
 
-Create a signed-off commit with:
+Create a signed-off commit with this command:
 
 ```bash
 git commit -s -m "Describe the change"
 ```
 
-Git appends a trailer in this form:
+Git adds a trailer in this form:
 
 ```text
 Signed-off-by: Your Name <your.email@example.com>
 ```
 
 Use your own name and email address. If you amend, rebase, squash, or
-cherry-pick commits, confirm that every resulting commit still contains a valid
-trailer. DCO sign-off is a commit-message declaration; it is separate from
+cherry-pick commits, confirm that each resulting commit still contains a valid
+`Signed-off-by:` trailer.
+
+DCO sign-off is a declaration in the commit message. It is separate from
 cryptographic commit signing.
 
-Commits without the required sign-off will not be accepted.
+Maintainers do not accept commits without the required sign-off.
 
 ## Open a Pull Request
 
@@ -213,21 +260,33 @@ Complete [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md).
 
 Your pull request should include:
 
-- The problem and intended outcome.
-- The examples or repository surfaces affected.
-- Exact verification commands and results.
-- An explanation for applicable checks that were not run.
-- Documentation and dependency changes.
-- Migration details and downstream follow-ups, when applicable.
+- The problem and expected result.
+- The examples and repository areas that the change affects.
+- The exact check commands and results.
+- An explanation for checks that you did not run.
+- The documentation and dependency changes.
+- For a migration, its details and downstream follow-up work.
 - Confirmation that every commit includes DCO sign-off.
 
-Submit all changes to `main` through a pull request. Maintainers merge only
-after the DCO and license-header requirements are satisfied, review
-conversations are resolved, and a maintainer approves the change.
+Submit all changes to `main` through a pull request.
+
+Maintainers merge a pull request only when all these conditions are true:
+
+- Every commit satisfies the DCO requirement.
+- The pull request satisfies the license-header requirements.
+- The pull request has no unresolved review conversations.
+- A maintainer approves the pull request.
 
 Maintainers review and merge contributions according to
-[GOVERNANCE.md](GOVERNANCE.md). Major scope, distribution, dependency, or
-compliance changes may require additional review before merge.
+[GOVERNANCE.md](GOVERNANCE.md).
+
+Maintainers may require NVIDIA internal open-source review for these changes:
+
+- A major scope change.
+- A new dependency.
+- A distribution scope change.
+- Publication of a container image.
+- A material change to the project license or compliance surface.
 
 ## License
 


### PR DESCRIPTION
## Description

Rewrite `CONTRIBUTING.md` around the full NemoClaw Community repository instead
of one example. The existing guide assumes contributors can push to the NVIDIA
repository, hard-codes checks for one example, and duplicates the full DCO text
without clearly distinguishing per-commit sign-off from cryptographic signing.

Apply a manual controlled-language pass based on
[ASD-STE100 Issue 9](https://www.asd-ste100.org/assets/files/ASD-STE100_ISSUE9.pdf).
This pass improves clarity, but it does not claim full ASD-STE100 conformance.
Full conformance also requires a controlled-dictionary review.

## Changes

- Add an external-contributor fork and `upstream` workflow.
- Separate repository-wide prerequisites and checks from example-owned setup
  and verification.
- Replace single-example shell and Python commands with universal SPDX and
  pull-request-range whitespace checks.
- Restore unstaged-change checks, dependency minimization, and the generated
  snapshot prohibition from the original guide.
- Document expectations for new examples and coordinated path migrations.
- Replace the embedded DCO text with concise, explicit per-commit sign-off
  instructions.
- Clarify security, dependency, attribution, verification-evidence, and
  maintainer-review expectations.
- Use short sentences, active voice, consistent terms, explicit conditions,
  and one action per instruction.

This is a standalone pull request against `main`. PR #61 also edits
`CONTRIBUTING.md` and will need to rebase or reconcile its smaller documentation
change after this lands.

The DCO workflow repair and `main` branch ruleset remain separate
repository-control follow-ups. This change describes the maintainer policy
without claiming those controls are currently operational.

## Verification

- [x] `python3 scripts/check_license_headers.py --check` — all 215 checked
  source files passed.
- [x] `git diff --check origin/main...HEAD`
- [x] All relative links in `CONTRIBUTING.md` resolve on current `main`.
- [x] All existing command blocks and link destinations remain unchanged.
- [x] No prose sentence exceeds 20 words.
- [x] No paragraph exceeds six sentences.
- [x] The prose has no semicolons.
- [x] No line exceeds 100 characters.
- [x] The pull request changes only `CONTRIBUTING.md`.

## Release And Compliance

- [x] No secrets, local `.env` files, private certificates, snapshots, or token
  caches are included.
- [x] No third-party dependency or distribution changes.
- [x] Public documentation contains no internal-only links or private workspace
  details.
- [x] Both commits include DCO sign-off (`git commit -s`).
