### PR TITLE
fix(recipe): harden enterprise preflights

### DIFF
--- a/examples/recipes/nvidia/developer-community-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/README.md
@@ -470,8 +470,9 @@ sandbox, e.g. `find /tmp/atif -type f -mtime +7 -delete`.
 - **(Optional)** If your network performs TLS interception (e.g. an
   SSL-inspecting proxy), place the inspection CA certificate(s) as `.crt`
   files in the example-root `certs/` directory before running `bring-up.sh`.
-  Otherwise leave it empty. See [`certs/README.md`](certs/README.md) for
-  details.
+  Additional roots installed in the host's standard local CA directory are
+  staged automatically. Otherwise leave the directory empty. See
+  [`certs/README.md`](certs/README.md) for details.
 
 ## Providers created by `bring-up.sh`
 
@@ -559,7 +560,7 @@ unless you remove the compose volumes.
 | `OPENSHELL_GATEWAY` | `openshell` | Gateway name. The default matches the package-managed OpenShell installer. Use `snap-docker` when following the snap setup. |
 | `OPENSHELL_GATEWAY_ENDPOINT` | auto (`https://127.0.0.1:17670` for `openshell`, `http://127.0.0.1:17670` for `snap-docker`) | Override the local gateway endpoint if you registered it under a different URL. |
 | `NEMOCLAW_MODEL` | `nvidia/nemotron-3-super-120b-a12b` | Inference model passed to `openshell inference set`. |
-| `NEMOCLAW_INFERENCE_PREFLIGHT` | `1` | Requires one bounded structured tool call before sandbox creation, then verifies that OpenShell activated the requested provider and model. Remote endpoints must use HTTPS; loopback HTTP is allowed for local proxies. Standard proxy and CA environment variables are preserved. Set to `0` only for intentional offline setup or an endpoint that cannot support verification. |
+| `NEMOCLAW_INFERENCE_PREFLIGHT` | `1` | Requires one bounded structured tool call before sandbox creation, then verifies that OpenShell activated the requested provider and model. Remote endpoints must use HTTPS. For `http://host.openshell.internal:<port>`, the host-side check safely uses the same listener through `127.0.0.1:<port>`. Non-empty proxy and CA environment variables are preserved; unset CA overrides remain unset so the platform trust store still works. Set to `0` only for intentional offline setup or an endpoint that cannot support verification. |
 | `NEMOCLAW_INFERENCE_PREFLIGHT_TIMEOUT_SECONDS` | `10` | Maximum time allowed for the preflight request. |
 | `NEMOCLAW_SLACK_RICH_BLOCKS` | `true` | Render supported semantic Markdown with Hermes's native Slack Block Kit renderer, including table blocks. Set to `false` for text-only output. Interactive clarification buttons remain available. Only `true` or `false` is accepted. Rebuild the sandbox after changing it. |
 | `NEMOCLAW_ENDPOINT_URL` | `https://integrate.api.nvidia.com/v1` | Upstream base URL for the `compatible-endpoint` provider. (`OPENAI_BASE_URL` is also accepted as a fallback.) |

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/certs/README.md
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/certs/README.md
@@ -35,3 +35,15 @@ succeeds as-is.
 The Dockerfile copies everything in this directory into
 `/usr/local/share/ca-certificates/` and runs `update-ca-certificates` to
 register the new trust roots.
+
+### Locally installed enterprise CAs
+
+On Linux hosts, `scripts/03-sandbox.sh` automatically stages readable `*.crt`
+files from `/usr/local/share/ca-certificates/`. This directory conventionally
+contains operator-installed roots rather than distribution-managed roots.
+Override the source with `NEMOCLAW_ENTERPRISE_CA_SOURCE_DIR` when additional
+roots are kept in another dedicated directory.
+
+The copied files remain ignored by Git through the repository-wide `*.crt`
+rule. Other environments can continue to place their public CA certificates in
+this directory before bring-up.

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/docs/host-tls-proxy.md
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/docs/host-tls-proxy.md
@@ -85,6 +85,12 @@ NEMOCLAW_ENDPOINT_URL=http://host.openshell.internal:18080/v1
 
 `host.openshell.internal` is the stable host-routed address OpenShell exposes inside Docker-backed sandboxes for package-managed and snap-managed gateways.
 
+Provider setup runs its inference preflight on the host before sandbox
+creation. For this special URL, the preflight translates only the hostname to
+`127.0.0.1` and checks the same proxy listener and request path. The provider
+configuration remains `host.openshell.internal`, so the created sandbox uses
+the correct host-routed address.
+
 `COMPATIBLE_API_KEY` (or `OPENAI_API_KEY`) stays unchanged — the proxy passes the `Authorization` header straight through.
 
 ## Smoke test

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/02-providers.sh
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/02-providers.sh
@@ -70,21 +70,23 @@ for profile_file in outlook-email.yaml slack.yaml github.yaml atif-export-relay.
 done
 
 # Keep preflight subprocesses isolated from unrelated host state while
