### PR TITLE
fix(build): install GitHub CLI from base distribution

### DIFF
--- a/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/Dockerfile
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/Dockerfile
@@ -92,16 +92,11 @@ COPY extras/atif-export-relay/tls/ca.crt \
 
 RUN update-ca-certificates
 
-# Install GitHub CLI (gh) — not in the base image. It is not allowed in the
-# GitHub network policy by default, so live GitHub reads use the bundled
-# curl/Python-safe helper with the OpenShell provider placeholder.
-RUN mkdir -p /etc/apt/keyrings \
-    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-       -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
-       > /etc/apt/sources.list.d/github-cli.list \
-    && apt-get update \
+# Install GitHub CLI (gh). It is not allowed in the GitHub network policy by
+# default, so live GitHub reads use the bundled curl/Python-safe helper with
+# the OpenShell provider placeholder. The pinned Debian 13 base provides gh
+# directly, avoiding a second mutable signing-key endpoint during the build.
+RUN apt-get update \
     && apt-get install -y --no-install-recommends gh postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/tests/test_generate_config.py
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/tests/test_generate_config.py
@@ -125,6 +125,16 @@ class GenerateConfigTest(unittest.TestCase):
         self.assertIn("NEMOCLAW_SLACK_RICH_BLOCKS=true", env_example)
         self.assertIn("verify-rich-block-renderer.py", dockerfile)
 
+    def test_github_cli_uses_base_distribution_package(self) -> None:
+        dockerfile = (HERMES_DIR / "Dockerfile").read_text(encoding="utf-8")
+
+        self.assertNotIn("cli.github.com", dockerfile)
+        self.assertNotIn("githubcli-archive-keyring", dockerfile)
+        self.assertIn(
+            "apt-get install -y --no-install-recommends gh postgresql-client",
+            dockerfile,
+        )
+
     def test_slack_interactive_clarification_contract_is_baked_in(self) -> None:
         dockerfile = (HERMES_DIR / "Dockerfile").read_text(encoding="utf-8")
         patch = (HERMES_DIR / "patches" / "sitecustomize.py").read_text(


### PR DESCRIPTION
## Related issue

Closes #96

## Description

Make the Developer Community Chief of Staff image build independent of the separate `cli.github.com` package endpoint.

The Dockerfile previously downloaded GitHub CLI's signing key and added its external package repository. That endpoint returned HTTP 503 during a deployment rebuild and stopped the sandbox image build. The pinned Debian 13 base already supplies the `gh` package, so the additional key and repository are unnecessary.

This change:

- removes the custom GitHub CLI signing-key download and package source;
- installs `gh` and `postgresql-client` from the base distribution; and
- adds a regression test that rejects the external endpoint and keyring configuration.

Normal GitHub access is unchanged. Live repository reads still use the recipe's policy-scoped helper.

## Validation

- branch already contains current `main`
- complete chief-of-staff Python suite: 85 passed
- snapshot-safety suite: passed
- the identical package-source change was used in the clean deployment candidate and the complete image build succeeded
- the resulting image contains Debian package `gh` 2.46.0-3
- GitHub DCO, SPDX, and governance checks: passed
- `git diff --check`: passed

## Risk and rollback

The base distribution may supply an older GitHub CLI than GitHub's own package repository. The recipe does not depend on a newer CLI feature, and policy-scoped live GitHub reads do not use the CLI. Roll back by reverting this commit if a future base image stops providing a compatible package.
