### PR TITLE
fix(etl): return empty forum topics before first sync

### DIFF
--- a/examples/recipes/nvidia/developer-community-chief-of-staff/extras/docker-compose.yml
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/extras/docker-compose.yml
@@ -95,6 +95,7 @@ services:
       POSTGRES_DB: "${SOURCE_ETL_POSTGRES_DB:-source_etls}"
       POSTGRES_USER: "${SOURCE_ETL_POSTGRES_APP_USER:-source_etl_writer}"
       POSTGRES_PASSWORD: "${SOURCE_ETL_POSTGRES_APP_PASSWORD:-source_etl_writer}"
+      SOURCE_ETL_POSTGRES_READER_USER: "${SOURCE_ETL_POSTGRES_READER_USER:-source_etl_reader}"
       # HTTPX reads SSL_CERT_FILE because trust_env is enabled by default.
       # Mount the managed host bundle to keep forum TLS verification enabled.
       SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/extras/source-etls/forums-etl/refresh_api_views.py
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/extras/source-etls/forums-etl/refresh_api_views.py
@@ -6,6 +6,24 @@
 import os
 
 import psycopg
+from psycopg import sql
+
+
+EMPTY_FORUM_TOPICS_VIEW = """
+CREATE VIEW api.forum_topics AS
+SELECT
+    NULL::bigint AS topic_id,
+    NULL::text AS slug,
+    NULL::text AS title,
+    NULL::timestamp with time zone AS created_at,
+    NULL::timestamp with time zone AS last_posted_at,
+    NULL::bigint AS views,
+    NULL::bigint AS like_count,
+    NULL::bigint AS reply_count,
+    NULL::text AS raw_payload,
+    NULL::text AS raw_payload_text
+WHERE false
+"""
 
 
 def main() -> None:
@@ -17,7 +35,31 @@ def main() -> None:
         password=os.environ["POSTGRES_PASSWORD"],
     ) as conn:
         with conn.cursor() as cur:
