### PR TITLE
ci(dco): reject placeholder sign-offs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,4 +26,4 @@ Describe what changed and why.
 - [ ] Public documentation is free of internal-only links or private workspace details.
 - [ ] I added my DCO sign-off declaration to this pull request description.
 
-<!-- Add a line in this format: Signed-off-by: Your Name <your.email@example.com> -->
+<!-- Replace the example values and add an uncommented line in this format: Signed-off-by: Your Name <your.email@example.com> -->

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -47,4 +47,12 @@ jobs:
             exit 1
           fi
 
+          if ! printf '%s\n' "$normalized_body" \
+            | grep -E '^Signed-off-by:[[:space:]]+.+[[:space:]]+<[^<>]+>$' \
+            | grep -Eiv '^Signed-off-by:[[:space:]]+Your Name[[:space:]]+<your[.-]email@example\.com>$' \
+            > /dev/null; then
+            echo "::error::Replace the example DCO sign-off with your own name and email address."
+            exit 1
+          fi
+
           echo "PR description contains a DCO sign-off."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -265,7 +265,8 @@ Signed-off-by: Your Name <your.email@example.com>
 
 Use your own name and email address. Individual commits may also include
 sign-off trailers, but the required check validates the declaration in the pull
-request description.
+request description. The example name and email address do not satisfy the
+required check.
 
 DCO sign-off is separate from cryptographic commit signing.
 


### PR DESCRIPTION
## Related Issue

N/A

## Description

Reject pull request descriptions that contain only the example DCO identity instead of a contributor's own name and email address. Continue to accept multiple sign-off declarations when at least one uses non-placeholder values.

Clarify the pull request template and contributing guide so contributors know that they must replace the example values.

## Verification

- [x] `python3 scripts/check_license_headers.py --check`
- [x] `git diff --check`
- [x] Exercised valid, missing, dotted-placeholder, hyphenated-placeholder, and mixed-sign-off cases locally

## Release And Compliance

- [x] No secrets, local `.env` files, private certificates, snapshots, or token caches are included.
- [x] No third-party dependencies changed.
- [x] Public documentation is free of internal-only links or private workspace details.
- [x] I added my DCO sign-off declaration to this pull request description.

Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>
