### PR TITLE
feat(examples): add NVIDIA TAO Toolkit computer-vision recipe

### DIFF
--- a/.agents/skills/nemoclaw-community-contributor-examples/references/example-taxonomy.md
+++ b/.agents/skills/nemoclaw-community-contributor-examples/references/example-taxonomy.md
@@ -74,6 +74,7 @@ coordination and intelligence outcome rather than one analysis technique.
 | --- | --- |
 | Developer Community Chief of Staff | `examples/recipes/nvidia/developer-community-chief-of-staff/` |
 | Payment Operations Hermes Assistant | `examples/recipes/nvidia/payment-ops-hermes/` |
+| TAO Toolkit Computer Vision | `examples/recipes/nvidia/tao-computer-vision/` |
 | HPE Retail Assistant | `examples/recipes/partners/hpe/retail-assistant/` |
 | Tavily Watchtower | `examples/recipes/partners/tavily/watchtower/` |
 | DGX Station Blender and Omniverse | `examples/demos/field/blender-omniverse-dgx-station/` |

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -31,6 +31,10 @@ Image: vllm/vllm-openai
 License: Apache-2.0 and included component licenses
 URL: https://github.com/vllm-project/vllm
 
+Image: nvcr.io/nvidia/tao/tao-toolkit
+License: NVIDIA AI Product Agreement and included component licenses
+URL: https://catalog.ngc.nvidia.com/orgs/nvidia/teams/tao/containers/tao-toolkit
+
 ================================================================================
 Docker Compose Images
 ================================================================================
@@ -230,6 +234,18 @@ URL: https://github.com/lfdevs/blender_linux_arm64
 Model: NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
 License: NVIDIA Open Model License
 URL: https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
+
+Project: NVIDIA-TAO/tao-skills-bank
+License: Apache-2.0
+URL: https://github.com/NVIDIA-TAO/tao-skills-bank
+
+Model: timm/resnet18.a1_in1k ImageNet backbone
+License: Apache-2.0
+URL: https://huggingface.co/timm/resnet18.a1_in1k
+
+Dataset: AI-Lab-Makerere/beans leaf disease images
+License: MIT
+URL: https://huggingface.co/datasets/AI-Lab-Makerere/beans
 
 Service: GitHub API
 Terms: See provider terms

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,6 +13,7 @@ again by contributor provenance.
 | [Developer Community Chief of Staff](recipes/nvidia/developer-community-chief-of-staff/README.md) | Synthesizes Slack, Outlook, GitHub, and mirrored community signals into operating briefs, gaps, priorities, and follow-up recommendations. |
 | [NV Tech Assistant](recipes/nvidia/nv-tech-assistant/README.md) | Answers NVIDIA technical questions with cited evidence from allowlisted NVIDIA, GitHub, and arXiv sources. |
 | [Payment Operations Hermes Assistant](recipes/nvidia/payment-ops-hermes/README.md) | Demonstrates constrained payment screening, evidence preparation, and a platform-enforced human release boundary. |
+| [TAO Toolkit Computer Vision](recipes/nvidia/tao-computer-vision/README.md) | Drives NVIDIA TAO Toolkit from a control-plane agent to train, evaluate, and run inference on computer-vision models on a host GPU, with host-side dataset pre-flight and a Docker/GPU/NGC boundary the agent cannot cross. |
 
 ## Partner Recipes
 

--- a/examples/recipes/nvidia/tao-computer-vision/.env.example
+++ b/examples/recipes/nvidia/tao-computer-vision/.env.example
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copy to .env and fill in. Never commit .env.
+
+# Required: OpenAI-compatible inference key for the NemoClaw agent.
+NEMOCLAW_PROVIDER_KEY=
+
+# Optional: NGC API key. Only needed if a skill pulls a gated NGC model or
+# checkpoint. The TAO container images use `docker login nvcr.io` on the host,
+# not this variable.
+NGC_API_KEY=
+
+# Optional: HuggingFace token. Only needed for gated datasets or backbones. The
+# assets scripts/verify.sh uses (AI-Lab-Makerere/beans and
+# timm/resnet18.a1_in1k) are public and need no token.
+HF_TOKEN=
+
+# Optional overrides (sensible defaults are used when unset).
+# TAO_SANDBOX=tao                       # NemoClaw sandbox name
+# TAO_WORKSPACE=$HOME/tao-workspace     # host workspace root (datasets + results)
+# TAO_SKILL_REF=main                    # tao-skills-bank branch or tag to install
+# TAO_SHELL_IMAGE=                      # override the pyt image tao_exec runs
+                                        # (otherwise resolved from the bank's versions.yaml)
+# TAO_VERIFY_MIN_ACC=0.80               # accuracy floor scripts/verify.sh enforces

--- a/examples/recipes/nvidia/tao-computer-vision/.gitignore
+++ b/examples/recipes/nvidia/tao-computer-vision/.gitignore
@@ -1,0 +1,3 @@
+.env
+.tmp/
+external/

