### PR TITLE
chore: update code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # .github/CODEOWNERS
 #
-# Auto-assigns NemoClaw maintainers to all pull requests.
+# Auto-assigns the current NemoClaw Community maintainers to all pull requests.
 
-* @NVIDIA/nemoclaw-maintainer
+* @wscurran @apurvvkumaria @ericksoa @cv


### PR DESCRIPTION
## Summary

Replace the invalid NemoClaw maintainer team reference with the four current individual maintainers.

## Changes

- Make `@wscurran`, `@apurvvkumaria`, `@ericksoa`, and `@cv` code owners for all repository paths.
- Remove the unrecognized `@NVIDIA/nemoclaw-maintainer` owner.

Any one listed code owner can satisfy the code-owner approval requirement. The existing branch rule also prevents the last pusher from providing the only approval.

## Verification

- [x] All four GitHub accounts have Admin access to `NVIDIA/nemoclaw-community`.
- [x] `python3 scripts/check_license_headers.py --check` — all 215 checked source files passed.
- [x] `git diff --check origin/main...HEAD`
- [x] The commit includes DCO sign-off.

## Rollout

After this pull request merges and GitHub reports zero CODEOWNERS errors, enable required code-owner reviews on the `main` protection rule.