-# preserving the standard proxy and CA settings needed on enterprise networks.
+# preserving non-empty proxy and CA settings needed on enterprise networks.
+# Do not define an unset OpenSSL override as an empty string: under `env -i`,
+# SSL_CERT_FILE= or SSL_CERT_DIR= suppresses the platform's default trust-store
+# discovery and makes every TLS endpoint appear untrusted.
 PREFLIGHT_NETWORK_ENV=(
   "HOME=$HOME"
   "PATH=$PATH"
-  "HTTP_PROXY=${HTTP_PROXY:-}"
-  "HTTPS_PROXY=${HTTPS_PROXY:-}"
-  "ALL_PROXY=${ALL_PROXY:-}"
-  "NO_PROXY=${NO_PROXY:-}"
-  "http_proxy=${http_proxy:-}"
-  "https_proxy=${https_proxy:-}"
-  "all_proxy=${all_proxy:-}"
-  "no_proxy=${no_proxy:-}"
-  "SSL_CERT_FILE=${SSL_CERT_FILE:-}"
-  "SSL_CERT_DIR=${SSL_CERT_DIR:-}"
 )
+for preflight_env_name in \
+  HTTP_PROXY HTTPS_PROXY ALL_PROXY NO_PROXY \
+  http_proxy https_proxy all_proxy no_proxy \
+  SSL_CERT_FILE SSL_CERT_DIR CURL_CA_BUNDLE REQUESTS_CA_BUNDLE; do
+  if [[ -n "${!preflight_env_name:-}" ]]; then
+    PREFLIGHT_NETWORK_ENV+=("$preflight_env_name=${!preflight_env_name}")
+  fi
+done
+unset preflight_env_name
 
 # ── Inference provider (built-in nvidia v2 profile via inference.local) ─
 INFERENCE_KEY="${OPENAI_API_KEY:-${COMPATIBLE_API_KEY:-}}"

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/03-sandbox.sh
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/03-sandbox.sh
@@ -70,6 +70,10 @@ case "$NEMOCLAW_SLACK_RICH_BLOCKS" in
 esac
 echo "Slack rich blocks: $NEMOCLAW_SLACK_RICH_BLOCKS"
 
+# Stage locally installed TLS-inspection roots into the ignored certs/ build
+# input before Docker runs so enterprise builds do not fail on HTTPS downloads.
+bash "$DIR/stage-enterprise-cas.sh"
+
 # ── Stage the Dockerfile and patch ARG defaults ────────────────────────
 # Build args go through sed substitution because `openshell sandbox create
 # --from <Dockerfile>` doesn't expose --build-arg passthrough. Values must

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/inference_preflight.py
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/inference_preflight.py
@@ -24,6 +24,7 @@ KEY_ENV = "NEMOCLAW_INFERENCE_PREFLIGHT_KEY"
 TOOL_NAME = "nemoclaw_preflight"
 TOOL_ARGUMENTS = {"value": "ready"}
 TOOL_MARKERS = ("<|call|>", "<|tool_call|>", "<tool_call>", "</tool_call>")
+SANDBOX_HOST_ALIAS = "host.openshell.internal"
 ANSI_ESCAPE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 
 
@@ -46,6 +47,27 @@ def is_loopback_host(hostname: str | None) -> bool:
         return ipaddress.ip_address(hostname).is_loopback
     except ValueError:
         return False
+
+
+def endpoint_for_host_preflight(endpoint: str) -> str:
+    """Translate the sandbox-only host alias to the host's loopback address.
+
+    The host TLS proxy listens on the host and is configured inside the sandbox
+    as ``http://host.openshell.internal:<port>``. That name intentionally does
+    not resolve on the host, where this preflight runs. Using loopback here
+    exercises the same proxy listener without weakening the HTTP safety rule for
+    arbitrary remote hosts.
+    """
+
+    parsed = urllib.parse.urlsplit(endpoint)
+    if parsed.scheme != "http" or parsed.hostname != SANDBOX_HOST_ALIAS:
+        return endpoint
+    if parsed.username or parsed.password:
+        raise PreflightError("endpoint", "endpoint must not contain user info", 3)
+    port = f":{parsed.port}" if parsed.port else ""
+    return urllib.parse.urlunsplit(
+        (parsed.scheme, f"127.0.0.1{port}", parsed.path, parsed.query, parsed.fragment)
+    )
 
 
 def completion_url(endpoint: str) -> str:
@@ -230,6 +252,7 @@ def run_preflight(endpoint: str, model: str, key: str, timeout: float) -> None:
     if timeout <= 0:
         raise PreflightError("configuration", "timeout must be greater than zero", 2)
 
