### PR TITLE
feat(examples): add x402-payment-gate partner recipe (BlueTier)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -18,6 +18,7 @@ again by contributor provenance.
 
 | Contributor | Example | Description |
 | --- | --- | --- |
+| BlueTier | [x402 Payment Gate](recipes/partners/bluetier/x402-payment-gate/README.md) | Releases an agent's x402 payments through a maker/checker boundary: the sandboxed agent can only submit payment intents, and a host-side gate outside the sandbox re-screens each one with pre-signature GO/HOLD/STOP verdicts (counterparty reputation, price anomaly, OFAC sanctions) before anything is signed or settled. |
 | HPE | [Retail Assistant](recipes/partners/hpe/retail-assistant/README.md) | Provides role-aware retail operations through Telegram, FastAPI, PostgreSQL, Docker Compose, and Helm. |
 | Tavily | [Watchtower](recipes/partners/tavily/watchtower/README.md) | Runs scheduled, cited web monitoring with persistent deduplication and auditable outputs. |
 

--- a/examples/recipes/partners/bluetier/x402-payment-gate/.dockerignore
+++ b/examples/recipes/partners/bluetier/x402-payment-gate/.dockerignore
@@ -1,0 +1,10 @@
+# The sandbox image is built with the RECIPE ROOT as the build context (so the
+# Dockerfile's COPY paths -- agents/, scripts/ -- resolve). Keep that context
+# lean: exclude everything the image never needs.
+.git/
+plugin/
+host/
+.run/
+**/__pycache__/
+*.pyc
+*.pid

--- a/examples/recipes/partners/bluetier/x402-payment-gate/Dockerfile
+++ b/examples/recipes/partners/bluetier/x402-payment-gate/Dockerfile
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Reproducible sandbox image for the x402-payment-gate recipe: the pinned
+# NemoClaw Hermes base plus this recipe's skill and stdlib client baked into
+# the immutable skills directory.
+#
+# IMPORTANT -- build context is the RECIPE ROOT (this file's directory), not a
+# sub-directory. The COPY paths below (agents/, scripts/) are resolved against
+# the recipe root, so both `openshell sandbox create --from <recipe-root>` and a
+# plain `docker build` must run with the recipe root as context:
+#
+#   docker build -t x402-payment-gate-sandbox .        # from the recipe root
+#   openshell sandbox create --from <recipe-root> ...  # OpenShell builds it
+#
+# (This is why the Dockerfile lives at the recipe root, not under sandbox/:
+# `openshell --from` uses the Dockerfile's own directory as the build context,
+# so the Dockerfile and the files it COPYs must share one root. See .dockerignore
+# for what is kept out of that context.)
+#
+# Zero-build alternative: policy.yaml sets include_workdir: true, so running
+# the sandbox with this example directory as the workdir exposes the same
+# files without a custom image; the baked copy is the reproducible path.
+ARG BASE_IMAGE=ghcr.io/nvidia/nemoclaw/hermes-sandbox-base@sha256:fa05221f5c7bcafea7e263c84e5d06f87e37d1ccb78dc28c113f1a4066aa544c
+FROM ${BASE_IMAGE}
+
+COPY agents/hermes/skills/blackwall-payment-gate/ /sandbox/.hermes/skills/blackwall-payment-gate/
+COPY scripts/blackwall_client.py scripts/demo_verdicts.py /sandbox/.hermes/skills/blackwall-payment-gate/scripts/

