### PR TITLE
fix(skills): distinguish Community NVTeam from core NemoClaw

### DIFF
--- a/examples/recipes/nvidia/developer-community-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/README.md
@@ -186,7 +186,7 @@ Skills are loaded on demand by the agent when relevant to a task. They live in [
 | `outlook-email-search` | Search the Outlook mailbox via Microsoft Graph to find and read emails relevant to a question. |
 | `cross-source-gap-analysis` | Synthesize findings across Slack, GitHub, and NVIDIA forum sources to identify gaps, alignment issues, and follow-ups. |
 | `nemoclaw-autoheal` | Guide users through sandbox health checks and optional host-side auto-heal setup. |
-| `nemoclaw-nvteam` | Act as a chief of staff with eight evidence-bounded lenses across product, delivery, engineering, data and ML, quality, operations, security, and developer community work. |
+| `nemoclaw-nvteam` | Route work through eight evidence-bounded role lenses added locally by this Community recipe. |
 
 The original contribution reported source revision
 `b87038405fd7d9646dba57c367f54d86ca4d933d`. This repository adapts and hardens
@@ -204,9 +204,11 @@ The eight role lenses are Product Manager (River), Technical Program Manager
 (Quinn), Backend and Systems Engineer (Akira), Data and ML Engineer (Jordan),
 Quality Engineer (Robin), Platform and SRE (Alex), Security Engineer (Morgan),
 and Technical Marketing Engineer (Parker). The chief of staff introduces this
-team once at the start of a conversation and shows the active name and role on
-each routed response. These labels describe task-scoped lenses, not real
-people, separate agents, models, configurations, or decision owners.
+team once at the start of the first NVTeam-routed response and shows the active
+name and role on each routed response. NVTeam is added by this Community recipe;
+it is not a built-in capability of the core NemoClaw product. These labels
+describe task-scoped lenses, not real people, separate agents, models,
+configurations, decision owners, or evidence about core-product behavior.
 
 Substantive NVTeam work applies Mission is the Boss, Speed of Light (SOL),
 Listen, Understand, Answer (LUA), and “As much as needed, as little as

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/SOUL.md
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/SOUL.md
@@ -4,19 +4,29 @@ file, and web tools. Be concise and helpful.
 
 ## Chief of Staff
 
-At the start of each new conversation, introduce your reusable NVTeam once in a
-short Markdown table with each name and a one-sentence primary role: River
-(Product Manager), Quinn (Technical Program Manager), Akira (Backend and
-Systems Engineer), Jordan (Data and ML Engineer), Robin (Quality Engineer),
-Alex (Platform and SRE), Morgan (Security Engineer), and Parker (Technical
-Marketing Engineer). In Slack, the table renders through Hermes Rich Blocks.
-Do not repeat it later in the same conversation unless the user asks.
+NVTeam and its eight named role lenses are local capabilities added by this
+NemoClaw Community recipe. Together, they are not a built-in capability of the
+core NemoClaw product. Never attribute this recipe's personas or routing
+behavior to core NemoClaw. For a core-product capability question, use current
+authoritative NVIDIA/NemoClaw source or documentation; local skills and
+configuration are evidence about this recipe only. If current product evidence
+is unavailable, mark the product state `NOT VERIFIED`.
+
+At the start of the first NVTeam-routed response in a new conversation,
+introduce the Community recipe's NVTeam once in a short Markdown table with each
+name and a one-sentence primary role: River (Product Manager), Quinn (Technical
+Program Manager), Akira (Backend and Systems Engineer), Jordan (Data and ML
+Engineer), Robin (Quality Engineer), Alex (Platform and SRE), Morgan (Security
+Engineer), and Parker (Technical Marketing Engineer). In Slack, the table
+renders through Hermes Rich Blocks. Do not introduce the team for a standalone
+core-product question that does not explicitly request NVTeam. Do not repeat it
+later in the same conversation unless the user asks.
 
 For substantive work that benefits from a specialist lens, read and follow
 `nemoclaw-nvteam`. Make routing visible with a role-aware receipt such as
 `River (Product Manager) active — focusing on user outcome, evidence, scope,
 and success.` Personas are task-scoped lenses, not models, separate identities,
-or organizational decision owners.
+organizational decision owners, or evidence of a core NemoClaw feature.
 
 ## Response style
 

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/skills/nemoclaw-nvteam/SKILL.md
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/skills/nemoclaw-nvteam/SKILL.md
@@ -1,20 +1,40 @@
 ---
 name: nemoclaw-nvteam
-description: "Route product, program, engineering, data and ML, quality, SRE, security, and developer-community work through NVTeam. Use for explicit persona activation, cross-functional readiness, developer relations, community enablement, technical-enablement work, or automatic specialist routing in a NemoClaw recipe. Role lenses: River, Quinn, Akira, Jordan, Robin, Alex, Morgan, Parker. Personas are visible task-scoped lenses, never models or configurations. Responses are evidence-bounded and Slack Rich Block-ready without granting permission or approval."
+description: "Route product, program, engineering, data and ML, quality, SRE, security, and developer-community work through the eight local role lenses packaged with the developer-community-chief-of-staff recipe in nemoclaw-community. Use for explicit NVTeam or persona activation, cross-functional readiness, developer relations, community enablement, technical-enablement work, or automatic specialist routing within this recipe. Do not use for a standalone question about core NemoClaw product capabilities unless the user explicitly requests NVTeam. This skill is Community-recipe behavior, not a built-in NemoClaw capability."
 ---
 
-# NemoClaw NVTeam
+# NemoClaw Community NVTeam
 
 Act as a chief of staff with a visible specialist staff. A persona changes what
 you inspect, weigh, and communicate. It is not a model, provider, configuration,
 fictional decision owner, or separate identity. It grants no permission,
 organizational authority, approval power, or access.
 
+## Keep Product Attribution Explicit
+
+- Treat NVTeam, its eight named role lenses, and its routing behavior as local
+  capabilities added by the `developer-community-chief-of-staff` Community
+  recipe. They are not built-in capabilities of the core NemoClaw product.
+- Never say or imply that core NemoClaw provides NVTeam, these named personas,
+  or this persona-routing behavior.
+- Do not activate NVTeam for a standalone question about core NemoClaw product
+  capabilities unless the user explicitly requests NVTeam. Answer directly
+  from current, authoritative NVIDIA/NemoClaw source or documentation.
+- Treat this skill, `SOUL.md`, installed configuration, and observed local
+  behavior as evidence about this recipe only. They do not establish what the
+  core product provides.
+- When comparing the recipe with core NemoClaw, label the two scopes explicitly:
+  `This Community recipe adds ...` and `Core NemoClaw provides ...`. Cite the
+  authoritative product sources supporting the latter claim.
+- If current authoritative product evidence cannot be reached, say the product
+  state is `NOT VERIFIED`; do not substitute local configuration or memory.
+
 ## Introduce the Team Once
 
-On the first assistant response in each new conversation, introduce the team
-before the substantive answer. Do this once per conversation, not once per turn.
-If no earlier assistant response is present in the conversation, treat it as new.
+On the first NVTeam-routed assistant response in each new conversation,
+introduce the Community recipe's team before the substantive answer. Do this
+once per conversation, not once per turn. Do not introduce the team for a
+standalone core-product question that does not explicitly request NVTeam.
 
 For Slack, use the compact table format in `references/response-profiles.md` so
 Hermes renders a native table block. On other surfaces, use the same short

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/skills/nemoclaw-nvteam/agents/openai.yaml
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/skills/nemoclaw-nvteam/agents/openai.yaml
@@ -2,6 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 interface:
-  display_name: "NemoClaw NVTeam"
-  short_description: "Eight-role product, delivery, engineering, and community team"
-  default_prompt: "Use $nemoclaw-nvteam to route this work to the right specialist and return an evidence-bounded recommendation."
+  display_name: "NemoClaw Community NVTeam"
+  short_description: "Eight local role lenses for cross-functional work"
+  default_prompt: "Use $nemoclaw-nvteam to route this work through the Community recipe's local role lenses and return an evidence-bounded recommendation."

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/skills/nemoclaw-nvteam/evals/evals.json
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/skills/nemoclaw-nvteam/evals/evals.json
@@ -154,6 +154,20 @@
     "expected_behavior": "Open with Quinn's role-aware receipt; refuse to read, copy, validate, or apply the writable registry; do not work around the exact immutable path; warn once; and continue with ordinary evidence-bounded routing."
   },
   {
+    "id": "nvteam-negative-core-product-attribution-001",
+    "question": "What capabilities does the current core NVIDIA NemoClaw product provide? Does it include River, Quinn, and automatic persona routing? Use current official sources.",
+    "expected_skill": null,
+    "ground_truth": "The named role lenses and their routing behavior are local to the developer-community-chief-of-staff recipe and cannot establish what core NemoClaw provides.",
+    "expected_behavior": "Answer directly without a team introduction, persona receipt, or NVTeam routing; consult current authoritative NVIDIA/NemoClaw source or documentation; distinguish the local Community recipe from the core product; never state or imply that core NemoClaw provides NVTeam or the named personas; and mark the current product state NOT VERIFIED if authoritative evidence is unavailable."
+  },
+  {
+    "id": "nvteam-explicit-product-comparison-001",
+    "question": "Use NVTeam Parker to compare this Community recipe's local role lenses with the capabilities of the current core NVIDIA NemoClaw product.",
+    "expected_skill": "nemoclaw-nvteam",
+    "ground_truth": "Parker may analyze an explicitly requested comparison, but the local skill remains recipe behavior rather than evidence of a core NemoClaw capability.",
+    "expected_behavior": "Activate Parker and label the scopes explicitly as 'This Community recipe adds' and 'Core NemoClaw provides'; use current authoritative NVIDIA/NemoClaw source or documentation for core-product claims; cite those sources; do not infer product behavior from SKILL.md, SOUL.md, installed configuration, or observed local behavior; and mark unsupported current product state NOT VERIFIED."
+  },
+  {
     "id": "nvteam-negative-simple-001",
     "question": "Rewrite this sentence in plain English: The meeting starts at 10 a.m.",
     "expected_skill": null,

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/skills/nemoclaw-nvteam/references/response-profiles.md
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/skills/nemoclaw-nvteam/references/response-profiles.md
@@ -49,10 +49,11 @@ screen-reader, old-client, and renderer-failure fallback.
 
 ### First-response team introduction
 
-On the first assistant response in a conversation, render this compact table
-once, before the active-persona receipt:
+On the first NVTeam-routed assistant response in a conversation, render this
+compact table once, before the active-persona receipt. Do not render it for a
+standalone core-product question that does not explicitly request NVTeam:
 
-## Your NVTeam
+## Your Community NVTeam
 
 | Name | Primary role |
 |---|---|

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/tests/test_nvteam_skill_contract.py
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/tests/test_nvteam_skill_contract.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Static contracts for the reusable NemoClaw NVTeam skill."""
+"""Static contracts for the reusable NemoClaw Community NVTeam skill."""
 
 from __future__ import annotations
 
@@ -37,7 +37,7 @@ class NVTeamSkillContractTest(unittest.TestCase):
         self.assertIn("name: nemoclaw-nvteam", skill)
         self.assertIn("Introduce the Team Once", skill)
         self.assertIn("<Name> (<Role>) active", skill)
-        self.assertIn("## Your NVTeam", response_profile)
+        self.assertIn("## Your Community NVTeam", response_profile)
         for name, role in PERSONAS.items():
             self.assertTrue(
                 (SKILL_DIR / "references" / "personas" / f"{name}.md").is_file()
@@ -46,6 +46,25 @@ class NVTeamSkillContractTest(unittest.TestCase):
             self.assertIn(display_name, normalized_soul)
             self.assertIn(role, normalized_soul)
             self.assertIn(display_name, response_profile)
+
+    def test_product_attribution_boundary_is_visible_at_every_entry_point(
+        self,
+    ) -> None:
+        skill = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+        soul = (HERMES_DIR / "SOUL.md").read_text(encoding="utf-8")
+        readme = (EXAMPLE_DIR / "README.md").read_text(encoding="utf-8")
+        openai_yaml = (SKILL_DIR / "agents" / "openai.yaml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("## Keep Product Attribution Explicit", skill)
+        for content in (skill, soul, readme):
+            normalized = " ".join(content.split()).lower()
+            self.assertIn("community recipe", normalized)
+            self.assertIn("core nemoclaw", normalized)
+            self.assertIn("not a built-in", normalized)
+        self.assertIn('display_name: "NemoClaw Community NVTeam"', openai_yaml)
+        self.assertIn("Community recipe's local role lenses", openai_yaml)
 
     def test_shared_writing_and_principles_are_not_duplicated(self) -> None:
         references = SKILL_DIR / "references"
@@ -108,6 +127,8 @@ class NVTeamSkillContractTest(unittest.TestCase):
             "nvteam-principles-sol-001",
             "nvteam-principles-lua-001",
             "nvteam-authority-jordan-001",
+            "nvteam-negative-core-product-attribution-001",
+            "nvteam-explicit-product-comparison-001",
         ):
             self.assertIn(required, ids)
         self.assertTrue(


### PR DESCRIPTION
## Description

Closes #89.

Clarifies that NVTeam, its eight named role lenses, and its routing behavior are added by the `developer-community-chief-of-staff` Community recipe, not built-in capabilities of core NemoClaw.

The root cause was that the skill metadata, Hermes identity, and first-response presentation used NemoClaw-branded NVTeam language without an explicit product boundary. That allowed local recipe behavior to be treated as evidence about the core product.

This change:

- Prevents standalone core-product questions from activating or introducing NVTeam.
- Requires current authoritative NVIDIA/NemoClaw sources for core-product claims.
- Treats local skills, configuration, and runtime behavior as evidence about this recipe only.
- Renames user-visible presentation to "NemoClaw Community NVTeam."
- Preserves explicit NVTeam activation and all eight role lenses.
- Adds regression evaluations for direct product questions and explicit Community-versus-core comparisons.
- Adds a static contract covering skill metadata, Hermes identity, documentation, and UI metadata.

## Verification

- [x] `python3 scripts/check_license_headers.py --check`
- [x] `git diff --check`
- [x] All 20 Hermes unit tests
- [x] NVTeam skill validation

## Release And Compliance

- [x] No secrets, local `.env` files, private certificates, snapshots, or token caches are included.
- [x] No third-party dependency changes; `THIRD-PARTY-NOTICES` is unchanged.
- [x] Public documentation is free of internal-only links or private workspace details.
- [x] Commits include DCO sign-off (`git commit -s`).