+    endpoint = endpoint_for_host_preflight(endpoint)
     payload = json.dumps(
         {
             "model": model,

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/stage-enterprise-cas.sh
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/stage-enterprise-cas.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Stage locally installed TLS-inspection roots into the sandbox build context.
+# The destination is covered by the repository-wide *.crt ignore rule. The
+# standard local CA directory is separate from distribution-managed roots, so
+# only operator-installed certificates are copied by default.
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXAMPLE_DIR="$(dirname "$DIR")"
+SOURCE_DIR="${NEMOCLAW_ENTERPRISE_CA_SOURCE_DIR:-/usr/local/share/ca-certificates}"
+DEST_DIR="${NEMOCLAW_ENTERPRISE_CA_DEST_DIR:-$EXAMPLE_DIR/certs}"
+
+[[ -d "$SOURCE_DIR" ]] || exit 0
+shopt -s nullglob
+certificate_paths=("$SOURCE_DIR"/*.crt)
+shopt -u nullglob
+
+staged=0
+for source_path in "${certificate_paths[@]}"; do
+  [[ -f "$source_path" && -r "$source_path" ]] || continue
+  certificate_name="$(basename "$source_path")"
+
+  mkdir -p "$DEST_DIR"
+  destination_path="$DEST_DIR/$certificate_name"
+  if [[ -f "$destination_path" ]] && cmp -s "$source_path" "$destination_path"; then
+    continue
+  fi
+
+  temporary_path="$destination_path.tmp.$$"
+  trap 'rm -f "${temporary_path:-}"' EXIT
+  cp "$source_path" "$temporary_path"
+  chmod 0644 "$temporary_path"
+  mv "$temporary_path" "$destination_path"
+  trap - EXIT
+  echo "Staged enterprise CA: $certificate_name"
+  staged=$((staged + 1))
+done
+
+if (( staged > 0 )); then
+  echo "Enterprise CA staging complete ($staged updated)."
+fi

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/tests/test-enterprise-ca-staging.sh
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/tests/test-enterprise-ca-staging.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STAGER="$SCRIPT_DIR/../stage-enterprise-cas.sh"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+SOURCE_DIR="$TEST_ROOT/source"
+DEST_DIR="$TEST_ROOT/destination"
+mkdir -p "$SOURCE_DIR"
+
+printf '%s\n' root >"$SOURCE_DIR/company-root.crt"
+printf '%s\n' trust >"$SOURCE_DIR/company-trust.crt"
+printf '%s\n' ignored >"$SOURCE_DIR/unrelated.pem"
+
+output="$(
+  NEMOCLAW_ENTERPRISE_CA_SOURCE_DIR="$SOURCE_DIR" \
+  NEMOCLAW_ENTERPRISE_CA_DEST_DIR="$DEST_DIR" \
+    bash "$STAGER"
+)"
+
+[[ "$output" == *"Enterprise CA staging complete (2 updated)."* ]] \
+  || fail "expected two enterprise certificates to be staged"
+cmp -s "$SOURCE_DIR/company-root.crt" \
+  "$DEST_DIR/company-root.crt" \
+  || fail "root certificate content changed during staging"
+cmp -s "$SOURCE_DIR/company-trust.crt" \
+  "$DEST_DIR/company-trust.crt" \
+  || fail "trust certificate content changed during staging"
+[[ ! -e "$DEST_DIR/unrelated.pem" ]] \
+  || fail "unrelated certificate was staged"
+permissions="$(stat -c '%a' "$DEST_DIR/company-root.crt" 2>/dev/null \
+  || stat -f '%Lp' "$DEST_DIR/company-root.crt")"
+[[ "$permissions" == "644" ]] \
+  || fail "staged certificate permissions are not 0644"
+
+second_output="$(
+  NEMOCLAW_ENTERPRISE_CA_SOURCE_DIR="$SOURCE_DIR" \
+  NEMOCLAW_ENTERPRISE_CA_DEST_DIR="$DEST_DIR" \
+    bash "$STAGER"
+)"
+[[ -z "$second_output" ]] || fail "unchanged certificates were staged again"
+
+printf 'PASS: enterprise CA staging\n'

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/tests/test_inference_preflight.py
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/tests/test_inference_preflight.py
@@ -124,6 +124,39 @@ class InferencePreflightTest(TestCase):
             "http://127.0.0.1:18080/v1/chat/completions",
         )
 
+    def test_sandbox_host_alias_uses_host_loopback_for_preflight(self) -> None:
+        response = MagicMock()
+        response.status = 200
+        response.read.return_value = tool_response_body()
+        response.__enter__.return_value = response
+        with patch.object(
+            PREFLIGHT.urllib.request, "urlopen", return_value=response
+        ) as open_:
+            PREFLIGHT.run_preflight(
+                "http://host.openshell.internal:18080/v1?mode=test",
+                "nvidia/test-model",
+                "secret",
+                4,
+            )
+
+        self.assertEqual(
+            open_.call_args.args[0].full_url,
+            "http://127.0.0.1:18080/v1/chat/completions?mode=test",
+        )
+
+    def test_similar_remote_hostname_is_not_treated_as_host_alias(self) -> None:
+        with patch.object(PREFLIGHT.urllib.request, "urlopen") as open_:
+            with self.assertRaisesRegex(
+                PREFLIGHT.PreflightError, "remote inference endpoints must use HTTPS"
+            ):
+                PREFLIGHT.run_preflight(
+                    "http://host.openshell.internal.example.test:18080/v1",
+                    "nvidia/test-model",
+                    "secret",
+                    4,
+                )
+        open_.assert_not_called()
+
     def test_missing_credential_is_configuration_failure(self) -> None:
         with self.assertRaisesRegex(
             PREFLIGHT.PreflightError, "credential is missing"
@@ -505,3 +538,67 @@ exit 0
                 "http://proxy.example.test:8080|127.0.0.1,localhost|"
                 "/etc/example/ca.pem|/etc/example/certs",
             )
+
+    def test_preflights_leave_unset_ca_overrides_unset(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fake_openshell = Path(temp_dir) / "openshell"
+            network_log = Path(temp_dir) / "network-env.log"
+            fake_python = Path(temp_dir) / "python3"
+            fake_openshell.write_text(
+                """#!/usr/bin/env bash
+if [[ "$1 $2" == "settings get" ]]; then
+  echo "providers_v2_enabled = true"
+  exit 0
+fi
+if [[ "$1 $2" == "provider get" ]]; then
+  exit 1
+fi
+if [[ "$1 $2" == "inference get" ]]; then
+  printf 'Inference:\n\n  Provider: compatible-endpoint\n  Model: nvidia/test-model\n'
+  exit 0
+fi
+exit 0
+""",
+                encoding="utf-8",
+            )
+            fake_python.write_text(
+                f"""#!/usr/bin/env bash
+if [[ "$1" == *"inference_preflight.py" ]]; then
+  printf '%s|%s\n' "${{SSL_CERT_FILE+x}}" "${{SSL_CERT_DIR+x}}" > "{network_log!s}"
+fi
+exit 0
+""",
+                encoding="utf-8",
+            )
+            fake_openshell.chmod(0o755)
+            fake_python.chmod(0o755)
+            environment = {
+                **os.environ,
+                "PATH": f"{temp_dir}:{os.environ['PATH']}",
+                "COMPATIBLE_API_KEY": "test-inference-key",
+                "NEMOCLAW_MODEL": "nvidia/test-model",
+                "NEMOCLAW_INFERENCE_PREFLIGHT": "1",
+                "NEMOCLAW_ENDPOINT_URL": "https://example.test/v1",
+                "SLACK_BOT_TOKEN": "test-bot-token",
+                "SLACK_APP_TOKEN": "xapp-test-app-token",
+                "ATIF_EXPORT_MODE": "local",
+            }
+            for name in (
+                "OPENAI_API_KEY",
+                "SSL_CERT_FILE",
+                "SSL_CERT_DIR",
+                "CURL_CA_BUNDLE",
+                "REQUESTS_CA_BUNDLE",
+            ):
+                environment.pop(name, None)
+
+            result = subprocess.run(
+                ["bash", str(PROVIDERS_SCRIPT)],
+                env=environment,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(network_log.read_text(encoding="utf-8").strip(), "|")


### PR DESCRIPTION
## Summary

- preserve the platform trust store when proxy or CA overrides are unset
- stage locally installed enterprise roots into the ignored sandbox build input
- run host-side inference checks for `host.openshell.internal` through the same listener on loopback
- document enterprise CA staging and host TLS proxy behavior

## Why

Enterprise setup could report false Slack TLS failures because isolated preflight processes received empty OpenSSL override variables. The inference preflight also rejected the sandbox-only host alias before it could test the host TLS proxy. Users then had to discover and copy locally installed inspection roots manually.

## Validation

- `python3 -m unittest discover -s examples/recipes/nvidia/developer-community-chief-of-staff/scripts/tests -p 'test_*.py'` (52 tests)
- `bash examples/recipes/nvidia/developer-community-chief-of-staff/scripts/tests/test-enterprise-ca-staging.sh`
- `bash examples/recipes/nvidia/developer-community-chief-of-staff/scripts/tests/test-host-ca-bundle.sh`
- shell syntax checks for the changed scripts
- SPDX license-header and maintainer-taxonomy checks

Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>
