### PR TITLE
fix(ci): restore DCO enforcement

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -9,14 +9,42 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   dco:
     name: Check DCO sign-off
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: gsactions/dco-check@v1.1.1
+
+      - name: Check DCO sign-off
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          commit_count=0
+          missing_signoff=0
+
+          while IFS= read -r sha; do
+            commit_count=$((commit_count + 1))
+
+            if ! git show -s --format=%B "$sha" \
+              | git interpret-trailers --parse \
+              | grep -Eq '^Signed-off-by: .+ <[^<>[:space:]]+@[^<>[:space:]]+>$'; then
+              echo "::error::Commit $sha is missing a valid Signed-off-by trailer."
+              missing_signoff=1
+            fi
+          done < <(git rev-list --reverse "${BASE_SHA}..${HEAD_SHA}")
+
+          if ((commit_count == 0)); then
+            echo "::error::The pull request does not contain a commit to check."
+            exit 1
+          fi
+
+          exit "$missing_signoff"

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -191,10 +191,6 @@ Action: actions/setup-python@v5
 License: MIT
 URL: https://github.com/actions/setup-python
 
-Action: gsactions/dco-check@v1.1.1
-License: ISC
-URL: https://github.com/gsactions/dco-check
-
 ================================================================================
 External Source Archives And Services
 ================================================================================


### PR DESCRIPTION
## Summary

Restore per-commit DCO enforcement without relying on a third-party action.

## Root Cause

The workflow referenced `gsactions/dco-check@v1.1.1`. NVIDIA's Actions policy
rejects that action before runner allocation, and the referenced repository now
returns 404. All 138 runs of the current DCO workflow ended in
`startup_failure` with no jobs or check runs.

## Changes

- Replace the unavailable action with an inline Git commit-range check.
- Require a valid `Signed-off-by: Name <email>` trailer on every pull request
  commit.
- Fail closed when the pull request commit range is empty.
- Keep the check context named `Check DCO sign-off` for branch protection.
- Remove the unavailable action from `THIRD-PARTY-NOTICES`.
- Reduce workflow permissions to read-only repository contents.

The check reads commit messages only. It does not execute pull request code or
use secrets.

## Verification

- [x] The live `Check DCO sign-off` PR check passed.
- [x] The live `Check SPDX license headers` PR check passed.
- [x] `rhysd/actionlint:1.7.12` validates the workflow.
- [x] A signed commit range passes.
- [x] An unsigned commit range fails and identifies the commit SHA.
- [x] A mixed signed and unsigned range fails.
- [x] An empty range fails closed.
- [x] `python3 scripts/check_license_headers.py --check` — all 215 checked
  source files passed.
- [x] `git diff --check origin/main...HEAD`
- [x] The commit includes DCO sign-off.

## Rollout

`main` protection is enabled and requires the exact GitHub Actions checks
`Check DCO sign-off` and `Check SPDX license headers`, an up-to-date branch,
one independent approval, and resolved review conversations. The rule applies
to administrators and disallows force pushes and branch deletion.

After this pull request merges, the repaired DCO workflow will be available on
`main` for all future pull requests.