--- a/examples/recipes/nvidia/tao-computer-vision/README.md
+++ b/examples/recipes/nvidia/tao-computer-vision/README.md
@@ -1,0 +1,258 @@
+# NVIDIA TAO Toolkit — Computer Vision Model Engineer
+
+A NemoClaw community recipe for an always-on agent that trains, evaluates, and
+runs inference on computer-vision models with
+[NVIDIA TAO Toolkit](https://developer.nvidia.com/tao-toolkit) — object
+detection, segmentation, classification, pose, OCR, visual inspection, and
+more — on a host GPU.
+
+The agent is a **control-plane agent**. It never holds host credentials and
+never touches Docker, the GPU, or NGC directly. It drives everything through a
+host-side `tao` MCP server across **two planes joined by one shared workspace**:
+
+- **`tao_exec` — the CPU shell.** A confined, GPU-less container over the host
+  workspace at `/workspace`. Everything that is not GPU compute happens here:
+  inspecting data, authoring specs, unpacking archives, and staging models and
+  datasets (`huggingface_hub` / `ngcsdk` / `curl`). It runs as the host user, so
+  every file it writes is owned by that user — not root.
+- **`tao_run` — the GPU job.** Each call launches one fresh GPU container for a
+  heavy job (train / evaluate / inference / export), mounting the chosen
+  workspace subdirs at `/data` and `/results`.
+
+Docker, the GPU, and NGC credentials stay on the host behind the MCP server. A
+prompt cannot make the agent reach them directly — the OpenShell sandbox has no
+Docker socket, no GPU, and no host credentials.
+
+## Deployment model
+
+This recipe runs on a single Linux host or VM with an NVIDIA GPU. The host runs
+Docker with the NVIDIA Container Toolkit and is logged in to NGC. The NemoClaw
+gateway supervises a CPU-only OpenShell sandbox on the same host; the agent
+inside it reaches the host-side `tao` MCP server over the Docker bridge
+(`host.openshell.internal`). The server, not the agent, owns the GPU and
+credentials.
+
+This is an educational, single-host deployment — not a managed training
+platform. Production adopters should preserve its control boundaries (agent has
+no host GPU/credential access; all GPU work goes through the audited MCP server)
+while pointing the workspace at their own datasets and storage.
+
+## Architecture
+
+```mermaid
+%%{init: {'theme': 'default', 'flowchart': {'nodeSpacing': 40, 'rankSpacing': 70, 'curve': 'basis'}}}%%
+flowchart LR
+    operator["Engineer / operator"]
+    inference["OpenAI-compatible<br/>inference endpoint"]
+    ngc["NGC / HuggingFace<br/>images + public backbones"]
+
+    subgraph host["Linux host with NVIDIA GPU"]
+        direction TB
+        gateway["NemoClaw gateway<br/>provider store + policy"]
+        mcp["tao MCP server<br/>host UID:GID · Docker · GPU · NGC"]
+        ws[("/workspace<br/>datasets + results")]
+
+        subgraph supervisor["OpenShell sandbox supervisor"]
+            direction TB
+            policy["L7 egress policy<br/>bridge-only to tao MCP"]
+
+            subgraph sandbox["tao sandbox (CPU-only)"]
+                direction TB
+                agent["OpenClaw agent<br/>no Docker · no GPU · no creds"]
+                skills["TAO skill bank<br/>per-model SKILL.md + preflight"]
+                agent -->|"reads skills"| skills
+            end
+        end
+
+        agent -->|"tao_exec / tao_run / tao_pull ... (MCP over bridge)"| policy
+        policy --> mcp
+        mcp -->|"CPU shell: stage, validate, author"| shell["tao_exec container<br/>/workspace"]
+        mcp -->|"GPU job: train / eval / infer"| gpu["tao_run container<br/>/data · /results"]
+        shell --> ws
+        gpu --> ws
+        gateway <--> policy
+    end
+
+    operator --> agent
+    policy -->|"credentialed model request"| inference
+    mcp --> ngc
+    agent -.->|"denied: no host Docker / GPU / creds"| mcp
+
+    style host fill:#f7f6ef,stroke:#8a8068,stroke-width:2px
+    style supervisor fill:#e7f0ff,stroke:#2b5fab,stroke-width:3px
+    style sandbox fill:#d8e8ff,stroke:#2b5fab,stroke-dasharray:5 3
+    style policy fill:#fce5cd,stroke:#e69138,stroke-width:2px
+    style mcp fill:#eef7e9,stroke:#6aa84f,stroke-width:2px
+```
+
+The central property is the split between the control-plane agent and the
+host-side executor. The agent decides *what* to run and prepares inputs in the
+CPU shell; the MCP server is the only component that touches Docker, the GPU,
+and NGC — and it launches every container as the host user with dropped
+capabilities.
+
+## Key invariants
+
+- The agent can inspect data, stage models, author specs, and launch/monitor
+  jobs; it cannot reach the host Docker socket, GPU, or NGC credentials.
+- File preparation and model/dataset staging run in a **CPU-only** `tao_exec`
+  shell — never a GPU container. A trivial file copy never spins up a GPU.
+- Every container (shell and GPU job) runs as the host `UID:GID` with
+  `--cap-drop ALL`; outputs are owned by the host user and removable without
+  `sudo`.
+- Heavy compute is a one-shot `tao_run` GPU job that releases the GPU on exit.
+- Datasets are validated on the host **before** any GPU launch. A malformed
+  dataset fails in under a second instead of minutes into a container.
+
+## Agent tools and skills
+
+The agent drives TAO through the host `tao` MCP server:
+
+| Tool | Purpose |
+|---|---|
+| `tao_exec` | Run a shell command in the CPU workspace container (inspect, stage, author, validate). |
+| `tao_pull` | Pull an NGC image to the host cache (the one slow, uncapped call). |
+| `tao_run` | Launch a GPU training / evaluation / inference / export job. |
+| `tao_status` / `tao_logs` / `tao_list` | Monitor and recover jobs. |
+| `tao_stop` / `tao_rm` / `tao_cleanup_results` | Stop, remove, and clean a job's isolated results. |
+
+Model behavior comes from the [TAO skill bank](https://github.com/NVIDIA-TAO/tao-skills-bank):
+each `models/tao-train-*` skill documents the exact container image, action
+command, spec schema, dataset contract, and a mandatory host-side **pre-flight**
+(for example the Visual ChangeNet classify preflight that rejects absolute CSV
+paths, flat-vs-directory layouts, single-class training sets, and oversized
+batches before launch).
+
+## Intended user journey
+
+1. Bring up the NemoClaw gateway, the CPU-only `tao` sandbox, and the host `tao`
+   MCP server.
+2. Put a dataset under the host workspace (`~/tao-workspace/<name>/`).
+3. Ask the agent to train, evaluate, or run inference on a model (e.g. "train
+   Visual ChangeNet classify on my AOI dataset"). It reads the skill, runs the
+   dataset pre-flight in the CPU shell, stages the public backbone, pulls the
+   image, launches the GPU job, and reports results.
+4. Watch it refuse a malformed dataset on the host before wasting a GPU
+   spin-up — the same pre-flight runs ahead of every launch.
+
+## Requirements
+
+- Linux `x86_64` or `aarch64` host with an NVIDIA GPU (16 GB+ VRAM).
+- Docker with the NVIDIA Container Toolkit, logged in to NGC
+  (`docker login nvcr.io`, user `$oauthtoken`).
+- The NemoClaw / OpenShell CLI with a running local gateway.
+- [`uv`](https://astral.sh/uv) on `PATH` (runs the MCP server).
+- An OpenAI-compatible inference key for the agent.
+- Optional: `HF_TOKEN` only if a skill uses a gated HuggingFace backbone; public
+  backbones (e.g. `nvidia/C-RADIOv2-B`) need no token.
+
+- Roughly 40 GB of free disk. The TAO PyTorch image alone is **~27 GB**, pulled
+  from NGC on first use; budget 15–30 minutes for that pull on a first run.
+
+Review NGC and third-party license terms before use; the community repository
+records third-party components in its root `THIRD-PARTY-NOTICES` file.
+
+## Quick start
+
+```console
+$ cp .env.example .env
+$ # Edit .env: set NEMOCLAW_PROVIDER_KEY (and NGC_API_KEY / HF_TOKEN if needed).
+$ bash scripts/bring-up.sh
+```
+
+`bring-up.sh` clones the public TAO skill bank, ensures a CPU-only `tao`
+sandbox, and runs the bank's `integrations/nemoclaw/setup-tao-nemoclaw.sh`,
+which starts the host `tao` MCP server (bound to the Docker bridge), installs
+the skill bank into the sandbox, resolves the pinned TAO image for the shell,
+adds the bridge egress policy, and reloads the gateway. It is also the resume
+command: rerunning it reuses a healthy sandbox, and reuses an MCP server that is
+already answering on `:9901` rather than restarting it — run
+`scripts/tear-down.sh` first if you changed the workspace or the skill bank ref.
+The first run pulls the ~27 GB TAO image, which dominates setup time.
+
+Then connect to the sandbox and ask the agent what it can do:
+
+```console
+$ nemoclaw tao agent --agent main -m "What TAO models can you train, and what data do you need?"
+```
+
+## Verify the deployment
+
+```console
+$ bash scripts/verify.sh
+```
+
+The verification first confirms the MCP server is running, the sandbox reaches
+it over the bridge, and the skill bank is installed. It then runs the recipe's
+real workload: **one prompt that drives a full TAO train → evaluate → inference
+cycle on the host GPU**, using nothing but public assets.
+
+The agent stages the [`beans`](https://huggingface.co/datasets/AI-Lab-Makerere/beans)
+leaf-disease dataset (MIT, 3 classes, ~1.3k images) and a public ImageNet
+`resnet_18` backbone ([`timm/resnet18.a1_in1k`](https://huggingface.co/timm/resnet18.a1_in1k),
+Apache-2.0) in the CPU shell, then launches three GPU jobs and reports the
+accuracy and its predictions:
+
+```text
+==> Train -> evaluate -> inference on public data
+  [ok]   agent trained a classifier on public data (val_acc_1 = 0.9172932505607605)
+  [ok]   inference wrote 128 predictions to .../inference/.tao-jobs/<job>/result.csv
+         /data/test/healthy/healthy_test.7.jpg,healthy,0.8211978077888489
+VERIFY: PASS
+```
+
+`verify.sh` asserts against the artifacts on the host — the accuracy in
+`status.json` and the prediction rows in `result.csv` — not against what the
+agent says it did. Training is seeded and `cudnn.deterministic` is on, so the
+accuracy is reproducible run to run.
+
+Expect 7–9 minutes end to end on a single modern GPU, plus a ~180 MB dataset
+download the first time. See
+[`docs/verify-functionality.md`](docs/verify-functionality.md) for the full
+walkthrough and troubleshooting.
+
+## Repository layout
+
+```text
+scripts/         phased bring-up, verification, and teardown
+.env.example     inference key and optional NGC / HF tokens
+docs/            verification walkthrough and dataset-staging notes
+```
+
+The TAO integration itself (the `tao` MCP server, `setup-tao-nemoclaw.sh`, and
+the per-model skills) lives in the
+[TAO skill bank](https://github.com/NVIDIA-TAO/tao-skills-bank) under
+`integrations/nemoclaw/`; this recipe wraps it into a NemoClaw-native
+bring-up / verify / teardown flow.
+
+## Teardown
+
+The safe default stops the host `tao` MCP server and leaves the workspace and
+sandbox intact:
+
+```console
+$ bash scripts/tear-down.sh
+```
+
+Explicitly remove the sandbox as well:
+
+```console
+$ bash scripts/tear-down.sh --destroy-sandbox
+```
+
+The workspace under `~/tao-workspace` (datasets, checkpoints, results) is never
+deleted by teardown; remove it yourself when you no longer need the artifacts.
+
+## Data and safety
+
+- Datasets and checkpoints stay on the host under `~/tao-workspace`; the agent
+  reaches them only through the MCP server.
+- NGC and inference credentials live in the host provider store and the MCP
+  server's environment, never in the sandbox.
+- The verifier trains only on public, redistributable assets: the `beans`
+  dataset (MIT) and the `timm/resnet18.a1_in1k` ImageNet backbone (Apache-2.0).
+  No NGC model checkpoint is downloaded, and no token is needed for either.
+- TAO's public HuggingFace weights are training *backbones*, not zero-shot
+  checkpoints, so inference always follows a train step in this recipe.
+- Never place production credentials or proprietary datasets you cannot share in
+  a public deployment; this is an educational single-host example.

--- a/examples/recipes/nvidia/tao-computer-vision/docs/verify-functionality.md
+++ b/examples/recipes/nvidia/tao-computer-vision/docs/verify-functionality.md
@@ -1,0 +1,107 @@
+# Verify functionality
+
+`scripts/verify.sh` confirms the recipe is wired correctly, then has the agent
+drive a complete TAO **train → evaluate → inference** cycle on the host GPU from
+a single prompt, using only public data and public weights.
+
+## What it checks
+
+1. **MCP server up** — the host `tao` MCP server is listening on `:9901`.
+2. **Bridge reachable** — the sandbox can reach `host.openshell.internal:9901`
+   (HTTP `200`/`400`/`406` all mean the server answered; `403` means the egress
+   policy is blocking it; `000` means it is unreachable).
+3. **Skills installed** — `/sandbox/tao-skills-external/skills/models` exists in
+   the sandbox.
+4. **End-to-end model run** — the agent stages a dataset and a backbone in the
+   CPU shell, then runs three GPU jobs and reports the accuracy.
+
+The core checks are cheap and run first; if any of them fails the script stops
+before spending GPU time.
+
+## The end-to-end demo
+
+TAO's public HuggingFace weights are training **backbones**, not zero-shot
+checkpoints, so there is no meaningful "just run inference" demo — a checkpoint
+has to be trained first. The verifier therefore does the whole loop:
+
+| Step | Where | What |
+|---|---|---|
+| Stage dataset | `tao_exec` (CPU) | Downloads [`AI-Lab-Makerere/beans`](https://huggingface.co/datasets/AI-Lab-Makerere/beans) (MIT; 3 classes, 1034 train / 133 val / 128 test) and unpacks it folder-per-class |
+| Stage backbone | `tao_exec` (CPU) | Downloads [`timm/resnet18.a1_in1k`](https://huggingface.co/timm/resnet18.a1_in1k) (Apache-2.0) and strips its 1000-class ImageNet head |
+| Train | `tao_run` (GPU) | `classification_pyt train`, `resnet_18`, 10 epochs, 224×224 |
+| Evaluate | `tao_run` (GPU) | `classification_pyt evaluate` against the validation split |
+| Inference | `tao_run` (GPU) | `classification_pyt inference` over the 128 held-out test images |
+
+Neither asset is gated and neither needs a token. No NGC model checkpoint is
+downloaded — only the TAO container image itself comes from NGC.
+
+The ImageNet head must be stripped because it is shaped `[1000, 512]` while the
+3-class model expects `[3, 512]`; PyTorch raises a size mismatch on load even
+with `strict=False`. Dropping every `fc.*` tensor leaves the feature extractor,
+which is the part that transfers.
+
+## Expected result
+
+```text
+==> Core checks
+  [ok]   tao MCP server is listening on :9901
+  [ok]   sandbox reaches the tao MCP bridge (HTTP 406)
+  [ok]   skill bank installed in the sandbox
+==> Train -> evaluate -> inference on public data
+  [ok]   agent trained a classifier on public data (val_acc_1 = 0.9248120188713074)
+  [ok]   inference wrote 128 predictions to .../inference/.tao-jobs/<job>/result.csv
+         /data/test/healthy/healthy_test.7.jpg,healthy,0.8023015260696411
+         /data/test/healthy/healthy_test.23.jpg,healthy,0.9492994546890259
+         /data/test/healthy/healthy_test.33.jpg,healthy,0.9586153626441956
+
+VERIFY: PASS
+```
+
+`verify.sh` asserts against artifacts on the host, not against the agent's
+prose: it reads `val_acc_1` out of the `status.json` files written during this
+run and counts the prediction rows in the newest `result.csv`. The accuracy
+floor is `TAO_VERIFY_MIN_ACC` (default `0.80`); a healthy run lands around
+`0.92`. Because the spec sets `seed: 1234` and `cudnn.deterministic: true`, the
+number is reproducible run to run for a given container image.
+
+Budget **7–9 minutes** on a single modern GPU, plus a ~180 MB dataset download
+the first time (and the one-off ~27 GB TAO image pull before that). Staging is
+skipped on reruns, and the three GPU jobs are short — the training itself is
+about a minute.
+
+Validated on `nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt` (`val_acc_1` 0.9173) and
+on a 7.1.0 staging build (`0.9248`). The spec is identical on both; only the
+last digits of the accuracy move.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `no tao MCP server on :9901` | bring-up did not finish, or the server exited | rerun `bash scripts/bring-up.sh`; check `~/tao-workspace/tao-mcp-server.log` |
+| `ModuleNotFoundError: No module named 'mcp.server.fastmcp'` in the server log | the skill bank launches the server with an unpinned `uv run --with mcp`, and `mcp` 2.x removed that module | use a bank ref that pins `mcp<2` in `integrations/nemoclaw/setup-tao-nemoclaw.sh` |
+| bring-up says `bridge OK` but the agent uses the wrong image | a server from an earlier bring-up is still on `:9901`; bring-up reuses a healthy server rather than restarting it | `bash scripts/tear-down.sh`, wait for `:9901` to free, then rerun bring-up |
+| bridge returns `403` | egress policy not applied | rerun bring-up; confirm the `tao_mcp` policy is loaded |
+| bridge returns `000` | server bound to the wrong interface | ensure it is bound to the Docker bridge gateway, not `0.0.0.0` |
+| `no shell image available` from `tao_exec` | `TAO_SHELL_IMAGE` not resolved | ensure the bank's `versions.yaml` pins a `pyt` image, or set `TAO_SHELL_IMAGE` in `.env` |
+| empty agent output, script returns in ~1 min | the long-lived `main` session held its write lock | expected to be handled — `verify.sh` runs in its own `--session-key`; check no other agent invocation is mid-flight |
+| `no val_acc_1 was produced` | the train job never reached a terminal state | `nemoclaw <sandbox> agent --agent main -m "run tao_list and tao_logs for the last job"` |
+| `val_acc_1` below the floor | backbone was not applied, so the model trained from scratch | confirm `backbone.pth` exists and the train log says `Loaded pretrained weights`; from scratch this dataset plateaus near `0.62` |
+| size mismatch for `fc.weight` | the ImageNet head was not stripped | drop all `fc.*` tensors when staging the backbone |
+
+## Going further
+
+The same loop works for any TAO model in the bank — swap the skill and the
+dataset contract. Two notes from validating this recipe:
+
+- **Detection needs much more data.** RT-DETR on a 128-image COCO subset, even
+  with a public ImageNet ResNet-50 backbone, only reaches `mAP ≈ 0.06` after 100
+  epochs. DETR-family decoders need far more than a smoke-test dataset, which is
+  why the verifier uses classification.
+- **Backbones are interchangeable if the keys line up.** TAO's `resnet_18` /
+  `resnet_50` use the stock torchvision/timm layout, so public timm checkpoints
+  load with a full key match once the classifier head is removed.
+
+To train on your own data, drop a folder-per-class dataset under
+`~/tao-workspace/<name>/` with a `classes.txt`, and ask the agent to train on
+it. It will run the skill's pre-flight, stage the backbone, launch the GPU job,
+and report the result path.

--- a/examples/recipes/nvidia/tao-computer-vision/scripts/bring-up.sh
+++ b/examples/recipes/nvidia/tao-computer-vision/scripts/bring-up.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Bring up the TAO computer-vision recipe: install the TAO skill bank, ensure a
+# CPU-only NemoClaw sandbox, and wire the host `tao` MCP server into it. Also the
+# resume command — rerunning reuses a healthy sandbox and restarts the server.
+
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$DIR/.." && pwd)"
+cd "$ROOT"
+
+[ -f .env ] && { set -a; . ./.env; set +a; }
+
+SANDBOX="${TAO_SANDBOX:-tao}"
+WORKSPACE="${TAO_WORKSPACE:-$HOME/tao-workspace}"
+SKILL_REF="${TAO_SKILL_REF:-main}"
+BANK_REPO="https://github.com/NVIDIA-TAO/tao-skills-bank"
+BANK_DIR="$ROOT/external/tao-skills-bank"
+INTEG="$BANK_DIR/integrations/nemoclaw"
+
+for bin in docker uv nemoclaw git; do
+  command -v "$bin" >/dev/null || { echo "error: '$bin' not on PATH" >&2; exit 1; }
+done
+[ -n "${NEMOCLAW_PROVIDER_KEY:-}" ] || { echo "error: set NEMOCLAW_PROVIDER_KEY in .env" >&2; exit 1; }
+docker info >/dev/null 2>&1 || { echo "error: Docker is not available" >&2; exit 1; }
+
+echo "==> Installing the TAO skill bank ($SKILL_REF)"
+if [ -d "$BANK_DIR/.git" ]; then
+  git -C "$BANK_DIR" fetch -q origin "$SKILL_REF" && git -C "$BANK_DIR" checkout -q -B "$SKILL_REF" FETCH_HEAD
+else
+  git clone --depth 1 -b "$SKILL_REF" "$BANK_REPO" "$BANK_DIR"
+fi
+[ -f "$INTEG/setup-tao-nemoclaw.sh" ] || {
+  echo "error: this tao-skills-bank ref has no integrations/nemoclaw/ integration." >&2
+  echo "       Use a ref that ships the NemoClaw integration (TAO 7.1+)." >&2
+  exit 1
+}
+
+echo "==> Ensuring a CPU-only NemoClaw sandbox '$SANDBOX'"
+if ! nemoclaw list 2>/dev/null | grep -qw "$SANDBOX"; then
+  if [ -x "$INTEG/create-nemoclaw-sandbox.sh" ]; then
+    NEMOCLAW_PROVIDER_KEY="$NEMOCLAW_PROVIDER_KEY" "$INTEG/create-nemoclaw-sandbox.sh" openclaw "$SANDBOX"
+  else
+    echo "error: sandbox '$SANDBOX' not found. Onboard one first:  nemoclaw onboard" >&2
+    exit 1
+  fi
+fi
+
+echo "==> Wiring the host tao MCP server + skills into '$SANDBOX'"
+mkdir -p "$WORKSPACE"
+( cd "$INTEG" && SKILL_LOCAL="$BANK_DIR" ./setup-tao-nemoclaw.sh "$SANDBOX" "$WORKSPACE" )
+
+cat <<EOF
+
+==> Ready. Put a dataset under $WORKSPACE/<name>/ and ask the agent:
+
+    nemoclaw $SANDBOX agent --agent main -m "What TAO models can you train, and what data do you need?"
+
+Verify:   bash scripts/verify.sh
+Teardown: bash scripts/tear-down.sh [--destroy-sandbox]
+EOF

--- a/examples/recipes/nvidia/tao-computer-vision/scripts/tear-down.sh
+++ b/examples/recipes/nvidia/tao-computer-vision/scripts/tear-down.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tear down the TAO recipe. Safe default: stop the host tao MCP server only.
+# --destroy-sandbox also removes the NemoClaw sandbox. The host workspace
+# (datasets, checkpoints, results) is never deleted.
+
+set -uo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$DIR/.." && pwd)"
+cd "$ROOT"
+[ -f .env ] && { set -a; . ./.env; set +a; }
+
+SANDBOX="${TAO_SANDBOX:-tao}"
+WORKSPACE="${TAO_WORKSPACE:-$HOME/tao-workspace}"
+PORT=9901
+DESTROY=0
+for arg in "$@"; do [ "$arg" = "--destroy-sandbox" ] && DESTROY=1; done
+
+# Stop the MCP server by its listening port (never matches this script).
+SPID=$(ss -tlnp 2>/dev/null | grep ":$PORT" | grep -oE 'pid=[0-9]+' | head -1 | cut -d= -f2)
+if [ -n "${SPID:-}" ]; then
+  kill "$SPID" 2>/dev/null && echo "stopped tao MCP server (pid $SPID)"
+else
+  echo "no tao MCP server was running on :$PORT"
+fi
+
+if [ "$DESTROY" -eq 1 ]; then
+  nemoclaw "$SANDBOX" destroy --yes 2>/dev/null && echo "destroyed sandbox '$SANDBOX'" \
+    || echo "could not destroy sandbox '$SANDBOX' (already gone?)"
+fi
+
+echo "workspace kept at: $WORKSPACE  (remove manually when no longer needed)"

--- a/examples/recipes/nvidia/tao-computer-vision/scripts/verify.sh
+++ b/examples/recipes/nvidia/tao-computer-vision/scripts/verify.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Verify the TAO recipe: the host tao MCP server is up, the sandbox reaches it,
+# the skill bank is installed, and the agent drives a complete TAO
+# train -> evaluate -> inference cycle on the host GPU using only public data.
+
+set -uo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$DIR/.." && pwd)"
+cd "$ROOT"
+[ -f .env ] && { set -a; . ./.env; set +a; }
+
+SANDBOX="${TAO_SANDBOX:-tao}"
+WORKSPACE="${TAO_WORKSPACE:-$HOME/tao-workspace}"
+PORT=9901
+# The demo fine-tunes for 10 epochs from an ImageNet backbone; a healthy run
+# lands well above this floor. Lower it only to debug, never to pass a bad run.
+MIN_ACC="${TAO_VERIFY_MIN_ACC:-0.80}"
+fail=0
+pass() { echo "  [ok]   $*"; }
+bad()  { echo "  [FAIL] $*"; fail=1; }
+
+echo "==> Core checks"
+if ss -tlnp 2>/dev/null | grep -q ":$PORT"; then pass "tao MCP server is listening on :$PORT"
+else bad "no tao MCP server on :$PORT (run scripts/bring-up.sh)"; fi
+
+CODE=$(nemoclaw "$SANDBOX" exec -- curl -sS --max-time 8 -o /dev/null -w '%{http_code}' \
+       "http://host.openshell.internal:$PORT/mcp" 2>/dev/null || echo 000)
+case "$CODE" in
+  200|400|406) pass "sandbox reaches the tao MCP bridge (HTTP $CODE)";;
+  *)           bad  "sandbox cannot reach the tao MCP bridge (HTTP $CODE)";;
+esac
+
+if nemoclaw "$SANDBOX" exec -- bash -c 'ls /sandbox/tao-skills-external/skills/models >/dev/null 2>&1'; then
+  pass "skill bank installed in the sandbox"
+else bad "skill bank not installed in the sandbox"; fi
+
+[ "$fail" -eq 0 ] || { echo; echo "VERIFY: FAIL (core checks)"; exit 1; }
+
+echo "==> Train -> evaluate -> inference on public data"
+echo "    The agent stages the dataset and backbone itself, then runs three GPU"
+echo "    jobs. The first run downloads ~180 MB and takes a few minutes."
+
+STAMP="$WORKSPACE/.verify-start"
+: > "$STAMP"
+
+read -r -d '' PROMPT <<'AGENT_PROMPT'
+Train, evaluate, and run inference on a TAO image classifier end to end, using
+only public data and public weights. No NGC model checkpoints. Use plain
+training: automl_policy off, no HPO, no AutoML. Do everything through the tao
+MCP tools; read the tao-train-image-classification skill for the spec schema.
+
+1. Stage the dataset in the tao_exec CPU shell. Skip any step whose output
+   already exists. The beans leaf-disease dataset is public (MIT, 3 classes):
+
+     mkdir -p /workspace/beans/backbone
+     for s in train validation test; do
+       curl -sSL -o /workspace/beans/$s.zip \
+         https://huggingface.co/datasets/AI-Lab-Makerere/beans/resolve/main/data/$s.zip
+       unzip -q -o /workspace/beans/$s.zip -d /workspace/beans
+     done
+
+   That unpacks folder-per-class directories train/, validation/ and test/, each
+   holding angular_leaf_spot/, bean_rust/ and healthy/. Write those three names,
+   one per line, to /workspace/beans/classes.txt.
+
+2. Stage the public ImageNet backbone in the tao_exec shell (Apache-2.0, no
+   token needed):
+
+     curl -sSL -o /workspace/beans/backbone/resnet18_imagenet.pth \
+       https://huggingface.co/timm/resnet18.a1_in1k/resolve/main/pytorch_model.bin
+
+   Its 1000-class ImageNet head does not fit a 3-class model and torch raises a
+   size mismatch on load, so strip every tensor whose key starts with "fc." and
+   save the rest as /workspace/beans/backbone/backbone.pth.
+
+3. tao_pull the TAO PyTorch image, then run three tao_run jobs with
+   data_subdir "beans". /workspace/beans is mounted at /data inside each job.
+   Use backbone type resnet_18 with head in_channels 512, num_classes 3,
+   img_size 224, batch_size 64, wandb disabled, and point
+   dataset.train_dataset.images_dir at /data/train,
+   dataset.val_dataset.images_dir at /data/validation,
+   dataset.test_dataset.images_dir at /data/test and
+   dataset.classes_file at /data/classes.txt.
+
+     a. classification_pyt train - 10 epochs, adamw, lr 3e-4, 1 warmup epoch,
+        model.backbone.pretrained_backbone_path /data/backbone/backbone.pth
+     b. classification_pyt evaluate - checkpoint from the train results dir
+     c. classification_pyt inference - the same checkpoint
+
+   Poll tao_status until each job reaches a terminal state before starting the
+   next one - do not sleep in your own shell - and read the checkpoint filename
+   out of the train results directory rather than guessing it.
+
+4. Report the final val_acc_1, the host path of the inference result.csv, and
+   the first few predictions in it.
+AGENT_PROMPT
+
+# Run in a session of its own. Sharing the long-lived interactive `main` session
+# makes concurrent or back-to-back runs fail on its session write lock, and a
+# fresh session also keeps the demo reproducible.
+OUT=$(nemoclaw "$SANDBOX" agent --agent main --session-key "tao-verify-$$" \
+        -m "$PROMPT" 2>/dev/null)
+
+# Assert against host-side artifacts, not the agent's prose. The agent chooses
+# its own results_subdir, so scan the whole workspace and keep only files this
+# run produced.
+ACC=$(find "$WORKSPACE" -name status.json -newer "$STAMP" -exec cat {} + 2>/dev/null \
+      | grep -oE '"val_acc_1":[[:space:]]*[0-9.]+' | grep -oE '[0-9.]+$' | sort -g | tail -1)
+# Inference runs last, so the newest result.csv is its own.
+CSV=$(find "$WORKSPACE" -name result.csv -newer "$STAMP" -printf '%T@ %p\n' 2>/dev/null \
+      | sort -gr | head -1 | cut -d' ' -f2-)
+rm -f "$STAMP"
+
+if [ -n "$ACC" ] && awk "BEGIN{exit !($ACC >= $MIN_ACC)}"; then
+  pass "agent trained a classifier on public data (val_acc_1 = $ACC)"
+elif [ -n "$ACC" ]; then
+  bad "training ran but val_acc_1 = $ACC is below $MIN_ACC"
+else
+  bad "no val_acc_1 was produced - the training job did not complete"
+fi
+
+if [ -n "$CSV" ] && [ "$(grep -c . "$CSV")" -gt 1 ]; then
+  pass "inference wrote $(( $(grep -c . "$CSV") - 1 )) predictions to $CSV"
+  sed -n '2,4p' "$CSV" | sed 's/^/         /'
+else
+  bad "inference produced no result.csv under $WORKSPACE/results"
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "  --- agent output (tail) ---"; tail -n 12 <<<"$OUT" | sed 's/^/  /'
+fi
+
+echo ""
+[ "$fail" -eq 0 ] && echo "VERIFY: PASS" || echo "VERIFY: FAIL"
+exit "$fail"


### PR DESCRIPTION
## Summary

Adds `examples/recipes/nvidia/tao-computer-vision/` — a recipe where a control-plane agent drives [NVIDIA TAO Toolkit](https://developer.nvidia.com/tao-toolkit) to train, evaluate, and run inference on computer-vision models on a host GPU.

The agent holds no host credentials and never touches Docker, the GPU, or NGC. It works through a host-side `tao` MCP server across two planes joined by one shared workspace:

- **`tao_exec`** — a CPU-only shell for staging, inspection, and dataset pre-flight. A trivial file copy never spins up a GPU.
- **`tao_run`** — one-shot GPU jobs for train / evaluate / inference / export.

Every container runs as the host `UID:GID` with `--cap-drop ALL`, so outputs are owned by the invoking user and removable without `sudo`.

## What the verifier does

`scripts/verify.sh` checks the wiring, then drives a full **train → evaluate → inference** cycle from a single prompt using only public, redistributable assets:

| Asset | License | Gated |
|---|---|---|
| [`AI-Lab-Makerere/beans`](https://huggingface.co/datasets/AI-Lab-Makerere/beans) (3 classes, ~1.3k images) | MIT | no |
| [`timm/resnet18.a1_in1k`](https://huggingface.co/timm/resnet18.a1_in1k) ImageNet backbone | Apache-2.0 | no |

No NGC model checkpoint is downloaded and no token is required for either asset. TAO's public HuggingFace weights are training *backbones* rather than zero-shot checkpoints, so a trained checkpoint is a precondition for the inference step — hence the full cycle rather than a standalone inference demo.

```text
==> Train -> evaluate -> inference on public data
  [ok]   agent trained a classifier on public data (val_acc_1 = 0.9172932505607605)
  [ok]   inference wrote 128 predictions to .../inference/.tao-jobs/<job>/result.csv
         /data/test/healthy/healthy_test.7.jpg,healthy,0.8211978077888489
VERIFY: PASS
```

`verify.sh` asserts against artifacts on the host — `val_acc_1` in `status.json` and the prediction rows in `result.csv` — not against what the agent claims. Training is seeded with `cudnn.deterministic`, so the number is reproducible.

## Verification

Run end to end on a DGX Spark host (GB10):

- Clean-room test: fresh clone, empty workspace, public skill bank, `nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt` → **VERIFY: PASS in 7m15s**, `val_acc_1` 0.9173, 128 predictions.
- Also validated on a 7.1.0 staging build (`val_acc_1` 0.9248). The spec is identical on both.
- `python3 scripts/check_license_headers.py --check` → all files have SPDX headers.
- `git diff --check` → clean.

RT-DETR on a 128-image COCO subset was evaluated as an alternative and rejected: even with a public ImageNet ResNet-50 backbone it only reached `mAP ≈ 0.06` after 100 epochs, so classification is the honest choice for a smoke-test-sized public dataset. That finding is recorded in `docs/verify-functionality.md`.

## Dependency

`scripts/bring-up.sh` installs the public [TAO skill bank](https://github.com/NVIDIA-TAO/tao-skill-bank), which ships the `integrations/nemoclaw` integration this recipe wraps.

That bank currently launches its MCP server with an unpinned `uv run --with mcp`; `mcp` 2.x removed `mcp.server.fastmcp`, so a fresh bring-up fails until NVIDIA-TAO/tao-skill-bank#71 merges. The symptom and the workaround are documented in this recipe's troubleshooting table.

## Notes for reviewers

- Rebased onto current `main` as a single signed commit. An earlier "Update branch" merge commit carried no DCO sign-off, and this repo's DCO job checks every commit in the range (its `git rev-list` runs without `--no-merges`), so that merge was rebased away. Tree content is unchanged.
- `THIRD-PARTY-NOTICES` is updated with the TAO image, the skill bank, the backbone, and the dataset.