--- a/examples/recipes/partners/bluetier/x402-payment-gate/README.md
+++ b/examples/recipes/partners/bluetier/x402-payment-gate/README.md
@@ -1,0 +1,237 @@
+# x402-payment-gate: Verdict-Gated Payment Release
+
+A maker/checker payment boundary for [x402](https://www.x402.org/) machine
+payments, in the pattern of the
+[Payment Operations Hermes Assistant](../../../nvidia/payment-ops-hermes/README.md):
+the sandboxed Hermes agent can screen payments and **submit payment intents**,
+but it cannot sign or settle anything — it holds no key and has no network
+route to any payment rail. The **mandatory** decision lives in a host-side
+**release gate outside the agent sandbox**, which asks
+[Blackwall](https://blackwall-free.onrender.com/.well-known/x402) for a
+**GO / HOLD / STOP** verdict — counterparty reputation on Base, price-anomaly
+detection, OFAC sanctions screening, Sybil/graph signals — and only a GO is
+signed and settled. The decision is **genuinely pre-signature**: no signature
+exists until after the verdict, and the signing step is on a code path only
+the release branch reaches (pinned by unit test).
+
+The threat this closes: an injected or manipulated agent with payment
+capability is one signature away from paying a drainer, a sanctioned address,
+or a 100x-gouged invoice. Here a prompt cannot become a payment: the most a
+compromised agent can do is *submit an intent*, and the checker it cannot
+touch re-screens every intent before any money moves.
+
+> **Third-party integration — requirements & support.** This is an independent
+> community example contributed by BlueTier Operations, **not** a supported
+> part of NemoClaw core. It calls the external Blackwall verdict service — the
+> default public instance is **keyless and free** (no API key, no signup);
+> self-hosting is documented for real workloads. **Support** for this example
+> and the service is provided by BlueTier Operations, not NVIDIA — contact
+> <bluetier.operations@gmail.com>.
+
+> **Scope — a payment-*boundary* demonstration, not a full agent runtime.**
+> `bring-up.sh` stands up the boundary (mock rail + release gate + a
+> policy-scoped sandbox), and `verify.sh` exercises the in-sandbox **maker path
+> at the intent-submission level** (`POST /v1/intents` over the scoped
+> `host.openshell.internal` route → a live verdict) together with the denied
+> edge. It does **not** start an interactive Hermes agent. The skill under
+> `agents/hermes/skills/` documents how a Hermes agent *would* drive this
+> boundary; actually running that agent needs a full NemoClaw Relay+Hermes
+> runtime (inference provider, `nemoclaw-start`) and is a **separate operator
+> step, out of scope here**. What this recipe proves — on a real OpenShell host
+> — is the security property: a prompt in the sandbox cannot reach the rail, and
+> every intent is re-screened by the host-side checker before any money moves.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    blackwall["External\nBlackwall verdict service"]
+    seller["External\nx402 seller (402 challenge)"]
+
+    subgraph host["Host machine"]
+        direction TB
+        gate["Release gate — CHECKER\n127.0.0.1:8790\nmandatory verdict → sign → settle"]
+        rail["Mock payment rail\n127.0.0.1:8780 · HOST ONLY"]
+        human["Named human operator\napproves HELD intents"]
+
+        subgraph supervisor["OpenShell sandbox supervisor"]
+            policy["L7 egress policy"]
+            subgraph sandbox["x402-payment-gate sandbox"]
+                agent["Hermes agent — MAKER"]
+                skill["blackwall-payment-gate skill\n+ stdlib client (advisory)"]
+                agent --> skill
+            end
+        end
+
+        skill -->|"advisory forecast"| policy
+        skill -->|"submit intent\nhost.openshell.internal:8790"| policy
+        policy --> gate
+        gate -->|"mandatory forecast"| blackwall
+        gate -->|"GO only: sign → settle"| rail
+        human -->|"approve HELD"| gate
+    end
+
+    policy -->|"advisory verdicts"| blackwall
+    seller -.->|"HTTP 402"| agent
+    sandbox -. "NO ROUTE — denied edge" .-> rail
+
+    style host fill:#f7f6ef,stroke:#8a8068,stroke-width:2px
+    style supervisor fill:#e7f0ff,stroke:#2b5fab,stroke-width:3px
+    style sandbox fill:#d8e8ff,stroke:#2b5fab,stroke-dasharray:5 3
+    style rail fill:#fce5cd,stroke:#c0392b,stroke-width:2px
+```
+
+The denied edge is the central security property: the rail route is absent
+from `policy.yaml`, so a prompt cannot override it. Note the deliberate bind
+asymmetry. The gate runs **two listeners**: a **submit/status** listener the
+sandbox reaches (via the `host.openshell.internal` route) and a **host-only
+approve** listener bound to `127.0.0.1:8791`. The sandbox reaches the host over
+the OpenShell bridge (`host.openshell.internal` → the `openshell-docker` network
+gateway), *not* host loopback — so the submit listener must bind that **specific
+bridge interface**: loopback would be unreachable from the sandbox (the maker
+path dies), and `0.0.0.0` would expose submission on every host interface (the
+LAN included). `bring-up.sh` discovers the bridge gateway and binds the submit
+listener there automatically (`RELEASE_GATE_BIND`; it defaults to a safe
+`127.0.0.1` when set by hand, and is never `0.0.0.0`). The **rail** binds
+`127.0.0.1` and is unreachable from the sandbox at the network layer — that
+asymmetry *is* the denied edge. Splitting
+the listeners means exposing the submit interface never exposes `/approve`: the
+sandbox can reach only the least-privileged operation (submit), while the
+human-only operations (approve, settle) live behind loopback. Everything
+in-sandbox is **advisory** — the skill's pre-check warns the user early, but
+nothing the agent does or skips changes what the gate enforces.
+
+## Key invariants
+
+- The agent can screen, explain, and submit intents; it cannot sign, release,
+  or settle a payment. No signing key exists inside the sandbox (in this demo
+  no real key exists anywhere — the rail signature is an explicitly labeled
+  simulation).
+- The sandbox has no route to the rail or any facilitator, even when a tool
+  or prompt attempts one. Its egress is the inference endpoints, the verdict
+  service, and the intent-submission route — nothing else.
+- **Only the host-side gate settles, and it does so through exactly two
+  authorization paths — never any other way.** Both run host-side and both
+  decide before any signature exists (verdict → sign → settle, enforced by
+  code and pinned by unit test):
+  1. **Automated release** — an intent settles unattended *only* on a fresh
+     **GO** verdict. HOLD and STOP never settle on this path.
+  2. **Human-approved release** — a **HELD** intent (a fresh HOLD, or a
+     verdict-service failure that held it) can be released by a **named human**
+     plus the approval token printed only to the gate's host-side log — a value
+     the sandbox cannot read; the held→releasing transition is lock-guarded
+     against concurrent double-approval. This path **re-screens with a fresh
+     verdict**: the named human overrides a HOLD, but a fresh **STOP** (e.g. the
+     payee became sanctioned between submit and approval) refuses the release
+     even with a valid operator and token — the re-forecast precedes signing, so
+     the decision stays pre-signature.
+  A STOP is terminal on both paths: no verdict, human, or token releases it.
+- A verdict-service failure HOLDS — the mandatory layer never fails open.
+- Only the payment claim (`counterparty, amount, asset, chain, resource`)
+  leaves the sandbox or the host — never tool payloads, never keys.
+
+## The verdict
+
+The gate (and the advisory skill) call `POST /v1/forecast-payment` with the
+claim and receive: `verdict` (GO/HOLD/STOP), `hard_stop`, `score`,
+`reasons[]`, per-signal breakdown, confidence, and a `receipt_id` +
+`report_token` for closing the loop after settlement
+(`POST /v1/report-outcome`). Gate mapping (shared with Blackwall's other
+guard integrations): **GO → release, HOLD → held for a human, STOP →
+refused**; anything unrecognized holds.
+
+## Lifecycle: bring-up, verify, tear-down
+
+```bash
+scripts/bring-up.sh     # host services (rail + gate) → reproducible sandbox
+                        #   image (pinned Hermes base + baked skill) → sandbox
+                        #   with policy.yaml applied whole
+scripts/verify.sh       # unit tests + FRESH payment canaries through the gate
+                        #   + denied-edge test from inside the sandbox
+scripts/tear-down.sh    # sandbox → host services
+```
+
+Only python3 is required to exercise the host boundary; docker + openshell
+add the sandbox phases. The policy is a **complete** sandbox policy: the
+inference routes mirror the
+[chief-of-staff recipe](../../../nvidia/developer-community-chief-of-staff/README.md)
+unbroadened, plus this recipe's verdict and intent routes — every in-sandbox
+HTTP caller is python3 or curl, exactly matching the binary allowlists.
+
+### Verification is live and fresh
+
+`verify.sh` initiates **new payments on every run** — nothing is inferred
+from pre-existing logs:
+
+1. Unit tests pin the decision core, including the verdict-then-sign order.
+2. Three fresh canaries go through the gate against the live verdict service:
+   a warm payee at its fair price (→ `released`, producing a fresh settlement),
+   a sanctioned payee (→ `refused`, never signed), an unknown payee
+   (→ `held`). The mock-rail ledger must grow by exactly the released one.
+3. From inside the sandbox: the intent route must work and the rail route
+   must be denied by the supervisor.
+
+A held intent can then be released only by a named human holding the
+approval token that the gate prints to its host-side log at startup — a
+value nothing inside the sandbox can read. The approve endpoint lives on the
+**host-only** listener (`127.0.0.1:8791`), which the sandbox has no route to:
+
+```bash
+curl -X POST 127.0.0.1:8791/v1/intents/<id>/approve \
+  -H 'X-Operator: <your name>' -H "X-Approve-Token: <from .run/gate.log>"
+```
+
+The held→releasing→released transition is lock-guarded, so two concurrent
+approvals can never both settle, and intent submission is bounded
+(`RELEASE_GATE_MAX_INTENTS`, default 1000) so a compromised agent cannot grow
+the store or hammer the verdict service without limit.
+
+## Files
+
+| Path | Purpose |
+|---|---|
+| `host/release_gate.py` | The checker: intent API + mandatory verdict → sign → settle. Stdlib only. |
+| `host/mock_rail.py` | Host-only settlement target with an auditable ledger; the denied edge. |
+| `host/test_release_gate.py` | Unit tests for the decision core (verdict mapping, order invariant, human-approval rules). |
+| `agents/hermes/skills/blackwall-payment-gate/SKILL.md` | The maker skill: advisory pre-check, intent submission, hold explanations. |
+| `scripts/blackwall_client.py` | Stdlib advisory client (`should_sign`: GO→sign, STOP→refuse, else escalate). |
+| `scripts/demo_verdicts.py` | Standalone four-scenario live verdict walkthrough. |
+| `policy.yaml` | Complete sandbox policy: inference + advisory verdict + intent routes; **no rail route**. |
+| `Dockerfile` | Reproducible sandbox image: pinned Hermes base + baked skill. Built with the recipe root as context (`--from <recipe-root>`), so its `COPY` paths resolve; `.dockerignore` trims that context. |
+| `scripts/bring-up.sh` · `verify.sh` · `tear-down.sh` | Lifecycle (above). |
+
+## Production notes and limits
+
+- **Replace the simulation at the edges, keep the boundary.** The mock rail
+  and simulated signature are demo stand-ins; production adopters wire the
+  release gate to a real wallet/signing provider so the same verdict gates
+  real signing — see the wallet and OpenClaw adapters in the Blackwall
+  repository (`integrations/wallets/`, `integrations/openclaw/`). For
+  OpenClaw-runtime agents, the related in-sandbox defense-in-depth hook is
+  contributed separately in the
+  [BLACK_WALL Preflight Guardrail](https://github.com/NVIDIA/nemoclaw-community/pull/52)
+  example.
+- **Enforcement architecture: host-side gate now, Supervisor middleware as the
+  documented next step.** An earlier review asked for the mandatory decision to
+  run inside OpenShell's `HTTP_REQUEST`/`PRE_CREDENTIALS` **Supervisor
+  middleware** (the decision function against in-flight egress, fail-closed,
+  inside OpenShell's own enforcement layer). This recipe instead places the
+  mandatory decision in a **host-side release gate outside the sandbox** — the
+  established pattern of the
+  [payment-ops-hermes recipe](../../../nvidia/payment-ops-hermes/README.md) — with
+  the rail denied to the sandbox by policy. That host-side boundary is what this
+  recipe validates end to end. Wiring the same verdict into Supervisor
+  middleware is the **ideal fail-closed tightening and the documented next
+  step**, once (and where) that configuration surface is available to community
+  recipes. Adopting the host-side gate as the accepted architecture for *this*
+  recipe is offered for explicit maintainer agreement; the middleware remains
+  tracked as follow-up rather than silently substituted.
+- **Verdict quality is advisory input, not an oracle.** Signals that depend
+  on seller-controlled inputs (e.g. the resource URL driving the category
+  price baseline) are HOLD-only and evadable by a motivated seller; the free
+  public instance is a shared demo tier (ephemeral state, idle spin-down,
+  ~60s cold start, no SLA). Self-host for real workloads.
+- **This example moves no real money.** Payments settle against the bundled
+  mock rail with simulated signatures. Extending to a real facilitator and a
+  funded wallet is a deliberate operator decision far outside this example's
+  scope.

--- a/examples/recipes/partners/bluetier/x402-payment-gate/agents/hermes/skills/blackwall-payment-gate/SKILL.md
+++ b/examples/recipes/partners/bluetier/x402-payment-gate/agents/hermes/skills/blackwall-payment-gate/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: blackwall-payment-gate
+description: Screen x402 payments with an advisory Blackwall verdict, then submit a payment intent to the host-side release gate. You prepare payments; only the gate can settle them.
+---
+
+# blackwall-payment-gate
+
+You are the MAKER in a maker/checker payment boundary. You can screen
+payments, explain verdicts, and submit payment intents. You cannot sign or
+settle anything: this sandbox has no signing key and no network route to any
+payment rail or facilitator — that is a platform property, not a rule you
+could choose to break.
+
+## When to use
+
+- A tool call or resource fetch returned HTTP 402 with an x402 challenge and
+  the user wants to pay it.
+- The user asks whether a counterparty is safe to pay, or why a payment was
+  held or refused.
+
+## Procedure
+
+1. Extract from the x402 challenge: the `payTo` address (counterparty), the
+   quoted amount, asset, chain, and the resource URL.
+2. Advisory pre-check (optional but preferred — it lets you warn the user
+   before anything is submitted):
+
+   ```bash
+   python3 scripts/blackwall_client.py \
+     --counterparty <payTo> --amount <amount> --resource <resource-url>
+   ```
+
+   GO means likely to release; HOLD/STOP mean expect the gate to hold or
+   refuse — tell the user the reasons now.
+3. Submit the intent to the release gate (the only path to settlement):
+
+   ```bash
+   curl -sS -X POST http://host.openshell.internal:8790/v1/intents \
+     -H 'Content-Type: application/json' \
+     -d '{"counterparty":"<payTo>","amount":"<amount>","resource":"<url>"}'
+   ```
+
+4. Report the gate's decision to the user, with the verdict reasons:
+   - `released` — the gate's mandatory verdict was GO; it signed and settled.
+   - `held` — escalated. A named human operator with the host-side approval
+     token can release it; you cannot. Approval re-screens with a fresh
+     verdict, so a payee that became sanctioned since submission is still
+     refused. Give the user the intent `id` and the reasons.
+   - `refused` — a hard signal fired (e.g. sanctions). Do not resubmit;
+     explain which reason caused it.
+5. To answer later "what happened to that payment?" questions:
+   `curl -sS http://host.openshell.internal:8790/v1/intents/<id>`
+
+## Rules
+
+- Never attempt to reach a facilitator, payment rail, or wallet directly —
+  the policy denies those routes, and an attempt is treated as a boundary
+  test, not a payment.
+- Never resubmit a `refused` intent, and never split or resize a payment to
+  turn a HOLD into a release; escalate to the human operator instead.
+- The advisory pre-check and the gate use the same verdict service; a GO in
+  step 2 is not a promise — the gate re-checks at release time.
+- Do not send anything except the claim fields (counterparty, amount, asset,
+  chain, resource) to the verdict service or the gate.

--- a/examples/recipes/partners/bluetier/x402-payment-gate/host/mock_rail.py
+++ b/examples/recipes/partners/bluetier/x402-payment-gate/host/mock_rail.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Mock payment rail — HOST ONLY, the deliberately denied edge.
+
+Binds 127.0.0.1 and is intentionally ABSENT from the sandbox's network
+policy: the sandboxed agent has no route here, so a prompt can never turn
+into a settlement (mirrors the payment-ops-hermes mock rail). Only the
+host-side release gate calls it, and only after a GO verdict.
+
+    POST /v1/settle   {claim, signature} -> {settled, tx}
+    GET  /v1/ledger   everything settled so far (verification reads this)
+    GET  /healthz
+
+Settlements are appended to .run/rail-ledger.jsonl next to this file's
+example dir so verify.sh can assert exactly what reached the rail.
+"""
+
+import json
+import os
+import sys
+import time
+import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+RAIL_PORT = int(os.environ.get("RAIL_PORT", "8780"))
+LEDGER_PATH = os.environ.get(
+    "RAIL_LEDGER",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                 "..", ".run", "rail-ledger.jsonl"))
+
+LEDGER = []
+
+
+class Handler(BaseHTTPRequestHandler):
+    server_version = "x402-mock-rail/1.0"
+
+    def _json(self, code, obj):
+        body = json.dumps(obj).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if self.path == "/healthz":
+            self._json(200, {"status": "ok", "role": "mock-rail"})
+        elif self.path == "/v1/ledger":
+            self._json(200, {"settlements": LEDGER})
+        else:
+            self._json(404, {"error": "not found"})
+
+    def do_POST(self):
+        if self.path != "/v1/settle":
+            self._json(404, {"error": "not found"})
+            return
+        length = int(self.headers.get("Content-Length") or 0)
+        try:
+            payload = json.loads(self.rfile.read(length).decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            self._json(400, {"error": "invalid JSON"})
+            return
+        claim = payload.get("claim")
+        signature = payload.get("signature")
+        if not isinstance(claim, dict) or not signature:
+            self._json(400, {"error": "claim and signature are required"})
+            return
+        entry = {"tx": "sim_" + uuid.uuid4().hex[:12], "claim": claim,
+                 "signature": signature, "at": int(time.time())}
+        LEDGER.append(entry)
+        os.makedirs(os.path.dirname(LEDGER_PATH), exist_ok=True)
+        with open(LEDGER_PATH, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry) + "\n")
+        sys.stdout.write("mock-rail: settled %s -> %s %s\n" % (
+            entry["tx"], claim.get("amount"), claim.get("counterparty")))
+        sys.stdout.flush()
+        self._json(200, {"settled": True, "tx": entry["tx"]})
+
+    def log_message(self, fmt, *args):
+        pass
+
+
+def main():
+    server = ThreadingHTTPServer(("127.0.0.1", RAIL_PORT), Handler)
+    sys.stdout.write("mock-rail: listening on 127.0.0.1:%d (HOST ONLY — "
+                     "no sandbox route by design)\n" % RAIL_PORT)
+    sys.stdout.flush()
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/recipes/partners/bluetier/x402-payment-gate/host/release_gate.py
+++ b/examples/recipes/partners/bluetier/x402-payment-gate/host/release_gate.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Host-side release gate — the CHECKER in the maker/checker boundary.
+
+Runs OUTSIDE the agent sandbox (mirroring the payment-ops-hermes pattern):
+the sandboxed agent can only SUBMIT a payment intent here; it holds no
+signing capability and no route to the payment rail. This gate runs the
+mandatory Blackwall verdict, and a payment reaches sign-then-settle through
+exactly TWO host-side authorization paths, never any other way:
+
+  1. Automated release (process_intent): an intent settles unattended ONLY on
+     a fresh GO verdict. HOLD and STOP never settle here.
+  2. Human-approved release (process_approval): a HELD intent (a fresh HOLD,
+     or a verdict-service failure that held it) can be released by a NAMED
+     human plus the host-side approval token. This path re-screens with a
+     FRESH verdict first: the human overrides a HOLD, but a fresh STOP refuses
+     the release even with a valid operator + token.
+
+Both paths decide BEFORE any signature exists (the signing step lives on a
+code path only the RELEASE branch reaches, pinned by test_release_gate.py),
+so the decision is genuinely pre-signature. A STOP is terminal on both paths.
+
+Verdict mapping (family contract shared with the Blackwall langchain,
+wallet, and openclaw guards): GO -> release, HOLD -> hold for a human,
+STOP/hard_stop -> refuse permanently. A verdict-service failure HOLDS —
+the mandatory layer never fails open.
+
+Stdlib only. Endpoints (127.0.0.1, reached from the sandbox via the
+host.openshell.internal route in policy.yaml):
+
+    POST /v1/intents            submit {counterparty, amount[, asset, chain,
+                                resource]} -> {id, status}
+    GET  /v1/intents/<id>       status + verdict reasons (agent explains holds)
+    POST /v1/intents/<id>/approve   HUMAN action: release a HELD intent
+                                (header X-Operator: <name> required)
+    GET  /healthz
+
+The demo "signature" is an explicitly labeled simulation (no real key exists
+anywhere in this example); production adopters replace simulate_signature/
+settle with a wallet-provider integration where the same verdict gates real
+signing (see the Blackwall wallet adapters).
+"""
+
+import hashlib
+import json
+import os
+import re
+import secrets
+import sys
+import threading
+import urllib.error
+import urllib.request
+import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+RELEASE = "release"
+HOLD = "hold"
+REFUSE = "refuse"
+
+_EVM = re.compile(r"^0x[0-9a-fA-F]{40}$")
+_AMOUNT = re.compile(r"^\d+(\.\d+)?$")
+
+BLACKWALL_URL = os.environ.get(
+    "BLACKWALL_URL", "https://blackwall-free.onrender.com")
+RAIL_URL = os.environ.get("RAIL_URL", "http://127.0.0.1:8780")
+GATE_PORT = int(os.environ.get("RELEASE_GATE_PORT", "8790"))
+# SUBMIT/status listener bind. Default 127.0.0.1 (host-only, SAFE): it never
+# exposes submission on every interface. For real sandbox reach, set
+# RELEASE_GATE_BIND to the SPECIFIC host-internal bridge interface behind
+# host.openshell.internal -- never 0.0.0.0. The APPROVE listener is a separate
+# server pinned to 127.0.0.1 (a named human on the host, never the sandbox).
+# The RAIL also stays 127.0.0.1 -- that asymmetry IS the denied edge.
+GATE_BIND = os.environ.get("RELEASE_GATE_BIND", "127.0.0.1")
+APPROVE_PORT = int(os.environ.get("RELEASE_GATE_APPROVE_PORT", "8791"))
+FORECAST_TIMEOUT = int(os.environ.get("BLACKWALL_TIMEOUT", "90"))
+
+
+# ---------------------------------------------------------------------------
+# Pure decision core (unit-tested, no I/O)
+# ---------------------------------------------------------------------------
+
+def validate_intent(payload):
+    """Validate a submitted payment intent -> (intent, None) | (None, error).
+
+    Required: counterparty (EVM address, lowercased for the reputation key),
+    amount (positive PLAIN-decimal string — scientific notation rejected).
+    Optional: asset (default USDC), chain (default base), resource.
+    """
+    if not isinstance(payload, dict):
+        return None, "intent must be a JSON object"
+    counterparty = payload.get("counterparty")
+    if not isinstance(counterparty, str) or not _EVM.match(counterparty.strip()):
+        return None, "counterparty must be an EVM address (0x + 40 hex chars)"
+    amount = payload.get("amount")
+    if isinstance(amount, (int, float)):
+        amount = str(amount)
+    if not isinstance(amount, str) or len(amount) > 40 \
+            or not _AMOUNT.match(amount.strip()) or float(amount) <= 0:
+        return None, "amount must be a positive plain-decimal string (max 40 chars)"
+    intent = {
+        "counterparty": counterparty.strip().lower(),
+        "amount": amount.strip(),
+        "asset": payload.get("asset") or "USDC",
+        "chain": payload.get("chain") or "base",
+    }
+    if payload.get("resource"):
+        resource = str(payload["resource"])
+        if len(resource) > 2048:
+            return None, "resource must be at most 2048 characters"
+        intent["resource"] = resource
+    return intent, None
+
+
+def decide_release(verdict_obj):
+    """Family verdict mapping. Anything unrecognized or missing HOLDS —
+    on the mandatory layer, uncertainty escalates to a human, never releases."""
+    if not isinstance(verdict_obj, dict):
+        return HOLD
+    if verdict_obj.get("hard_stop") or verdict_obj.get("verdict") == "STOP":
+        return REFUSE
+    if verdict_obj.get("verdict") == "GO":
+        return RELEASE
+    return HOLD
+
+
+def simulate_signature(intent):
+    """Deterministic, explicitly labeled DEMO signature over the intent.
+    No real key exists in this example; the label makes that unmistakable."""
+    digest = hashlib.sha256(
+        json.dumps(intent, sort_keys=True).encode("utf-8")).hexdigest()
+    return "SIMULATED_" + digest[:32]
+
+
+def process_intent(intent, forecast_fn, sign_fn, settle_fn):
+    """The gate's core sequence: forecast -> decide -> (sign -> settle).
+
+    Returns (status, detail). The signature and the rail are reachable ONLY
+    from the RELEASE branch; every other branch returns before either exists.
+    A forecast failure returns "held" (fail toward review, never open).
+    """
+    try:
+        verdict_obj = forecast_fn(intent)
+    except Exception as e:  # noqa: BLE001 - any failure means: do not release
+        return "held", {"error": "forecast failed: %s" % e, "verdict": None}
+
+    action = decide_release(verdict_obj)
+    if action == REFUSE:
+        return "refused", {"verdict": verdict_obj}
+    if action == HOLD:
+        return "held", {"verdict": verdict_obj}
+
+    signature = sign_fn(intent)
+    try:
+        settlement = settle_fn(intent, signature)
+    except Exception as e:  # noqa: BLE001
+        return "error", {"error": "settlement failed: %s" % e,
+                         "verdict": verdict_obj}
+    return "released", {"verdict": verdict_obj, "settlement": settlement}
+
+
+MAX_INTENTS = int(os.environ.get("RELEASE_GATE_MAX_INTENTS", "1000"))
+
+# The approval token is the "something the sandbox cannot have": generated at
+# startup (or via RELEASE_GATE_APPROVE_TOKEN) and printed ONLY to the gate's
+# host-side stdout. A named operator copies it from the host log. Even if the
+# sandbox policy were ever broadened to expose the approve route, a prompt
+# cannot mint this value.
+APPROVE_TOKEN = os.environ.get("RELEASE_GATE_APPROVE_TOKEN") \
+    or secrets.token_hex(16)
+
+_LOCK = threading.Lock()
+
+
+def reserve_slot(store, cap, record):
+    """Atomically claim one slot in the bounded intent store: the capacity
+    check and the insert happen together under the lock, so concurrent
+    submits at cap-1 can never both succeed (the store never exceeds cap).
+    Returns True and inserts `record` on success, False when full. Bounds
+    both memory and live-forecast load a compromised agent could drive."""
+    with _LOCK:
+        if len(store) >= cap:
+            return False
+        store[record["id"]] = record
+        return True
+
+
+def new_record(intent, status, detail):
+    return {"id": str(uuid.uuid4()), "status": status,
+            "intent": intent, "detail": detail}
+
+
+def resolve_gate_bind(explicit):
+    """Bind for the SUBMIT/status listener (the only sandbox-facing surface).
+
+    Defaults to host loopback (127.0.0.1) -- SAFE, never promiscuous: it never
+    exposes submission on every host interface. To let the sandbox reach it,
+    the operator sets RELEASE_GATE_BIND to the SPECIFIC host-internal bridge
+    interface (the address behind host.openshell.internal), not 0.0.0.0. The
+    approval listener is a separate, always-loopback server (see main)."""
+    return explicit if explicit else GATE_BIND
+
+
+def approve_record(record, operator, token, expected_token):
+    """Atomically claim a HELD record for release. Returns (0, None) when the
+    caller may proceed to settle (record is now 'releasing'), else
+    (http_code, error). Named human + host-side token are BOTH required, and
+    the held->releasing transition happens under a lock so two concurrent
+    approvals can never both settle (the double-release race)."""
+    if not operator or not token or expected_token is None \
+            or not secrets.compare_digest(str(token), str(expected_token)):
+        return 403, ("a named human (X-Operator) AND the approval token "
+                     "printed in the gate's host log (X-Approve-Token) are "
+                     "required")
+    with _LOCK:
+        if record["status"] != "held":
+            return 409, ("only HELD intents can be approved (status: %s)"
+                         % record["status"])
+        record["status"] = "releasing"
+    return 0, None
+
+
+def finalize_release(record, settlement, operator):
+    record["status"] = "released"
+    record["detail"]["settlement"] = settlement
+    record["detail"]["approved_by"] = operator
+
+
+def process_approval(record, forecast_fn, sign_fn, settle_fn, operator):
+    """Complete a human approval of a claimed (releasing) HELD intent, with a
+    FRESH re-screen. A named human overrides a HOLD -- but not a STOP: if the
+    counterparty became sanctioned (or otherwise hard-stops) between submit
+    and approval, the fresh verdict refuses the release even with a valid
+    operator + token. GO or a still-HOLD verdict let the human override
+    stand. Re-forecast happens BEFORE signing, so the decision stays
+    genuinely pre-signature. A re-forecast failure returns the intent to
+    'held' (never releases unscored)."""
+    try:
+        verdict_obj = forecast_fn(record["intent"])
+    except Exception as e:  # noqa: BLE001
+        record["status"] = "held"
+        return "held", {"error": "re-forecast failed: %s" % e}
+    if decide_release(verdict_obj) == REFUSE:
+        record["status"] = "refused"
+        record["detail"]["verdict"] = verdict_obj
+        return "refused", {"verdict": verdict_obj}
+    signature = sign_fn(record["intent"])
+    try:
+        settlement = settle_fn(record["intent"], signature)
+    except Exception as e:  # noqa: BLE001
+        record["status"] = "held"
+        return "error", {"error": "settlement failed: %s" % e}
+    finalize_release(record, settlement, operator)
+    return "released", {"verdict": verdict_obj, "settlement": settlement}
+
+
+# ---------------------------------------------------------------------------
+# I/O seams (thin; injected in tests)
+# ---------------------------------------------------------------------------
+
+def _post_json(url, body, timeout):
+    req = urllib.request.Request(
+        url, data=json.dumps(body).encode("utf-8"),
+        headers={"Content-Type": "application/json"}, method="POST")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def forecast(intent):
+    return _post_json(BLACKWALL_URL.rstrip("/") + "/v1/forecast-payment",
+                      intent, FORECAST_TIMEOUT)
+
+
+def settle(intent, signature):
+    return _post_json(RAIL_URL.rstrip("/") + "/v1/settle",
+                      {"claim": intent, "signature": signature}, 30)
+
+
+# ---------------------------------------------------------------------------
+# HTTP server -- TWO listeners with different exposure:
+#   * SUBMIT/status  (sandbox-facing, RELEASE_GATE_BIND): the maker path. The
+#     most a sandboxed prompt can do is submit an intent + read its status.
+#   * APPROVE        (always 127.0.0.1): the human release path. Bound to host
+#     loopback so a named operator on the host uses it and the sandbox cannot
+#     reach it at the network layer even if the submit interface is exposed.
+# Splitting them means exposing the submit interface never exposes /approve.
+# ---------------------------------------------------------------------------
+
+INTENTS = {}
+
+
+class _Base(BaseHTTPRequestHandler):
+    server_version = "x402-release-gate/1.0"
+
+    def _json(self, code, obj):
+        body = json.dumps(obj).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _read_body(self):
+        length = int(self.headers.get("Content-Length") or 0)
+        if length <= 0 or length > 65536:
+            return None
+        try:
+            return json.loads(self.rfile.read(length).decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            return None
+
+    def log_message(self, fmt, *args):  # quiet default access log
+        pass
+
+
+class SubmitHandler(_Base):
+    """Sandbox-facing: submit an intent, read status, health. NO /approve."""
+
+    def do_GET(self):
+        if self.path == "/healthz":
+            self._json(200, {"status": "ok", "role": "submit"})
+            return
+        m = re.match(r"^/v1/intents/([0-9a-f-]+)$", self.path)
+        if m and m.group(1) in INTENTS:
+            self._json(200, INTENTS[m.group(1)])
+            return
+        self._json(404, {"error": "not found"})
+
+    def do_POST(self):
+        if self.path != "/v1/intents":
+            # /approve is intentionally NOT served here (host-only listener).
+            self._json(404, {"error": "not found"})
+            return
+        intent, err = validate_intent(self._read_body())
+        if err:
+            self._json(400, {"error": err})
+            return
+        # Atomically reserve a slot BEFORE the (slow) forecast so the store
+        # cannot exceed its cap under concurrent submits.
+        record = new_record(intent, "processing", {})
+        if not reserve_slot(INTENTS, MAX_INTENTS, record):
+            self._json(429, {"error": "intent store full (%d); tear down or "
+                                      "raise RELEASE_GATE_MAX_INTENTS"
+                                      % MAX_INTENTS})
+            return
+        status, detail = process_intent(
+            intent, forecast, simulate_signature, settle)
+        record["status"] = status
+        record["detail"] = detail
+        sys.stdout.write("release-gate: %s %s %s -> %s\n" % (
+            record["id"][:8], intent["amount"], intent["counterparty"], status))
+        sys.stdout.flush()
+        self._json(201, record)
+
+
+class ApproveHandler(_Base):
+    """Host-only (127.0.0.1): a named human releases a HELD intent. The
+    sandbox has no route here."""
+
+    def do_GET(self):
+        if self.path == "/healthz":
+            self._json(200, {"status": "ok", "role": "approve"})
+            return
+        self._json(404, {"error": "not found"})
+
+    def do_POST(self):
+        m = re.match(r"^/v1/intents/([0-9a-f-]+)/approve$", self.path)
+        if not m:
+            self._json(404, {"error": "not found"})
+            return
+        record = INTENTS.get(m.group(1))
+        if record is None:
+            self._json(404, {"error": "not found"})
+            return
+        code, err = approve_record(
+            record, self.headers.get("X-Operator"),
+            self.headers.get("X-Approve-Token"), APPROVE_TOKEN)
+        if code:
+            self._json(code, {"error": err})
+            return
+        # Claimed (status 'releasing'). Re-screen with a FRESH verdict: a named
+        # human overrides a HOLD, but a fresh STOP refuses even so. Re-forecast
+        # precedes signing -> still pre-signature.
+        operator = self.headers.get("X-Operator")
+        status, detail = process_approval(
+            record, forecast, simulate_signature, settle, operator)
+        code_map = {"released": 200, "refused": 200, "held": 409, "error": 502}
+        sys.stdout.write("release-gate: %s approve by %s -> %s\n"
+                         % (record["id"][:8], operator, status))
+        sys.stdout.flush()
+        if status in ("released", "refused"):
+            self._json(200, record)
+        else:
+            self._json(code_map[status], {"status": status, **detail})
+
+
+def main():
+    submit_bind = resolve_gate_bind(None)
+    submit = ThreadingHTTPServer((submit_bind, GATE_PORT), SubmitHandler)
+    approve = ThreadingHTTPServer(("127.0.0.1", APPROVE_PORT), ApproveHandler)
+    sys.stdout.write(
+        "release-gate: SUBMIT/status on %s:%d (sandbox-facing) | APPROVE on "
+        "127.0.0.1:%d (host-only)\n"
+        % (submit_bind, GATE_PORT, APPROVE_PORT))
+    if submit_bind == "0.0.0.0":  # never our default; warn if forced
+        sys.stdout.write(
+            "release-gate: WARNING RELEASE_GATE_BIND=0.0.0.0 exposes submission "
+            "on every host interface; prefer the specific host-internal bridge.\n")
+    sys.stdout.write(
+        "release-gate: verdicts %s | rail %s\n" % (BLACKWALL_URL, RAIL_URL))
+    sys.stdout.write(
+        "release-gate: HOLD-approval token (host-side only, pass as "
+        "X-Approve-Token to 127.0.0.1:%d): %s\n" % (APPROVE_PORT, APPROVE_TOKEN))
+    sys.stdout.flush()
+    t = threading.Thread(target=submit.serve_forever, daemon=True)
+    t.start()
+    try:
+        approve.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/recipes/partners/bluetier/x402-payment-gate/host/test_release_gate.py
+++ b/examples/recipes/partners/bluetier/x402-payment-gate/host/test_release_gate.py
@@ -1,0 +1,514 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the host-side release gate (release_gate.py). Stdlib only, no
+network: the forecast/sign/settle seams are injected.
+
+The release contract has exactly TWO authorization paths, and these tests pin
+each one separately (same rule as the README and the module docstring):
+  * Automated release  -> ProcessIntent: settles unattended ONLY on a fresh
+    GO; HOLD/STOP/failure never settle here.
+  * Human-approved release -> ReviewRound2 (B3) + AuditRegressions (A1/A2):
+    a HELD intent needs a named human + host-side token AND a fresh re-screen;
+    a fresh STOP still refuses. A STOP is terminal on both paths.
+
+MUTATION NOTES per class: each names the invariant that block pins, so a
+surviving mutant points at the exact contract broken.
+"""
+
+import unittest
+
+from release_gate import (
+    HOLD,
+    REFUSE,
+    RELEASE,
+    approve_record,
+    decide_release,
+    finalize_release,
+    new_record,
+    process_approval,
+    process_intent,
+    reserve_slot,
+    resolve_gate_bind,
+    simulate_signature,
+    validate_intent,
+)
+
+PAYEE = "0x02c2FCAFce36b4AADb39625866Bc6b1699D83043"
+
+
+def verdict(v, **extra):
+    out = {"verdict": v, "hard_stop": v == "STOP",
+           "reasons": ["r1", "r2"], "receipt_id": "bw_x"}
+    out.update(extra)
+    return out
+
+
+class ValidateIntent(unittest.TestCase):
+    # MUTATION NOTES: the address gate is the anti-garbage filter; the
+    # lowercase step pins reputation-key canonicalization; plain-decimal
+    # amounts only (no scientific notation reaches the verdict service).
+
+    def test_valid_intent_normalizes(self):
+        intent, err = validate_intent(
+            {"counterparty": PAYEE, "amount": "0.014"})
+        self.assertIsNone(err)
+        self.assertEqual(intent["counterparty"], PAYEE.lower())
+        self.assertEqual(intent["amount"], "0.014")
+        self.assertEqual(intent["asset"], "USDC")
+        self.assertEqual(intent["chain"], "base")
+
+    def test_optional_fields_pass_through(self):
+        intent, err = validate_intent(
+            {"counterparty": PAYEE, "amount": "1", "asset": "USDC",
+             "chain": "base-sepolia", "resource": "https://api.example.com/x"})
+        self.assertIsNone(err)
+        self.assertEqual(intent["chain"], "base-sepolia")
+        self.assertEqual(intent["resource"], "https://api.example.com/x")
+
+    def test_rejects_bad_counterparty_and_amounts(self):
+        for payload in (
+            {"counterparty": "bob", "amount": "1"},
+            {"counterparty": PAYEE},
+            {"counterparty": PAYEE, "amount": "0"},
+            {"counterparty": PAYEE, "amount": "-1"},
+            {"counterparty": PAYEE, "amount": "1e3"},
+            {"amount": "1"},
+            "not-a-dict",
+            None,
+        ):
+            intent, err = validate_intent(payload)
+            self.assertIsNone(intent, payload)
+            self.assertIsNotNone(err, payload)
+
+
+class DecideRelease(unittest.TestCase):
+    # MUTATION NOTES: the family contract (langchain/wallet/openclaw guards).
+    # A mutant that releases on HOLD, on an unknown verdict, or on a service
+    # failure is the gate failing open on the MANDATORY layer.
+
+    def test_go_releases(self):
+        self.assertEqual(decide_release(verdict("GO")), RELEASE)
+
+    def test_hold_holds(self):
+        self.assertEqual(decide_release(verdict("HOLD")), HOLD)
+
+    def test_stop_refuses(self):
+        self.assertEqual(decide_release(verdict("STOP")), REFUSE)
+
+    def test_hard_stop_refuses_even_with_weird_text(self):
+        self.assertEqual(
+            decide_release(verdict("WEIRD", hard_stop=True)), REFUSE)
+
+    def test_unknown_and_missing_hold_never_release(self):
+        self.assertEqual(decide_release(verdict("???")), HOLD)
+        self.assertEqual(decide_release({}), HOLD)
+        self.assertEqual(decide_release(None), HOLD)
+
+
+class ProcessIntent(unittest.TestCase):
+    # MUTATION NOTES: the ORDER invariant — verdict first, signature second,
+    # settlement third, and neither of the latter two exists on any path but
+    # RELEASE. This is the "genuinely pre-signature" property as code.
+
+    def setUp(self):
+        self.calls = []
+        self.intent = {"counterparty": PAYEE.lower(), "amount": "0.014",
+                       "asset": "USDC", "chain": "base"}
+
+    def _sign(self, intent):
+        self.calls.append("sign")
+        return "sig_test"
+
+    def _settle(self, intent, signature):
+        self.calls.append("settle")
+        self.assertEqual(signature, "sig_test")  # settle gets the signature
+        return {"settled": True, "tx": "sim_1"}
+
+    def test_go_forecasts_then_signs_then_settles(self):
+        def forecast(intent):
+            self.calls.append("forecast")
+            return verdict("GO")
+        status, detail = process_intent(
+            self.intent, forecast, self._sign, self._settle)
+        self.assertEqual(status, "released")
+        self.assertEqual(self.calls, ["forecast", "sign", "settle"])
+        self.assertEqual(detail["settlement"]["tx"], "sim_1")
+        self.assertEqual(detail["verdict"]["verdict"], "GO")
+
+    def test_hold_never_touches_signature_or_rail(self):
+        status, detail = process_intent(
+            self.intent, lambda i: verdict("HOLD"), self._sign, self._settle)
+        self.assertEqual(status, "held")
+        self.assertEqual(self.calls, [])
+        self.assertIn("r1", detail["verdict"]["reasons"])
+
+    def test_stop_refuses_and_never_touches_signature_or_rail(self):
+        status, _ = process_intent(
+            self.intent, lambda i: verdict("STOP"), self._sign, self._settle)
+        self.assertEqual(status, "refused")
+        self.assertEqual(self.calls, [])
+
+    def test_forecast_failure_holds_never_releases(self):
+        def broken(intent):
+            raise OSError("verdict service unreachable")
+        status, detail = process_intent(
+            self.intent, broken, self._sign, self._settle)
+        self.assertEqual(status, "held")
+        self.assertEqual(self.calls, [])
+        self.assertIn("unreachable", detail["error"])
+
+    def test_settle_failure_reports_error_after_go(self):
+        def bad_settle(intent, signature):
+            self.calls.append("settle")
+            raise OSError("rail down")
+        status, detail = process_intent(
+            self.intent, lambda i: verdict("GO"), self._sign, bad_settle)
+        self.assertEqual(status, "error")
+        self.assertIn("rail down", detail["error"])
+
+
+class SimulatedSignature(unittest.TestCase):
+    # MUTATION NOTES: the simulation must be honest — clearly labeled, and
+    # deterministic over the intent so the rail can bind it to the claim.
+
+    def test_labeled_and_deterministic(self):
+        intent = {"counterparty": PAYEE.lower(), "amount": "0.014",
+                  "asset": "USDC", "chain": "base"}
+        s1 = simulate_signature(intent)
+        s2 = simulate_signature(intent)
+        self.assertTrue(s1.startswith("SIMULATED_"))
+        self.assertEqual(s1, s2)
+        intent2 = dict(intent, amount="0.015")
+        self.assertNotEqual(s1, simulate_signature(intent2))
+
+
+
+class AuditRegressions(unittest.TestCase):
+    """Session audit of the initial gate implementation.
+
+    MUTATION NOTES: A1 pins the double-release race (two concurrent approvals
+    of one HELD intent must yield exactly one settlement); A2 pins the
+    approval token (a named header alone must never release — the token is
+    printed host-side only, where the sandbox cannot read); A3 pins the
+    intent-store cap; A4 pins input size bounds.
+    """
+
+    def _held_record(self):
+        intent, err = validate_intent(
+            {"counterparty": PAYEE, "amount": "0.014"})
+        self.assertIsNone(err)
+        return new_record(intent, "held", {"verdict": verdict("HOLD")})
+
+    def test_a1_second_approval_of_same_intent_is_rejected(self):
+        record = self._held_record()
+        code, _ = approve_record(record, "samuel", "tok", "tok")
+        self.assertEqual(code, 0)                # first approval proceeds
+        self.assertEqual(record["status"], "releasing")
+        code2, err2 = approve_record(record, "mallory", "tok", "tok")
+        self.assertEqual(code2, 409)             # concurrent second: rejected
+        finalize_release(record, {"settled": True, "tx": "sim_a"}, "samuel")
+        self.assertEqual(record["status"], "released")
+        code3, _ = approve_record(record, "mallory", "tok", "tok")
+        self.assertEqual(code3, 409)             # after release: rejected
+
+    def test_a2_approval_requires_the_host_side_token(self):
+        from release_gate import approve_record
+        record = self._held_record()
+        code, _ = approve_record(record, "samuel", None, "tok")
+        self.assertEqual(code, 403)              # no token
+        code, _ = approve_record(record, "samuel", "wrong", "tok")
+        self.assertEqual(code, 403)              # wrong token
+        code, _ = approve_record(record, None, "tok", "tok")
+        self.assertEqual(code, 403)              # token but no named human
+        self.assertEqual(record["status"], "held")  # nothing changed state
+
+    def test_a3_intent_store_is_bounded(self):
+        # A3's capacity cap is now enforced atomically by reserve_slot
+        # (see ReviewRound2.test_b4_*); a full store rejects new reservations.
+        store = {"a": 1, "b": 2}
+        rec = new_record(validate_intent(
+            {"counterparty": PAYEE, "amount": "1"})[0], "processing", {})
+        self.assertFalse(reserve_slot(store, 2, rec))
+        self.assertTrue(reserve_slot({}, 2, rec))
+
+    def test_a4_oversized_fields_are_rejected(self):
+        big_amount = "9" * 60
+        intent, err = validate_intent(
+            {"counterparty": PAYEE, "amount": big_amount})
+        self.assertIsNone(intent)
+        intent, err = validate_intent(
+            {"counterparty": PAYEE, "amount": "1",
+             "resource": "https://x/" + "a" * 3000})
+        self.assertIsNone(intent)
+        # sane values still pass
+        intent, err = validate_intent(
+            {"counterparty": PAYEE, "amount": "1",
+             "resource": "https://api.example.com/v1/data"})
+        self.assertIsNone(err)
+
+
+class ConcurrencyGuard(unittest.TestCase):
+    """Deterministic proof of the double-release lock (A1).
+
+    A single-threaded test cannot catch a missing lock (check-then-act still
+    passes sequentially), and an HTTP-level race test cannot catch it either
+    (CPython's GIL makes the tiny window near-impossible to interleave). So we
+    force the interleave in-process: a record whose status-read inside the
+    critical section pauses thread A, during which thread B attempts its own
+    approval. With the lock, B blocks on acquire and later sees 'releasing'
+    (409); without it, B reads 'held' and also releases (two 0s -> caught).
+    """
+
+    def test_a1_lock_serializes_concurrent_approvals(self):
+        import threading
+        import time
+
+        base = self._held_record()
+        a_in_section = threading.Event()
+        release_a = threading.Event()
+
+        class CoordDict(dict):
+            first = True
+
+            def __getitem__(self, key):
+                val = dict.__getitem__(self, key)
+                if key == "status" and self.first \
+                        and threading.current_thread().name == "A":
+                    self.first = False
+                    a_in_section.set()      # A has read status; let B start
+                    release_a.wait(3)       # pause A between check and set
+                return val
+
+        record = CoordDict(base)
+        results = {}
+
+        def call(name):
+            results[name] = approve_record(record, name, "tok", "tok")[0]
+
+        a = threading.Thread(target=call, args=("A",), name="A")
+        b = threading.Thread(target=call, args=("B",), name="B")
+        a.start()
+        self.assertTrue(a_in_section.wait(3), "A never entered its section")
+        b.start()
+        time.sleep(0.2)          # B blocks on the lock (fixed) or completes (mutant)
+        release_a.set()          # resume A
+        a.join(3)
+        b.join(3)
+
+        releases = [k for k, v in results.items() if v == 0]
+        self.assertEqual(len(releases), 1,
+                         "exactly one approval may release; got %s" % results)
+
+    def _held_record(self):
+        intent, err = validate_intent(
+            {"counterparty": PAYEE, "amount": "0.014"})
+        self.assertIsNone(err)
+        return new_record(intent, "held", {"verdict": verdict("HOLD")})
+
+
+class ReviewRound2(unittest.TestCase):
+    """Second review round (PR #105, commit 54345d0).
+
+    MUTATION NOTES:
+      B1 gate must bind an address reachable from the sandbox (not host
+         loopback); the rail must stay loopback (the denied edge).
+      B2 covered by verify.sh stage 3 (in-sandbox fresh submission), not here.
+      B3 human approval RE-SCREENS: a fresh STOP refuses even a named human
+         with a valid token; GO/HOLD let the override stand. Signature never
+         appears on a refused path.
+      B4 slot reservation is atomic under the lock (check + insert together),
+         so the store cannot exceed its cap under concurrent submits.
+    """
+
+    def _intent(self):
+        intent, err = validate_intent(
+            {"counterparty": PAYEE, "amount": "0.014"})
+        self.assertIsNone(err)
+        return intent
+
+    # B1 -------------------------------------------------------------
+    def test_b1_submit_bind_defaults_safe_never_promiscuous(self):
+        from release_gate import resolve_gate_bind, RAIL_URL
+        # SAFE default: host loopback, and NEVER 0.0.0.0 (which would expose
+        # submission on every host interface). Reachability from the sandbox is
+        # an explicit opt-in (operator sets the specific bridge interface).
+        self.assertEqual(resolve_gate_bind(None), "127.0.0.1")
+        self.assertNotEqual(resolve_gate_bind(None), "0.0.0.0")
+        self.assertEqual(resolve_gate_bind("10.0.2.2"), "10.0.2.2")  # honored
+        self.assertTrue(RAIL_URL.startswith("http://127.0.0.1"))
+
+    def test_b1_listeners_are_split_approval_host_only(self):
+        # The maker (submit) and human (approve) surfaces are DIFFERENT
+        # listeners: submit never serves /approve, approve never serves
+        # /v1/intents, and approve is bound to host loopback.
+        import http.client
+        import json
+        import threading
+        from http.server import ThreadingHTTPServer
+        import release_gate as rg
+
+        # Route-only test: inject fast fakes so a submit never makes a live
+        # forecast/settle call, and restore module state afterward.
+        saved = (dict(rg.INTENTS), rg.APPROVE_TOKEN, rg.forecast, rg.settle)
+        rg.INTENTS.clear()
+        rg.APPROVE_TOKEN = "tok"
+        rg.forecast = lambda intent: {"verdict": "HOLD"}
+        rg.settle = lambda intent, sig: {"tx": "x"}
+        submit = ThreadingHTTPServer(("127.0.0.1", 0), rg.SubmitHandler)
+        approve = ThreadingHTTPServer(("127.0.0.1", 0), rg.ApproveHandler)
+        for s in (submit, approve):
+            threading.Thread(target=s.serve_forever, daemon=True).start()
+        sp = submit.server_address[1]
+        ap = approve.server_address[1]
+
+        def req(port, method, path, body=None, headers=None):
+            c = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+            c.request(method, path,
+                      body=json.dumps(body) if body is not None else None,
+                      headers=headers or {})
+            r = c.getresponse(); r.read(); c.close()
+            return r.status
+        try:
+            # submit listener serves submit, NOT approve
+            self.assertEqual(req(sp, "POST", "/v1/intents",
+                                 {"counterparty": PAYEE, "amount": "0.014"},
+                                 {"Content-Type": "application/json"}), 201)
+            self.assertEqual(
+                req(sp, "POST", "/v1/intents/anything/approve",
+                    {}, {"X-Operator": "x", "X-Approve-Token": "tok"}), 404)
+            # approve listener serves approve, NOT submit
+            self.assertEqual(
+                req(ap, "POST", "/v1/intents",
+                    {"counterparty": PAYEE, "amount": "0.014"},
+                    {"Content-Type": "application/json"}), 404)
+            # approve is bound to host loopback
+            self.assertEqual(approve.server_address[0], "127.0.0.1")
+        finally:
+            submit.shutdown(); approve.shutdown()
+            submit.server_close(); approve.server_close()
+            rg.INTENTS.clear(); rg.INTENTS.update(saved[0])
+            rg.APPROVE_TOKEN, rg.forecast, rg.settle = saved[1], saved[2], saved[3]
+
+    # B3 -------------------------------------------------------------
+    def test_b3_approval_reforecasts_fresh_stop_refuses_human(self):
+        from release_gate import approve_record, process_approval
+        record = new_record(self._intent(), "held", {"verdict": verdict("HOLD")})
+        code, _ = approve_record(record, "samuel", "tok", "tok")
+        self.assertEqual(code, 0)                 # authz + claim ok
+        calls = []
+        status, detail = process_approval(
+            record,
+            forecast_fn=lambda i: verdict("STOP"),          # became sanctioned
+            sign_fn=lambda i: calls.append("sign") or "sig",
+            settle_fn=lambda i, s: calls.append("settle") or {"tx": "x"},
+            operator="samuel")
+        self.assertEqual(status, "refused")
+        self.assertEqual(record["status"], "refused")
+        self.assertEqual(calls, [])               # never signed, never settled
+
+    def test_b3_approval_go_lets_override_stand(self):
+        from release_gate import approve_record, process_approval
+        record = new_record(self._intent(), "held", {"verdict": verdict("HOLD")})
+        approve_record(record, "samuel", "tok", "tok")
+        calls = []
+        status, detail = process_approval(
+            record, lambda i: verdict("GO"),
+            lambda i: calls.append("sign") or "sig",
+            lambda i, s: calls.append("settle") or {"tx": "x"}, "samuel")
+        self.assertEqual(status, "released")
+        self.assertEqual(calls, ["sign", "settle"])   # order preserved
+        self.assertEqual(record["detail"]["approved_by"], "samuel")
+
+    def test_b3_approval_hold_is_a_human_override(self):
+        from release_gate import approve_record, process_approval
+        record = new_record(self._intent(), "held", {"verdict": verdict("HOLD")})
+        approve_record(record, "samuel", "tok", "tok")
+        # a still-HOLD re-forecast: the named human's override stands
+        status, _ = process_approval(
+            record, lambda i: verdict("HOLD"),
+            lambda i: "sig", lambda i, s: {"tx": "x"}, "samuel")
+        self.assertEqual(status, "released")
+
+    def test_b3_reforecast_failure_returns_to_held(self):
+        from release_gate import approve_record, process_approval
+        record = new_record(self._intent(), "held", {"verdict": verdict("HOLD")})
+        approve_record(record, "samuel", "tok", "tok")
+
+        def broken(i):
+            raise OSError("verdict service down")
+        calls = []
+        status, _ = process_approval(
+            record, broken, lambda i: calls.append("s") or "sig",
+            lambda i, s: calls.append("t") or {}, "samuel")
+        self.assertEqual(status, "held")
+        self.assertEqual(record["status"], "held")   # claim released, retryable
+        self.assertEqual(calls, [])
+
+    # B4 -------------------------------------------------------------
+    def test_b4_reserve_slot_is_atomic_and_bounded(self):
+        from release_gate import reserve_slot
+        store = {}
+        r1 = new_record(self._intent(), "processing", {})
+        r2 = new_record(self._intent(), "processing", {})
+        r3 = new_record(self._intent(), "processing", {})
+        self.assertTrue(reserve_slot(store, 2, r1))
+        self.assertTrue(reserve_slot(store, 2, r2))
+        self.assertFalse(reserve_slot(store, 2, r3))   # at cap
+        self.assertEqual(len(store), 2)
+        self.assertIn(r1["id"], store)
+        self.assertNotIn(r3["id"], store)
+
+    def test_b4_reserve_slot_lock_prevents_overshoot(self):
+        # Deterministic: a store whose length-check inside reserve_slot pauses
+        # thread A between "is there room?" and the insert, during which thread
+        # B attempts its own reservation at cap-1. With the lock, B blocks on
+        # acquire and later sees the store full; without it, both insert and
+        # the store overshoots cap. (A single-threaded or barrier test cannot
+        # catch a missing lock here — CPython's GIL hides the window.)
+        import threading
+        import time
+
+        a_checked = threading.Event()
+        release_a = threading.Event()
+
+        class CoordStore(dict):
+            armed = True
+
+            def __len__(self):
+                n = dict.__len__(self)
+                if self.armed and threading.current_thread().name == "A":
+                    self.armed = False
+                    a_checked.set()       # A has read the length; let B start
+                    release_a.wait(3)     # pause A between check and insert
+                return n
+
+        store = CoordStore()
+        store["existing"] = 1             # cap 2, so exactly one slot free
+        cap = 2
+        results = {}
+
+        def call(name):
+            rec = new_record(self._intent(), "processing", {})
+            results[name] = reserve_slot(store, cap, rec)
+
+        a = threading.Thread(target=call, args=("A",), name="A")
+        b = threading.Thread(target=call, args=("B",), name="B")
+        a.start()
+        self.assertTrue(a_checked.wait(3), "A never entered reserve_slot")
+        b.start()
+        time.sleep(0.2)          # B blocks on the lock (fixed) or inserts (mutant)
+        release_a.set()
+        a.join(3)
+        b.join(3)
+
+        self.assertEqual(dict.__len__(store), cap,
+                         "store overshot cap: %d" % dict.__len__(store))
+        self.assertEqual(list(results.values()).count(True), 1,
+                         "exactly one reservation may succeed; got %s" % results)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/recipes/partners/bluetier/x402-payment-gate/policy.yaml
+++ b/examples/recipes/partners/bluetier/x402-payment-gate/policy.yaml
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# COMPLETE sandbox policy for the x402-payment-gate recipe (Hermes runtime).
+# Applied whole by scripts/bring-up.sh. Composition: the inference block below
+# mirrors recipes/nvidia/developer-community-chief-of-staff/policy.yaml (the
+# agent's required NemoClaw routes, unbroadened); the blackwall and
+# release-gate blocks are this recipe's additions. All in-sandbox HTTP is
+# made by the Hermes python runtime or curl -- the binary allowlists say
+# exactly that and nothing more.
+#
+# THE DENIED EDGE (deliberate): there is NO route to any x402 facilitator,
+# payment rail, or the host mock rail (127.0.0.1:8780 stays host-only). The
+# sandboxed agent can ASK for verdicts and SUBMIT intents; only the host-side
+# release gate, outside this sandbox, can settle a payment.
+version: 1
+filesystem_policy:
+  include_workdir: true
+  read_only:
+  - /usr
+  - /lib
+  - /opt/hermes
+  - /proc
+  - /dev/urandom
+  - /app
+  - /etc
+  - /var/log
+  - /sandbox/.hermes
+  read_write:
+  - /sandbox
+  - /tmp
+  - /dev/null
+  - /sandbox/.hermes-data
+landlock:
+  compatibility: best_effort
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+network_policies:
+  # Load-bearing: per-path allow rules for the NVIDIA inference API — the
+  # agent's required routes, copied unbroadened from the chief-of-staff recipe.
+  nvidia:
+    name: nvidia
+    endpoints:
+    - host: integrate.api.nvidia.com
+      port: 443
+      protocol: rest
+      tls: terminate
+      enforcement: enforce
+      rules:
+      - allow:
+          method: POST
+          path: /v1/chat/completions
+      - allow:
+          method: POST
+          path: /v1/completions
+      - allow:
+          method: POST
+          path: /v1/embeddings
+      - allow:
+          method: GET
+          path: /v1/models
+      - allow:
+          method: GET
+          path: /v1/models/**
+    - host: inference-api.nvidia.com
+      port: 443
+      protocol: rest
+      tls: terminate
+      enforcement: enforce
+      rules:
+      - allow:
+          method: POST
+          path: /v1/chat/completions
+      - allow:
+          method: POST
+          path: /v1/completions
+      - allow:
+          method: POST
+          path: /v1/embeddings
+      - allow:
+          method: GET
+          path: /v1/models
+      - allow:
+          method: GET
+          path: /v1/models/**
+    binaries:
+    - path: /usr/local/bin/hermes
+    - path: /opt/hermes/.venv/bin/hermes
+    - path: /usr/bin/python3
+    - path: /usr/bin/python3.13
+    - path: /opt/hermes/.venv/bin/python
+  # Blackwall verdict service — ADVISORY pre-checks from inside the sandbox
+  # (the skill's stdlib client). The MANDATORY verdict happens host-side in
+  # the release gate; this route existing changes nothing about that.
+  blackwall:
+    name: blackwall
+    endpoints:
+    - host: blackwall-free.onrender.com
+      port: 443
+      protocol: rest
+      tls: terminate
+      enforcement: enforce
+      rules:
+      - allow:
+          method: POST
+          path: /v1/forecast-payment
+      - allow:
+          method: POST
+          path: /v1/report-outcome
+      - allow:
+          method: GET
+          path: /healthz
+      - allow:
+          method: GET
+          path: /.well-known/x402
+    binaries:
+    - path: /usr/bin/python3
+    - path: /usr/bin/python3.13
+    - path: /opt/hermes/.venv/bin/python
+    - path: /usr/bin/curl
+  # Host-side release gate — intent SUBMISSION and status only. Note what is
+  # absent: the mock rail port (8780) and any facilitator. Submitting an
+  # intent is the most a sandboxed prompt can ever do.
+  release-gate:
+    name: release-gate
+    endpoints:
+    - host: host.openshell.internal
+      port: 8790
+      protocol: rest
+      enforcement: enforce
+      rules:
+      - allow:
+          method: POST
+          path: /v1/intents
+      - allow:
+          method: GET
+          path: /v1/intents/**
+      - allow:
+          method: GET
+          path: /healthz
+    binaries:
+    - path: /usr/bin/python3
+    - path: /usr/bin/python3.13
+    - path: /opt/hermes/.venv/bin/python
+    - path: /usr/bin/curl

--- a/examples/recipes/partners/bluetier/x402-payment-gate/scripts/blackwall_client.py
+++ b/examples/recipes/partners/bluetier/x402-payment-gate/scripts/blackwall_client.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Minimal stdlib client for the Blackwall x402 payment-verdict service.
+
+Blackwall answers one question before an agent signs an x402 payment:
+should this payment happen? It returns GO / HOLD / STOP from counterparty
+reputation, price-anomaly, OFAC sanctions, and Sybil/graph signals.
+
+This client is stdlib-only (urllib) so it runs unmodified inside an
+OpenShell sandbox with no package installs. The sandbox network policy
+(../policy.yaml) restricts it to exactly the verdict endpoints it needs.
+
+Usage as a library:
+
+    from blackwall_client import forecast_payment, should_sign
+    verdict = forecast_payment("0xPayee...", "0.014")
+    action = should_sign(verdict)   # "sign" | "escalate" | "refuse"
+
+Usage from a shell:
+
+    python3 blackwall_client.py --counterparty 0xPayee... --amount 0.014
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+DEFAULT_BASE_URL = os.environ.get(
+    "BLACKWALL_URL", "https://blackwall-free.onrender.com"
+)
+# The free instance spins down when idle; the first request is a slow cold
+# start (up to ~60s). Later requests are fast.
+DEFAULT_TIMEOUT = 90
+
+# Outcomes the /v1/report-outcome endpoint accepts (ledger vocabulary).
+VALID_OUTCOMES = (
+    "settled", "delivered",              # good: counts toward reputation
+    "underdelivered", "disputed", "refunded",  # bad: counts toward disputes
+    "abandoned",                         # neutral: GO issued but never paid
+)
+
+
+def should_sign(verdict: dict) -> str:
+    """Map a Blackwall verdict to the agent's next action.
+
+    Pure decision function -- no I/O. Returns one of:
+      "sign"     -- GO: proceed to sign the x402 payment.
+      "escalate" -- HOLD (or anything unrecognized): do NOT sign; surface the
+                    verdict's `reasons` to a human or a higher-trust policy.
+      "refuse"   -- STOP or hard_stop: never sign; the counterparty is
+                    sanctioned or the payload does not match the claim.
+
+    Unknown/malformed verdicts map to "escalate", never "sign": the gate
+    fails toward human review, not toward moving money.
+    """
+    if not isinstance(verdict, dict):
+        return "escalate"
+    if verdict.get("hard_stop") or verdict.get("verdict") == "STOP":
+        return "refuse"
+    if verdict.get("verdict") == "GO":
+        return "sign"
+    return "escalate"
+
+
+def _post_json(url: str, body: dict, timeout: int) -> dict:
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        # 4xx/5xx bodies are JSON error objects; surface them instead of a stack.
+        try:
+            detail = json.loads(e.read().decode("utf-8"))
+        except Exception:
+            detail = {"error": str(e)}
+        detail.setdefault("http_status", e.code)
+        return detail
+
+
+def forecast_payment(counterparty: str, amount: str, asset: str = "USDC",
+                     chain: str = "base", resource: str | None = None,
+                     payer: str | None = None,
+                     base_url: str = DEFAULT_BASE_URL,
+                     timeout: int = DEFAULT_TIMEOUT) -> dict:
+    """POST /v1/forecast-payment -- ask for a verdict BEFORE signing.
+
+    Required: counterparty (the x402 payTo address), amount (positive decimal
+    string, e.g. "0.014"), asset, chain. Optional: resource (the URL being
+    paid for -- enables the per-category price baseline), payer (the agent's
+    own wallet, binds settlement confirmation to this agent).
+
+    Returns the verdict dict: verdict (GO/HOLD/STOP), hard_stop, score,
+    reasons[], signals{}, confidence{}, receipt_id, report_token.
+    """
+    body = {"counterparty": counterparty, "amount": amount,
+            "asset": asset, "chain": chain}
+    if resource:
+        body["resource"] = resource
+    if payer:
+        body["payer"] = payer
+    return _post_json(base_url.rstrip("/") + "/v1/forecast-payment",
+                      body, timeout)
+
+
+def report_outcome(receipt_id: str, report_token: str, outcome: str,
+                   base_url: str = DEFAULT_BASE_URL,
+                   timeout: int = DEFAULT_TIMEOUT) -> dict:
+    """POST /v1/report-outcome -- close the loop on a prior verdict.
+
+    After the payment settles (or fails), report what actually happened so
+    the counterparty's reputation reflects real outcomes. `outcome` must be
+    one of VALID_OUTCOMES; `report_token` came back with the verdict and is
+    the capability that authorizes reporting on that receipt_id.
+    """
+    return _post_json(base_url.rstrip("/") + "/v1/report-outcome",
+                      {"receipt_id": receipt_id, "report_token": report_token,
+                       "outcome": outcome}, timeout)
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(
+        description="Ask Blackwall for a GO/HOLD/STOP verdict on an x402 payment.")
+    p.add_argument("--counterparty", required=True,
+                   help="x402 payTo address the agent is about to pay")
+    p.add_argument("--amount", required=True,
+                   help='positive decimal string, e.g. "0.014"')
+    p.add_argument("--asset", default="USDC")
+    p.add_argument("--chain", default="base")
+    p.add_argument("--resource", default=None,
+                   help="URL of the resource being paid for (optional)")
+    p.add_argument("--payer", default=None,
+                   help="the agent's own wallet address (optional)")
+    p.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    args = p.parse_args(argv)
+
+    verdict = forecast_payment(args.counterparty, args.amount,
+                               asset=args.asset, chain=args.chain,
+                               resource=args.resource, payer=args.payer,
+                               base_url=args.base_url)
+    print(json.dumps(verdict, indent=2))
+    action = should_sign(verdict)
+    print("\naction: %s" % action, file=sys.stderr)
+    # Exit code mirrors the gate so shell callers can branch on it:
+    # 0 = sign, 1 = escalate, 2 = refuse.
+    return {"sign": 0, "escalate": 1, "refuse": 2}[action]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/recipes/partners/bluetier/x402-payment-gate/scripts/bring-up.sh
+++ b/examples/recipes/partners/bluetier/x402-payment-gate/scripts/bring-up.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Bring up the maker/checker payment boundary end to end.
+#
+#   1. host services — mock payment rail (127.0.0.1:8780, HOST ONLY), the
+#      release gate SUBMIT listener (127.0.0.1:8790; the sandbox reaches it only
+#      via the host.openshell.internal route in policy.yaml), and the host-only
+#      APPROVE listener (127.0.0.1:8791; the sandbox has no route to it)
+#   2. optional local image sanity build — OpenShell builds the real image
+#      itself from the recipe-root Dockerfile via --from in phase 3; this is
+#      only a fast local fail-early check and is skipped without docker
+#   3. sandbox — `openshell sandbox create --from <recipe-root>` with
+#      policy.yaml applied WHOLE (inference routes + blackwall advisory routes +
+#      release-gate SUBMIT route; no rail route, no approve route). This is what
+#      the security boundary needs: verify.sh exercises the denied edge via
+#      `sandbox exec` and does NOT require the Hermes agent runtime to be up.
+#      NOTE: --from takes the recipe ROOT (the Dockerfile's directory), because
+#      OpenShell uses that directory as the Docker build context and the
+#      Dockerfile COPYs from recipe-root-relative paths (agents/, scripts/).
+#
+# Requires: python3. openshell for phase 3 (and docker only for the optional
+# phase-2 sanity build); without them the host boundary still comes up and
+# scripts/verify.sh --host-only can exercise it.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXAMPLE_DIR="$(dirname "$DIR")"
+RUN="$EXAMPLE_DIR/.run"
+SANDBOX_NAME="${SANDBOX_NAME:-x402-gate-demo}"
+IMAGE_TAG="${IMAGE_TAG:-x402-payment-gate-sandbox}"
+mkdir -p "$RUN"
+
+echo "== 1/3 host services (the CHECKER side) =="
+command -v python3 >/dev/null || { echo "python3 required" >&2; exit 1; }
+
+# Where the SUBMIT listener binds. The sandbox reaches the host over the
+# OpenShell bridge (host.openshell.internal -> the openshell-docker network
+# gateway), NOT host loopback -- so a gate on 127.0.0.1 is unreachable from the
+# sandbox (the maker path is dead), while 0.0.0.0 would expose submission on
+# every host interface (LAN included). We bind the SPECIFIC bridge interface:
+# reachable by the sandbox's supervisor proxy and by the host, but not the LAN.
+# The gateway recreates the openshell-docker network at startup, so its gateway
+# address is discoverable before any sandbox exists. Without openshell (a
+# host-only run) we fall back to loopback -- there is no sandbox to reach.
+# The RAIL and APPROVE listeners ALWAYS stay on loopback: the rail's
+# loopback-only bind IS the denied edge, and approve is a named human on the
+# host. Only the least-privileged SUBMIT listener is exposed to the bridge.
+GATE_BIND="127.0.0.1"
+if command -v openshell >/dev/null 2>&1 && command -v docker >/dev/null 2>&1; then
+  bridge="$(docker network inspect openshell-docker \
+    -f '{{(index .IPAM.Config 0).Gateway}}' 2>/dev/null || true)"
+  if [ -n "$bridge" ]; then
+    GATE_BIND="$bridge"
+  else
+    echo "  WARN: openshell-docker bridge not found (is the gateway running?)." >&2
+    echo "  Binding the SUBMIT listener to loopback; the in-sandbox maker path" >&2
+    echo "  will NOT work until the gate is bound to the bridge. Start the" >&2
+    echo "  openshell gateway, then re-run bring-up." >&2
+  fi
+fi
+GATE_URL="http://$GATE_BIND:8790"
+
+# Own our processes: only reuse a service THIS lifecycle started (tracked by
+# pid file) and still alive. Never silently adopt an arbitrary process that
+# merely answers /healthz on the port -- that could be a prior checkout or an
+# unrelated service, and fresh verification would then exercise stale code.
+# If the port is held by something we do not own, fail with an actionable
+# error rather than reusing it.
+start_service() { # start_service <name> <script> <port> <bind>
+  local name="$1" script="$2" port="$3" bind="$4"
+  local pidf="$RUN/$name.pid"
+  if [ -f "$pidf" ] && kill -0 "$(cat "$pidf" 2>/dev/null)" 2>/dev/null; then
+    echo "  $name: reusing our running instance (pid $(cat "$pidf"))"
+    return 0
+  fi
+  if curl -sS -m 2 "http://$bind:$port/healthz" >/dev/null 2>&1; then
+    echo "  ERROR: $bind:$port is already serving, but not a process this" >&2
+    echo "         lifecycle owns (no live pid file). Stop it, or run" >&2
+    echo "         scripts/tear-down.sh, before bring-up. Refusing to reuse" >&2
+    echo "         an unknown process (it may run stale code)." >&2
+    exit 1
+  fi
+  # RELEASE_GATE_BIND is read by release_gate.py for the SUBMIT listener;
+  # mock_rail.py ignores it (the rail is loopback-only by design). We `exec` the
+  # backgrounded subshell straight into python3, so $! is python3's OWN pid --
+  # NOT the wrapping subshell's. tear-down.sh kills by this pid, so it must be
+  # the real one (capturing the subshell pid leaves the service running).
+  ( cd "$EXAMPLE_DIR/host" \
+      && exec env RELEASE_GATE_BIND="$bind" nohup python3 "$script" ) \
+      > "$RUN/$name.log" 2>&1 &
+  echo $! > "$pidf"
+  echo "  $name: started (pid $(cat "$pidf"))"
+}
+start_service rail mock_rail.py 8780 127.0.0.1
+start_service gate release_gate.py 8790 "$GATE_BIND"
+# Record the host-reachable gate URL so scripts/verify.sh targets the same
+# address the SUBMIT listener actually bound (loopback or bridge).
+printf '%s\n' "$GATE_URL" > "$RUN/gate.url"
+sleep 1
+curl -sS -m 5 http://127.0.0.1:8780/healthz >/dev/null && echo "  mock rail: healthy (host-only; NO sandbox route by design)"
+curl -sS -m 5 "$GATE_URL/healthz" >/dev/null && echo "  release gate: healthy (SUBMIT on $GATE_BIND:8790; approve host-only on 8791)"
+
+echo
+echo "== 2/3 optional local image sanity build =="
+# OpenShell builds the sandbox image itself from the recipe-root Dockerfile via
+# the `--from` flag in phase 3 (see below) -- there is NO separate `--image`
+# step. This phase is only a fast, local fail-early check that the Dockerfile
+# builds; it is entirely optional and skipped when docker is absent. Build
+# context is the recipe root (matching --from), so the COPY paths resolve.
+if command -v docker >/dev/null 2>&1; then
+  if (cd "$EXAMPLE_DIR" && docker build -t "$IMAGE_TAG" .); then
+    echo "  Dockerfile builds cleanly ($IMAGE_TAG). OpenShell will build its own"
+    echo "  copy from --from in phase 3."
+  else
+    echo "  WARN: local docker build failed. This is only a pre-flight sanity"
+    echo "  check; OpenShell still builds from --from in phase 3."
+  fi
+else
+  echo "  skipped: docker not available (only used for the optional local"
+  echo "  sanity build; OpenShell builds from --from in phase 3)."
+fi
+
+echo
+echo "== 3/3 sandbox ($SANDBOX_NAME) =="
+# What this phase stands up is the security boundary: a sandbox with
+# policy.yaml applied. The denied-edge and in-sandbox maker checks in
+# verify.sh run via `openshell sandbox exec` (curl/python3 straight inside the
+# sandbox) and therefore do NOT need the Hermes agent runtime to be running --
+# they need only this created sandbox + its policy. Running the interactive
+# Hermes MAKER agent (the SKILL.md UX) additionally needs a full NemoClaw
+# Relay+Hermes image and `nemoclaw-start`; that is an operator step layered on
+# top, not part of the boundary this recipe verifies.
+if ! command -v openshell >/dev/null 2>&1; then
+  echo "  skipped: openshell not in PATH. Run scripts/verify.sh now to exercise"
+  echo "  the host boundary; re-run bring-up where openshell is available for"
+  echo "  the full sandbox + denied-edge test."
+  exit 0
+fi
+# A sandbox with this name may have been built from an OLDER checkout, and
+# reusing it (only re-applying policy) would run stale Dockerfile/skill/client
+# content -- which verify.sh, exercising the sandbox over curl/exec, cannot
+# detect. So we ALWAYS rebuild from THIS checkout: delete any existing sandbox
+# of this name, then create it fresh.
+if openshell sandbox list 2>/dev/null | grep -qE "^\s*$SANDBOX_NAME\s"; then
+  echo "  sandbox '$SANDBOX_NAME' already exists -- deleting it so we rebuild from"
+  echo "  this checkout (reusing it could run a stale Dockerfile/skill/client)."
+  openshell sandbox delete "$SANDBOX_NAME" </dev/null >/dev/null 2>&1 || true
+  for _ in $(seq 1 30); do
+    openshell sandbox list 2>/dev/null | grep -qE "^\s*$SANDBOX_NAME\s" || break
+    sleep 1
+  done
+fi
+# OpenShell builds the image from the recipe-root Dockerfile (--from points at
+# the recipe root so that directory is the build context and the Dockerfile's
+# COPY paths resolve), applies the whole policy, and reaches Ready. This is the
+# v0.0.85+ contract (--from <path>, not --image <tag>).
+#
+# `create` provisions the sandbox and then tries to attach an interactive
+# session; run from a script (no controlling TTY) that attach fails with an
+# "os error 2" and a NON-ZERO exit -- even though the sandbox is created and
+# goes on to reach Ready. So we must NOT let that exit abort bring-up under
+# `set -e`: tolerate it and treat the Ready-poll below as the source of truth.
+# A genuine build/policy failure instead shows up as an Error phase, which the
+# poll detects and reports immediately.
+openshell sandbox create \
+  --from "$EXAMPLE_DIR" \
+  --name "$SANDBOX_NAME" \
+  --policy "$EXAMPLE_DIR/policy.yaml" </dev/null || true
+echo "  waiting for sandbox to reach Ready..."
+ready=0
+for _ in $(seq 1 240); do
+  phase="$(openshell sandbox list 2>/dev/null | grep -E "^\s*$SANDBOX_NAME\s" || true)"
+  if printf '%s' "$phase" | grep -qi ready; then ready=1; break; fi
+  if printf '%s' "$phase" | grep -qi error; then
+    echo "  ERROR: sandbox '$SANDBOX_NAME' entered an Error phase:" >&2
+    printf '         %s\n' "$phase" >&2
+    exit 1
+  fi
+  sleep 2
+done
+if [ "$ready" -ne 1 ]; then
+  echo "  ERROR: sandbox did not reach Ready in ~8 min. Inspect with" >&2
+  echo "         'openshell sandbox list'." >&2
+  exit 1
+fi
+echo "  sandbox Ready"
+openshell policy set --policy "$EXAMPLE_DIR/policy.yaml" --wait "$SANDBOX_NAME"
+# Prove the sandbox can actually execute the in-sandbox test tooling before
+# handing off to verify.sh (which relies on `sandbox exec` curl/python3).
+if openshell sandbox exec --name "$SANDBOX_NAME" -- python3 --version >/dev/null 2>&1; then
+  echo "  sandbox exec works (python3 present) -- ready for scripts/verify.sh"
+else
+  echo "  WARN: 'sandbox exec python3' failed; verify.sh stage 3 needs in-sandbox"
+  echo "  python3/curl. Check the image's binary allowlist and base tooling." >&2
+fi
+echo
+echo "bring-up complete. Next: scripts/verify.sh"

--- a/examples/recipes/partners/bluetier/x402-payment-gate/scripts/demo_verdicts.py
+++ b/examples/recipes/partners/bluetier/x402-payment-gate/scripts/demo_verdicts.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Live walkthrough of the Blackwall verdict gate: GO, HOLD, and STOP.
+
+Runs four payment scenarios against the free public Blackwall instance
+(override with BLACKWALL_URL) and checks each verdict against what the
+signals should produce:
+
+  1. Warm counterparty at its fair market price      -> GO    (sign)
+  2. Same counterparty quoted ~3.5x its median price  -> HOLD  (escalate)
+  3. Unknown counterparty (cold start)                -> HOLD  (escalate)
+  4. OFAC-sanctioned counterparty                     -> STOP  (refuse)
+
+The warm/sanctioned addresses come from Blackwall's committed seed corpus
+(public Base USDC history + the published OFAC list). If the corpus is
+refreshed and a scenario's expectation drifts, the script says which one
+and why rather than failing silently.
+
+The first request may take up to ~60s: the free instance spins down when
+idle and cold-starts on demand.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from blackwall_client import forecast_payment, should_sign
+
+# A payee from Blackwall's committed reputation seed (100+ settled x402
+# payments on Base, 0% disputes). Its recorded median price for this
+# resource class is ~0.014 USDC.
+WARM_PAYEE = "0x02c2fcafce36b4aadb39625866bc6b1699d83043"
+FAIR_PRICE = "0.014"
+GOUGED_PRICE = "0.05"
+
+# No on-chain history at all -> cold-start HOLD.
+UNKNOWN_PAYEE = "0x0000000000000000000000000000000000000001"
+
+# From the published OFAC SDN digital-currency list baked into the service.
+SANCTIONED_PAYEE = "0x0330070fd38ec3bb94f58fa55d40368271e9e54a"
+
+SCENARIOS = [
+    ("warm payee, fair price", WARM_PAYEE, FAIR_PRICE, "GO", "sign"),
+    ("warm payee, gouged price", WARM_PAYEE, GOUGED_PRICE, "HOLD", "escalate"),
+    ("unknown payee (cold start)", UNKNOWN_PAYEE, FAIR_PRICE, "HOLD", "escalate"),
+    ("sanctioned payee", SANCTIONED_PAYEE, FAIR_PRICE, "STOP", "refuse"),
+]
+
+
+def main() -> int:
+    failures = 0
+    for label, payee, amount, want_verdict, want_action in SCENARIOS:
+        verdict = forecast_payment(payee, amount)
+        got_verdict = verdict.get("verdict", "<error: %s>" % verdict.get("error"))
+        got_action = should_sign(verdict)
+        ok = got_verdict == want_verdict and got_action == want_action
+        print("%s  %-28s  %s %s -> %s (gate: %s)"
+              % ("PASS" if ok else "DRIFT", label, payee[:10] + "...",
+                 amount, got_verdict, got_action))
+        for reason in verdict.get("reasons", [])[:3]:
+            print("       - %s" % reason)
+        if not ok:
+            failures += 1
+            print("       expected %s (gate: %s) -- the seed corpus may have "
+                  "been refreshed since this demo was written; pick a fresh "
+                  "warm payee from the service's discovery endpoint or re-run "
+                  "later" % (want_verdict, want_action))
+        print()
+    if failures:
+        print("%d of %d scenarios drifted from their expected verdict."
+              % (failures, len(SCENARIOS)))
+        return 1
+    print("All %d scenarios matched their expected verdicts." % len(SCENARIOS))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/recipes/partners/bluetier/x402-payment-gate/scripts/tear-down.sh
+++ b/examples/recipes/partners/bluetier/x402-payment-gate/scripts/tear-down.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Tear down what bring-up.sh created: sandbox, then host services.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXAMPLE_DIR="$(dirname "$DIR")"
+RUN="$EXAMPLE_DIR/.run"
+SANDBOX_NAME="${SANDBOX_NAME:-x402-gate-demo}"
+
+if command -v openshell >/dev/null 2>&1; then
+  echo "Deleting sandbox $SANDBOX_NAME (if present)"
+  openshell sandbox delete "$SANDBOX_NAME" 2>/dev/null || true
+fi
+for svc in gate rail; do
+  if [ -f "$RUN/$svc.pid" ]; then
+    kill "$(cat "$RUN/$svc.pid")" 2>/dev/null || true
+    echo "stopped $svc"
+  fi
+done
+rm -rf "$RUN"
+echo "tear-down complete."

--- a/examples/recipes/partners/bluetier/x402-payment-gate/scripts/verify.sh
+++ b/examples/recipes/partners/bluetier/x402-payment-gate/scripts/verify.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify the maker/checker boundary with FRESH payment calls — every stage
+# initiates new payments during this run; nothing is inferred from old logs.
+#
+#   1. Unit tests — the gate's decision core (verdict mapping, the
+#      verdict-then-sign order invariant). Stdlib unittest, no network.
+#   2. Fresh mandatory-path canaries THROUGH the release gate (live verdict
+#      service; first call may cold-start ~60s):
+#        warm payee at fair price  -> released (fresh settlement on the rail)
+#        sanctioned payee          -> refused (never signed)
+#        unknown payee             -> held (a named human could approve)
+#      then asserts the mock-rail ledger grew by EXACTLY the released one.
+#   3. Denied edge — from INSIDE the sandbox (needs openshell): attempt the
+#      rail directly; the supervisor must refuse the route. Also submits a
+#      fresh in-sandbox intent via the host.openshell.internal route to prove
+#      the maker path works under policy.
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXAMPLE_DIR="$(dirname "$DIR")"
+# The gate's SUBMIT listener may be bound to the OpenShell bridge (not loopback)
+# so the sandbox can reach it; bring-up.sh records the host-reachable URL here.
+# Fall back to loopback for a standalone/host-only gate.
+GATE="$(cat "$EXAMPLE_DIR/.run/gate.url" 2>/dev/null || echo "http://127.0.0.1:8790")"
+RAIL="http://127.0.0.1:8780"
+WARM="0x02c2fcafce36b4aadb39625866bc6b1699d83043"
+SANCTIONED="0x0330070fd38ec3bb94f58fa55d40368271e9e54a"
+UNKNOWN="0x0000000000000000000000000000000000000001"
+# Same default as bring-up.sh / tear-down.sh, so the plain `bring-up ->
+# verify` flow exercises stage 3 automatically instead of silently skipping
+# it. Override to target a differently-named sandbox.
+SANDBOX_NAME="${SANDBOX_NAME:-x402-gate-demo}"
+FAIL=0
+SANDBOX_EDGE_TESTED=0   # set to 1 only when stage 3 actually runs
+
+submit() { # submit <counterparty> <amount> -> prints "status tx" (tx empty unless released)
+  curl -sS -m 120 -X POST "$GATE/v1/intents" -H 'Content-Type: application/json' \
+    -d "{\"counterparty\":\"$1\",\"amount\":\"$2\"}" \
+    | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("status","<error>"), d.get("detail",{}).get("settlement",{}).get("tx",""))'
+}
+ledger_has_tx() { # deterministic current-run assertion: THIS submission's tx is on the rail
+  curl -sS -m 5 "$RAIL/v1/ledger" | python3 -c "import json,sys; txs=[s['tx'] for s in json.load(sys.stdin)['settlements']]; sys.exit(0 if '$1' in txs else 1)"
+}
+ledger_count() {
+  curl -sS -m 5 "$RAIL/v1/ledger" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)["settlements"]))'
+}
+
+echo "== 1/3 unit tests (gate decision core) =="
+(cd "$EXAMPLE_DIR/host" && python3 -m unittest test_release_gate) || FAIL=1
+
+echo
+echo "== 2/3 fresh mandatory-path canaries (live) =="
+if ! curl -sS -m 3 "$GATE/healthz" >/dev/null 2>&1; then
+  echo "FAIL: release gate not running — scripts/bring-up.sh first"; exit 1
+fi
+BEFORE=$(ledger_count)
+R1=$(submit "$WARM" "0.014");  S1=${R1%% *}; TX1=${R1#* }
+echo "  warm payee, fair price -> $S1 tx=$TX1 (want released + fresh tx)"
+R2=$(submit "$SANCTIONED" "0.014"); S2=${R2%% *}
+echo "  sanctioned payee       -> $S2 (want refused)"
+R3=$(submit "$UNKNOWN" "0.014");    S3=${R3%% *}
+echo "  unknown payee          -> $S3 (want held)"
+AFTER=$(ledger_count)
+GREW=$((AFTER - BEFORE))
+echo "  rail ledger grew by $GREW settlement(s) (want exactly 1 — only the GO)"
+[ "$S1" = "released" ] && [ "$S2" = "refused" ] && [ "$S3" = "held" ] && [ "$GREW" = "1" ] \
+  || { echo "  FAIL: canary expectations not met"; FAIL=1; }
+# The deterministic, uniquely identifiable assertion: the settlement THIS RUN
+# just created (tx from the submission response, not from any log) is on the
+# rail ledger. Stale lines cannot satisfy this.
+if [ -n "$TX1" ] && ledger_has_tx "$TX1"; then
+  echo "  PASS: this run's settlement $TX1 is on the rail ledger"
+else
+  echo "  FAIL: this run's settlement tx not found on the rail ledger"; FAIL=1
+fi
+
+echo
+echo "== 3/3 in-sandbox maker path + denied edge (sandbox: $SANDBOX_NAME) =="
+if ! command -v openshell >/dev/null 2>&1; then
+  echo "NOT RUN: openshell CLI unavailable here — the sandbox maker/denied-edge"
+  echo "         boundary was NOT exercised. Run this on the host where"
+  echo "         bring-up.sh created the sandbox. Inside the sandbox, all three"
+  echo "         must hold:"
+  echo "           1. POST host.openshell.internal:8790/v1/intents -> a fresh verdict"
+  echo "           2. that intent id is retrievable via the gate on the host"
+  echo "           3. GET  host.openshell.internal:8780/healthz     -> DENIED by policy"
+elif ! openshell sandbox list 2>/dev/null | grep -qE "^\s*$SANDBOX_NAME\s"; then
+  echo "  FAIL: sandbox '$SANDBOX_NAME' not found — run scripts/bring-up.sh first"
+  echo "        (or set SANDBOX_NAME to your sandbox). The boundary was NOT tested."
+  FAIL=1
+else
+  SANDBOX_EDGE_TESTED=1
+  # 1. Fresh maker submission FROM INSIDE the sandbox, tagged uniquely to this
+  #    run so nothing stale can satisfy it. The agent's real path: submit an
+  #    intent over the scoped route and get back a current-run verdict.
+  TAG="verify-$$-$(od -An -N4 -tx1 /dev/urandom | tr -d ' ')"
+  SUBMIT=$(openshell sandbox exec --name "$SANDBOX_NAME" -- \
+    curl -sS -m 120 -X POST http://host.openshell.internal:8790/v1/intents \
+      -H 'Content-Type: application/json' \
+      -d "{\"counterparty\":\"$UNKNOWN\",\"amount\":\"0.014\",\"resource\":\"https://x/$TAG\"}" 2>/dev/null)
+  IID=$(printf '%s' "$SUBMIT" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("id",""))' 2>/dev/null)
+  ISTATUS=$(printf '%s' "$SUBMIT" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("status",""))' 2>/dev/null)
+  if [ -n "$IID" ] && [ "$ISTATUS" = "held" ]; then
+    echo "  PASS: fresh in-sandbox intent $IID -> $ISTATUS (maker path works under policy)"
+  else
+    echo "  FAIL: in-sandbox submission did not yield a fresh verdict (got: $ISTATUS)"; FAIL=1
+  fi
+  # 2. The verdict is real current-run state on the host gate, carrying THIS
+  #    run's unique tag (stale state cannot match).
+  if [ -n "$IID" ] && curl -sS -m 5 "$GATE/v1/intents/$IID" \
+       | python3 -c "import json,sys; d=json.load(sys.stdin); sys.exit(0 if d['intent'].get('resource','').endswith('$TAG') else 1)" 2>/dev/null; then
+    echo "  PASS: intent $IID is current-run state on the host gate (tag $TAG)"
+  else
+    echo "  FAIL: submitted intent not found as current-run state on the gate"; FAIL=1
+  fi
+  # 3. The denied edge: the rail must be refused from the sandbox, and we must
+  #    PROVE that refusal came from policy -- not from a flaky network. OpenShell
+  #    enforces egress at L7 (a supervisor proxy), so a denied route returns an
+  #    explicit HTTP 403 with a "policy_denied" body. We capture BOTH the status
+  #    and the body and require exactly that: a positive proof of enforcement.
+  #    Anything else -- the rail's actual reply (breach), OR a transport failure
+  #    (DNS error, timeout, connection refusal, proxy error, empty/malformed
+  #    output) -- FAILS, because none of those prove the policy did the refusing.
+  RAIL_OUT=$(openshell sandbox exec --name "$SANDBOX_NAME" -- \
+    curl -sS -m 10 -w '\n<<HTTP_STATUS:%{http_code}>>' \
+      http://host.openshell.internal:8780/healthz 2>&1 || true)
+  RAIL_CODE=$(printf '%s' "$RAIL_OUT" | grep -oE '<<HTTP_STATUS:[0-9]+>>' | grep -oE '[0-9]+' | tail -1)
+  RAIL_BODY=$(printf '%s' "$RAIL_OUT" | sed 's/<<HTTP_STATUS:[0-9]*>>//')
+  if printf '%s' "$RAIL_BODY" | grep -q "mock-rail"; then
+    echo "  FAIL: sandbox REACHED the rail — the denied edge is OPEN (HTTP ${RAIL_CODE:-?}: $RAIL_BODY)"; FAIL=1
+  elif [ "$RAIL_CODE" = "403" ] && printf '%s' "$RAIL_BODY" | grep -q "policy_denied"; then
+    echo "  PASS: rail route refused by policy (HTTP 403 policy_denied) — boundary held"
+  else
+    echo "  FAIL: denied edge NOT positively proven — expected HTTP 403 + policy_denied," >&2
+    echo "        got HTTP '${RAIL_CODE:-<none>}' body '${RAIL_BODY:-<empty / transport error>}'." >&2
+    echo "        A timeout, DNS failure, connection refusal, or proxy error is NOT proof" >&2
+    echo "        that OpenShell enforced the policy."; FAIL=1
+  fi
+fi
+
+echo
+if [ "$FAIL" -ne 0 ]; then
+  echo "verify: FAILURES above"
+  exit 1
+fi
+if [ "$SANDBOX_EDGE_TESTED" -eq 1 ]; then
+  echo "verify: OK (host boundary + in-sandbox maker/denied-edge exercised)"
+  exit 0
+fi
+# Stage 3 (the denied rail edge -- the central security property) was NOT
+# exercised. The DEFAULT full verification must fail in that case, so a skip
+# can never read as success to CI. A host-only run is an explicit opt-in with
+# a distinct result.
+if [ "${VERIFY_HOST_ONLY:-0}" = "1" ]; then
+  echo "verify: HOST-ONLY OK (explicit VERIFY_HOST_ONLY=1) — host boundary"
+  echo "        exercised; the in-sandbox maker/denied-edge was NOT tested."
+  exit 0
+fi
+echo "verify: FAIL — the in-sandbox maker path + denied rail edge (the central"
+echo "        security property) was NOT exercised (see stage 3). Run on the"
+echo "        host with openshell, or set VERIFY_HOST_ONLY=1 to accept a"
+echo "        host-only run explicitly."
+exit 1


### PR DESCRIPTION
## Related Issue

Companion to #52 (blackwall-guard) — same contributor, complementary scope. No issue to close.

## Description

Adds a partner recipe at `examples/recipes/partners/bluetier/x402-payment-gate/`: a maker/checker payment **boundary** for [x402](https://www.x402.org/) machine payments, in the pattern of `recipes/nvidia/payment-ops-hermes`. Before any x402 payment is signed, a host-side gate outside the sandbox asks a Blackwall verdict service to score the claim — counterparty reputation on Base, price-anomaly detection, OFAC sanctions screening, Sybil/graph signals — pre-signature.

- **Scope — a boundary demonstration, not a full agent runtime.** `bring-up.sh` stands up the boundary (rail + gate + policy-scoped sandbox); `verify.sh` exercises the in-sandbox maker path at the **intent-submission level** (`POST /v1/intents` over the scoped `host.openshell.internal` route → live verdict) plus the denied edge. It does **not** start an interactive Hermes agent — the skill under `agents/hermes/skills/` documents how a Hermes agent *would* drive this boundary; running that agent needs a full NemoClaw Relay+Hermes runtime and is a separate operator step.
- **Keyless, minimal data sharing.** Default endpoint is the free public instance; no API key exists anywhere. Only the payment claim (`counterparty, amount, asset, chain, resource`) leaves the sandbox — never tool payloads, never keys.
- **Maker/checker boundary.** The sandboxed agent (MAKER) can only submit intents; a host-side release gate (CHECKER) runs the mandatory verdict and is the only thing that signs and settles. The rail has **no** sandbox route — that denied edge is the boundary. No plugin ships here; the OpenClaw plugin lives in the Blackwall repo, contributed separately in #52.
- **Two authorization paths.** Automated release settles only on a fresh **GO**; human-approved release is a separate path for a HELD intent (named human + a host-only approval token on `127.0.0.1:8791`) that re-screens with a fresh verdict and still refuses a fresh **STOP**. Both decide before any signature exists; STOP is terminal on both.
- **Split listeners, discovered bind.** The sandbox reaches the host over the OpenShell bridge (`host.openshell.internal` → the `openshell-docker` gateway), not loopback, so `bring-up.sh` **discovers that bridge interface and binds the submit listener there** — reachable by the sandbox and the host, not the LAN, never `0.0.0.0`. Rail and approve stay on loopback.
- **Complete lifecycle.** `scripts/bring-up.sh` (`openshell sandbox create --from <recipe-root>` — the Dockerfile lives at the recipe root so its build context matches its `COPY` paths, `.dockerignore` trims it — and **always rebuilds the sandbox from the current checkout**, never reusing a stale one), `scripts/verify.sh` (live canaries + the in-sandbox denied-edge test, which **positively requires HTTP `403 policy_denied`** and fails on transport errors), `scripts/tear-down.sh`.
- **Enforcement architecture.** The mandatory decision runs in the host-side release gate (the `payment-ops-hermes` pattern). Wiring the same verdict into OpenShell Supervisor middleware is the ideal fail-closed tightening and the documented next step — offered for explicit maintainer agreement, not silently substituted.
- Single verified commit on current `main`, registered in the Partner Recipes catalog table. Note: #52 also adds a BlueTier row to that table — whichever PR lands second needs a one-line rebase there.

## Verification

- [x] `python3 scripts/check_license_headers.py --check`
- [ ] `python3 scripts/check_label_taxonomy.py --check` when governance metadata changes (n/a — no governance metadata changed)
- [x] `git diff --check`
- [x] Relevant example setup or syntax checks (`bash -n` on all lifecycle scripts; host unit suite 27/27; **validated end to end on a live OpenShell + Docker host** — bring-up → verify → tear-down, the in-sandbox maker path returns a fresh verdict and the rail is refused as HTTP 403 `policy_denied`)

## Release And Compliance

- [x] No secrets, local `.env` files, private certificates, snapshots, or token caches are included.
- [x] Third-party dependency changes are reflected in `THIRD-PARTY-NOTICES` (none added — stdlib Python only).
- [x] Public documentation is free of internal-only links or private workspace details.
- [x] I added my DCO sign-off declaration to this pull request description.

Signed-off-by: Samuel Trujillo <bluetier.operations@gmail.com>

---
_Generated by [Claude Code](https://claude.ai/code)_