### PR TITLE
ci(dco): check sign-offs before push

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+remote_name="${1:-origin}"
+repo_root="$(git rev-parse --show-toplevel)"
+checker="${repo_root}/scripts/check_dco_signoffs.sh"
+zero_sha="0000000000000000000000000000000000000000"
+failed=0
+
+find_main_base() {
+  local candidate
+
+  for candidate in refs/remotes/upstream/main refs/remotes/origin/main; do
+    if git rev-parse --verify --quiet "${candidate}^{commit}" >/dev/null; then
+      git rev-parse "${candidate}^{commit}"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+  if [[ "$local_sha" == "$zero_sha" || "$remote_ref" != refs/heads/* ]]; then
+    continue
+  fi
+
+  base_sha=""
+  if [[ "$remote_sha" != "$zero_sha" ]] \
+    && git rev-parse --verify --quiet "${remote_sha}^{commit}" >/dev/null; then
+    base_sha="$remote_sha"
+  else
+    base_sha="$(find_main_base || true)"
+  fi
+
+  if [[ -z "$base_sha" ]]; then
+    echo "DCO check failed: Cannot find upstream/main or origin/main for ${remote_ref}." >&2
+    echo "Fetch the current main branch, then push again." >&2
+    failed=1
+    continue
+  fi
+
+  if ! "$checker" "$base_sha" "$local_sha"; then
+    echo "Push to ${remote_name}:${remote_ref#refs/heads/} was stopped before data was sent." >&2
+    failed=1
+  fi
+done
+
+exit "$failed"

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -24,27 +24,4 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          commit_count=0
-          missing_signoff=0
-
-          while IFS= read -r sha; do
-            commit_count=$((commit_count + 1))
-
-            if ! git show -s --format=%B "$sha" \
-              | git interpret-trailers --parse \
-              | grep -Eq '^Signed-off-by: .+ <[^<>[:space:]]+@[^<>[:space:]]+>$'; then
-              echo "::error::Commit $sha is missing a valid Signed-off-by trailer."
-              missing_signoff=1
-            fi
-          done < <(git rev-list --reverse "${BASE_SHA}..${HEAD_SHA}")
-
-          if ((commit_count == 0)); then
-            echo "::error::The pull request does not contain a commit to check."
-            exit 1
-          fi
-
-          exit "$missing_signoff"
+        run: scripts/check_dco_signoffs.sh "$BASE_SHA" "$HEAD_SHA"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -273,6 +273,26 @@ Use your own name and email address. If you amend, rebase, squash, or
 cherry-pick commits, confirm that each resulting commit still contains a valid
 `Signed-off-by:` trailer.
 
+Install the repository's local Git hooks after you clone the repository:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Confirm the configuration with this command:
+
+```bash
+git config --get core.hooksPath
+```
+
+The pre-push hook checks every new branch commit before Git sends it to the
+remote repository. The hook stops the push if a commit does not contain a
+valid sign-off. Fetch `upstream/main` before you push a new branch so the hook
+can identify the contribution's commit range.
+
+Local hooks can be skipped or removed. The required GitHub DCO check remains
+the authoritative merge requirement.
+
 DCO sign-off is a declaration in the commit message. It is separate from
 cryptographic commit signing.
 

--- a/scripts/check_dco_signoffs.sh
+++ b/scripts/check_dco_signoffs.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <base-commit> <head-commit>" >&2
+  exit 2
+fi
+
+base_sha="$1"
+head_sha="$2"
+
+report_error() {
+  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    echo "::error::$1"
+  else
+    echo "DCO check failed: $1" >&2
+  fi
+}
+
+if ! git rev-parse --verify --quiet "${base_sha}^{commit}" >/dev/null; then
+  report_error "Base commit ${base_sha} is not available locally."
+  exit 2
+fi
+
+if ! git rev-parse --verify --quiet "${head_sha}^{commit}" >/dev/null; then
+  report_error "Head commit ${head_sha} is not available locally."
+  exit 2
+fi
+
+commit_count=0
+missing_signoff=0
+
+while IFS= read -r sha; do
+  commit_count=$((commit_count + 1))
+
+  if ! git show -s --format=%B "$sha" \
+    | git interpret-trailers --parse \
+    | grep -Eq '^Signed-off-by: .+ <[^<>[:space:]]+@[^<>[:space:]]+>$'; then
+    subject="$(git show -s --format=%s "$sha")"
+    report_error "Commit ${sha} (${subject}) is missing a valid Signed-off-by trailer."
+    missing_signoff=1
+  fi
+done < <(git rev-list --reverse "${base_sha}..${head_sha}")
+
+if ((commit_count == 0)); then
+  report_error "The commit range ${base_sha}..${head_sha} does not contain a commit to check."
+  exit 1
+fi
+
+if ((missing_signoff != 0)); then
+  echo "Create commits with 'git commit -s'. Repair the affected commit before pushing again." >&2
+  exit 1
+fi
+
+echo "DCO sign-off check passed for ${commit_count} commit(s)."

--- a/scripts/tests/test_dco_pre_push.py
+++ b/scripts/tests/test_dco_pre_push.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the repository DCO checker and pre-push hook."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHECKER = REPO_ROOT / "scripts" / "check_dco_signoffs.sh"
+PRE_PUSH = REPO_ROOT / ".githooks" / "pre-push"
+ZERO_SHA = "0" * 40
+
+
+class DcoPrePushTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.repo = Path(self.temp_dir.name)
+        (self.repo / "scripts").mkdir()
+        (self.repo / ".githooks").mkdir()
+        shutil.copy2(CHECKER, self.repo / "scripts" / CHECKER.name)
+        shutil.copy2(PRE_PUSH, self.repo / ".githooks" / PRE_PUSH.name)
+
+        self.git("init", "--initial-branch=main")
+        self.git("config", "user.name", "Test Contributor")
+        self.git("config", "user.email", "contributor@example.com")
+        self.commit("chore: establish base", signed_off=True)
+        self.base_sha = self.git("rev-parse", "HEAD").stdout.strip()
+        self.git("update-ref", "refs/remotes/origin/main", self.base_sha)
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def git(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *args],
+            cwd=self.repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    def commit(self, subject: str, *, signed_off: bool) -> str:
+        args = ["commit", "--allow-empty", "-m", subject]
+        if signed_off:
+            args.append("--signoff")
+        self.git(*args)
+        return self.git("rev-parse", "HEAD").stdout.strip()
+
+    def run_checker(self, head_sha: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(self.repo / "scripts" / CHECKER.name), self.base_sha, head_sha],
+            cwd=self.repo,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def run_pre_push(self, head_sha: str) -> subprocess.CompletedProcess[str]:
+        update = f"refs/heads/topic {head_sha} refs/heads/topic {ZERO_SHA}\n"
+        return subprocess.run(
+            [str(self.repo / ".githooks" / PRE_PUSH.name), "origin", "unused"],
+            cwd=self.repo,
+            input=update,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_checker_accepts_a_signed_off_commit(self) -> None:
+        head_sha = self.commit("fix: preserve sign-off", signed_off=True)
+
+        result = self.run_checker(head_sha)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("passed for 1 commit", result.stdout)
+
+    def test_checker_rejects_an_unsigned_commit(self) -> None:
+        head_sha = self.commit("fix: omit sign-off", signed_off=False)
+
+        result = self.run_checker(head_sha)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("missing a valid Signed-off-by trailer", result.stderr)
+
+    def test_pre_push_stops_an_unsigned_new_branch(self) -> None:
+        head_sha = self.commit("fix: stop unsigned push", signed_off=False)
+
+        result = self.run_pre_push(head_sha)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("was stopped before data was sent", result.stderr)
+
+    def test_pre_push_accepts_a_signed_off_new_branch(self) -> None:
+        head_sha = self.commit("fix: allow signed push", signed_off=True)
+
+        result = self.run_pre_push(head_sha)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("passed for 1 commit", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a repository pre-push hook that rejects branch updates containing commits without valid DCO trailers
- use one shared DCO range checker locally and in GitHub Actions
- document the one-time local hook installation command
- add focused coverage for accepted and rejected pushes

## Why

The required GitHub DCO check currently detects missing trailers only after a commit reaches a PR branch. The local hook gives contributors the same result before Git sends the branch update while preserving the required GitHub check as the authoritative merge gate.

Local hooks remain user-controlled and can be bypassed. This change does not claim to enforce policy inside user-owned forks without installation.

## Verification

- `bash -n scripts/check_dco_signoffs.sh .githooks/pre-push`
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 8 tests passed
- `python3 scripts/check_license_headers.py --check` — 253 files passed
- `python3 scripts/check_label_taxonomy.py --check` — 64 labels valid
- `git diff --check`

ShellCheck was not available locally; Bash syntax validation passed.