-            cur.execute("SELECT api.refresh_views()")
+            cur.execute("SELECT to_regclass('forums_etl.forum_topics')")
+            forum_topics_exists = cur.fetchone()[0] is not None
+
+            # dlt does not create a destination table when a source returns no
+            # rows. Keep PostgREST's documented empty-array contract instead
+            # of returning 404 until the first matching forum topic arrives.
+            if not forum_topics_exists:
+                cur.execute("DROP VIEW IF EXISTS api.forum_topics")
+                cur.execute(EMPTY_FORUM_TOPICS_VIEW)
+                cur.execute(
+                    sql.SQL("GRANT SELECT ON api.forum_topics TO {}").format(
+                        sql.Identifier(
+                            os.environ.get(
+                                "SOURCE_ETL_POSTGRES_READER_USER",
+                                "source_etl_reader",
+                            )
+                        )
+                    )
+                )
+                cur.execute("NOTIFY pgrst, 'reload schema'")
+            else:
+                # Drop the typed empty fallback in the same transaction before
+                # replacing it with the view over dlt's inferred table schema.
+                cur.execute("DROP VIEW IF EXISTS api.forum_topics")
+                cur.execute("SELECT api.refresh_views()")
 
     print("source-etl api views refreshed", flush=True)
 

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/tests/test_forum_api_views.py
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/tests/test_forum_api_views.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+RECIPE_DIR = Path(__file__).resolve().parents[2]
+MODULE_PATH = (
+    RECIPE_DIR
+    / "extras/source-etls/forums-etl/refresh_api_views.py"
+)
+
+
+class FakeSQL(str):
+    def format(self, identifier: "FakeIdentifier") -> "FakeSQL":
+        return FakeSQL(self.replace("{}", f'"{identifier.name}"'))
+
+
+class FakeIdentifier:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class FakeCursor:
+    def __init__(self, table_exists: bool) -> None:
+        self.table_exists = table_exists
+        self.statements: list[str] = []
+
+    def __enter__(self) -> "FakeCursor":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def execute(self, statement: object) -> None:
+        self.statements.append(str(statement))
+
+    def fetchone(self) -> tuple[str | None]:
+        return ("forums_etl.forum_topics" if self.table_exists else None,)
+
+
+class FakeConnection:
+    def __init__(self, cursor: FakeCursor) -> None:
+        self._cursor = cursor
+
+    def __enter__(self) -> "FakeConnection":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def cursor(self) -> FakeCursor:
+        return self._cursor
+
+
+def load_module(cursor: FakeCursor):
+    fake_psycopg = types.ModuleType("psycopg")
+    fake_psycopg.sql = types.SimpleNamespace(SQL=FakeSQL, Identifier=FakeIdentifier)
+    fake_psycopg.connect = lambda **_kwargs: FakeConnection(cursor)
+
+    previous = sys.modules.get("psycopg")
+    sys.modules["psycopg"] = fake_psycopg
+    try:
+        spec = importlib.util.spec_from_file_location("refresh_api_views", MODULE_PATH)
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        if previous is None:
+            sys.modules.pop("psycopg", None)
+        else:
+            sys.modules["psycopg"] = previous
+
+
+def set_database_env(monkeypatch) -> None:
+    for key, value in {
+        "POSTGRES_HOST": "postgres",
+        "POSTGRES_DB": "source_etls",
+        "POSTGRES_USER": "source_etl_writer",
+        "POSTGRES_PASSWORD": "test-only",
+        "SOURCE_ETL_POSTGRES_READER_USER": "source_etl_reader",
+    }.items():
+        monkeypatch.setenv(key, value)
+
+
+def test_empty_source_creates_typed_empty_view(monkeypatch) -> None:
+    cursor = FakeCursor(table_exists=False)
+    module = load_module(cursor)
+    set_database_env(monkeypatch)
+
+    module.main()
+
+    rendered = "\n".join(cursor.statements)
+    assert "CREATE VIEW api.forum_topics" in rendered
+    assert 'GRANT SELECT ON api.forum_topics TO "source_etl_reader"' in rendered
+    assert "NOTIFY pgrst, 'reload schema'" in rendered
+    assert "SELECT api.refresh_views()" not in rendered
+
+
+def test_populated_source_replaces_fallback_with_normal_view(monkeypatch) -> None:
+    cursor = FakeCursor(table_exists=True)
+    module = load_module(cursor)
+    set_database_env(monkeypatch)
+
+    module.main()
+
+    assert cursor.statements[-2:] == [
+        "DROP VIEW IF EXISTS api.forum_topics",
+        "SELECT api.refresh_views()",
+    ]


### PR DESCRIPTION
## Related issue

Closes #98

## Description

Return a valid empty forum-topic collection before the first matching NVIDIA forum topic is imported.

The forum ETL uses `dlt`, which does not create `forums_etl.forum_topics` when a source run produces zero rows. The API refresh then leaves `api.forum_topics` absent, so PostgREST reports a missing resource instead of the documented empty mirror.

This change:

- detects whether the real forum-topic table exists;
- creates a typed, empty `api.forum_topics` view when it does not;
- grants the configured PostgREST reader access and reloads the API schema;
- replaces the fallback with the normal populated view once forum data arrives; and
- tests both the empty and populated transitions.

The public endpoint and populated-data schema are unchanged.

## Validation

- branch already contains current `main`
- complete chief-of-staff Python suite: 86 passed
- snapshot-safety suite: passed
- focused empty/populated view-transition tests: passed
- clean deployed candidate returned HTTP 200 with an empty collection in the pre-first-topic state
- populated services continued to run after the transition
- GitHub DCO, SPDX, and governance checks: passed
- `git diff --check`: passed

## Risk and rollback

Risk is limited to refreshing the forum API view. The fallback is read-only, contains no rows, and is dropped before the normal populated view is created. Roll back by reverting this commit; until real forum data arrives, the endpoint would again report a missing resource.
