### PR TITLE
ci(dco): require sign-off in pull requests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,4 +24,6 @@ Describe what changed and why.
 - [ ] No secrets, local `.env` files, private certificates, snapshots, or token caches are included.
 - [ ] Third-party dependency changes are reflected in `THIRD-PARTY-NOTICES`.
 - [ ] Public documentation is free of internal-only links or private workspace details.
-- [ ] Commits include DCO sign-off (`git commit -s`).
+- [ ] I added my DCO sign-off declaration to this pull request description.
+
+<!-- Add a line in this format: Signed-off-by: Your Name <your.email@example.com> -->

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -6,6 +6,7 @@ name: DCO
 on:
   pull_request:
     branches: [main]
+    types: [opened, edited, synchronize, reopened]
 
 permissions:
   contents: read
@@ -16,35 +17,34 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Check DCO sign-off
+      - name: Check Dependabot DCO bypass
+        id: dco-bypass
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          USERNAME: ${{ github.event.pull_request.user.login }}
+        run: |
+          if [[ "$USERNAME" == "dependabot[bot]" || "$USERNAME" == "app/dependabot" ]]; then
+            echo "bypass=true" >> "$GITHUB_OUTPUT"
+            echo "Dependabot is exempt from the PR-description DCO declaration."
+          else
+            echo "bypass=false" >> "$GITHUB_OUTPUT"
+            echo "The PR-description DCO declaration is required."
+          fi
+
+      - name: Check PR description for Signed-off-by
+        if: ${{ steps.dco-bypass.outputs.bypass != 'true' }}
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
         shell: bash
         run: |
           set -euo pipefail
 
-          commit_count=0
-          missing_signoff=0
+          normalized_body="$(printf '%s\n' "$PR_BODY" | tr -d '\r')"
 
-          while IFS= read -r sha; do
-            commit_count=$((commit_count + 1))
-
-            if ! git show -s --format=%B "$sha" \
-              | git interpret-trailers --parse \
-              | grep -Eq '^Signed-off-by: .+ <[^<>[:space:]]+@[^<>[:space:]]+>$'; then
-              echo "::error::Commit $sha is missing a valid Signed-off-by trailer."
-              missing_signoff=1
-            fi
-          done < <(git rev-list --reverse "${BASE_SHA}..${HEAD_SHA}")
-
-          if ((commit_count == 0)); then
-            echo "::error::The pull request does not contain a commit to check."
+          if ! printf '%s\n' "$normalized_body" \
+            | grep -Eq '^Signed-off-by:[[:space:]]+.+[[:space:]]+<[^<>]+>$'; then
+            echo "::error::PR description must contain a DCO sign-off line."
+            echo "::error::Expected format: Signed-off-by: Your Name <your-email@example.com>"
             exit 1
           fi
 
-          exit "$missing_signoff"
+          echo "PR description contains a DCO sign-off."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,33 +250,26 @@ request branch onto `upstream/main`.
 After each rebase, confirm that the pull request does not restore an obsolete
 path.
 
-## Sign Off Every Commit
+## Sign Off Every Pull Request
 
-Every commit in a pull request must include a
-[`Signed-off-by:` trailer](https://developercertificate.org/) for Developer
-Certificate of Origin (DCO) compliance. A sign-off in the pull request
-description does not satisfy this requirement.
+Every pull request description must include a
+[`Signed-off-by:` declaration](https://developercertificate.org/) for Developer
+Certificate of Origin (DCO) compliance. The pull request author must add the
+declaration before requesting review.
 
-Create a signed-off commit with this command:
-
-```bash
-git commit -s -m "Describe the change"
-```
-
-Git adds a trailer in this form:
+Add this line to the pull request description:
 
 ```text
 Signed-off-by: Your Name <your.email@example.com>
 ```
 
-Use your own name and email address. If you amend, rebase, squash, or
-cherry-pick commits, confirm that each resulting commit still contains a valid
-`Signed-off-by:` trailer.
+Use your own name and email address. Individual commits may also include
+sign-off trailers, but the required check validates the declaration in the pull
+request description.
 
-DCO sign-off is a declaration in the commit message. It is separate from
-cryptographic commit signing.
+DCO sign-off is separate from cryptographic commit signing.
 
-Maintainers do not accept commits without the required sign-off.
+Maintainers do not accept pull requests without the required declaration.
 
 ## Open a Pull Request
 
@@ -290,13 +283,13 @@ Your pull request should include:
 - An explanation for checks that you did not run.
 - The documentation and dependency changes.
 - For a migration, its details and downstream follow-up work.
-- Confirmation that every commit includes DCO sign-off.
+- Your DCO sign-off declaration.
 
 Submit all changes to `main` through a pull request.
 
 Maintainers merge a pull request only when all these conditions are true:
 
-- Every commit satisfies the DCO requirement.
+- The pull request description satisfies the DCO requirement.
 - The pull request satisfies the license-header requirements.
 - The pull request has no unresolved review conversations.
 - A maintainer approves the pull request.


### PR DESCRIPTION
## Summary

- require one DCO `Signed-off-by` declaration in every pull request description
- rerun the DCO check when a pull request is opened, edited, synchronized, or reopened
- exempt Dependabot in the same way as NVIDIA/NemoClaw
- update the contributing guide and pull request template for the PR-level policy

## Why

GitHub-generated branch-update commits can omit commit-message trailers, especially when the pull request branch belongs to a fork. PR-level DCO follows NVIDIA/NemoClaw's model and avoids rewriting otherwise valid contribution history solely to repair an update commit.

This supersedes #100. It does not change merge methods, branch protection, or cryptographic commit-signature requirements.

## Verification

- parsed `.github/workflows/dco.yml` successfully
- confirmed a valid PR-body declaration passes the workflow expression
- confirmed the commented template example does not satisfy the expression
- confirmed a PR body without a declaration fails the expression
- `python3 scripts/check_license_headers.py --check` — 251 files passed
- `python3 scripts/check_label_taxonomy.py --check` — 64 labels valid
- `git diff --check`

Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>
