### PR TITLE
fix(hermes): use prebuilt TUI in sandbox shells

### DIFF
--- a/examples/recipes/nvidia/developer-community-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/README.md
@@ -346,6 +346,17 @@ a fresh login with `OUTLOOK_LOGIN_CACHE=2 bash scripts/bring-up.sh`. Set
 `OUTLOOK_LOGIN_CACHE=0` to skip the cache entirely and do device-code on every
 bring-up — see [docs/set-up-outlook-bridge.md](docs/set-up-outlook-bridge.md#security-note-where-the-refresh-token-lives).
 
+To use Hermes interactively after bring-up, connect to the sandbox and start a
+new TUI session:
+
+```console
+$ openshell sandbox connect hermes-direct
+$ hermes chat --tui
+```
+
+Use `hermes chat --tui --continue` only after a TUI session exists. The image
+contains the TUI bundle and does not need an `npm install` at runtime.
+
 The image always installs NeMo-Relay so the agent writes ATIF traces to `/tmp/atif/`
 regardless of Phoenix config. If `PHOENIX_COLLECTOR_ENDPOINT` is set, `03-sandbox.sh`
 additionally bakes the endpoint into the image so OpenInference traces stream into

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/Dockerfile
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/Dockerfile
@@ -54,6 +54,12 @@ RUN --mount=type=secret,id=github_token,required=false \
 # ── Main sandbox image ────────────────────────────────────────────────────────
 FROM ${BASE_IMAGE}
 
+# The sandbox cannot install npm dependencies at runtime under the enforced
+# OpenShell policy. Keep the prebuilt Hermes TUI bundle as an explicit base
+# image contract so `hermes chat --tui` fails at build time, not on first use,
+# if a future base-image update drops it.
+RUN test -s /opt/hermes/ui-tui/dist/entry.js
+
 # NeMo-Relay Phoenix OTLP endpoint — baked at image build time so start.sh
 # reads it directly from the container ENV without relying on runtime injection.
 # Empty string means no telemetry (standard behavior).
@@ -220,13 +226,14 @@ RUN mkdir -p /etc/nemo-relay \
 # transport when a proxy is present. The OpenShell L7 proxy owns credential
 # placeholder rewriting and hostname-based policy enforcement.
 #
-# Only HERMES_HOME and HERMES_DISABLE_LAZY_INSTALLS reliably reach
-# user processes — OpenShell's exec-session allowlist strips most other
-# HERMES_* vars. PID-1 (start.sh-launched gateway) keeps everything;
-# HERMES_DISABLE_LAZY_INSTALLS is also re-exported from start.sh's
-# _PROXY_ENV_FILE so interactive shells get it.
+# Only HERMES_HOME and HERMES_DISABLE_LAZY_INSTALLS reliably reach user
+# processes — OpenShell's exec-session allowlist strips most other HERMES_*
+# vars. PID-1 (start.sh-launched gateway) keeps everything; start.sh also
+# re-exports HERMES_DISABLE_LAZY_INSTALLS and HERMES_TUI_DIR from its
+# _PROXY_ENV_FILE so interactive shells use the prebuilt bundle.
 ENV HERMES_TELEGRAM_DISABLE_FALLBACK_IPS=1 \
     HERMES_DISABLE_LAZY_INSTALLS=1 \
+    HERMES_TUI_DIR=/opt/hermes/ui-tui \
     HERMES_HOME=/sandbox/.hermes-data
 
 # Copy NemoClaw plugin for Hermes (Python-based)

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/start.sh
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/start.sh
@@ -488,6 +488,14 @@ export PATH="/usr/local/lib/nemoclaw/bin:\$PATH"
 export HERMES_TUI_THEME=dark
 export HERMES_DISABLE_LAZY_INSTALLS=1
 PROXYEOF
+  # OpenShell strips most HERMES_* variables from interactive exec sessions.
+  # Re-export the trusted prebuilt bundle only when its build-time contract is
+  # still present. This keeps `hermes chat --tui` off the runtime npm path.
+  cat <<'TUIENVEOF'
+if [ -s /opt/hermes/ui-tui/dist/entry.js ]; then
+  export HERMES_TUI_DIR="/opt/hermes/ui-tui"
+fi
+TUIENVEOF
   for _ca_env_name in SSL_CERT_FILE CURL_CA_BUNDLE REQUESTS_CA_BUNDLE GIT_SSL_CAINFO; do
     _ca_env_value="${!_ca_env_name:-}"
     if [ -n "$_ca_env_value" ]; then

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/tests/test_tui_runtime_contract.py
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/tests/test_tui_runtime_contract.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import TestCase
+
+HERMES_DIR = Path(__file__).parents[1]
+DOCKERFILE = (HERMES_DIR / "Dockerfile").read_text(encoding="utf-8")
+START_SCRIPT = (HERMES_DIR / "start.sh").read_text(encoding="utf-8")
+TUI_ENTRY = "/opt/hermes/ui-tui/dist/entry.js"
+TUI_DIR = "/opt/hermes/ui-tui"
+
+
+class HermesTuiRuntimeContractTest(TestCase):
+    def test_image_requires_the_prebuilt_tui_bundle(self) -> None:
+        self.assertIn(f"RUN test -s {TUI_ENTRY}", DOCKERFILE)
+        self.assertIn(f"HERMES_TUI_DIR={TUI_DIR}", DOCKERFILE)
+
+    def test_interactive_shell_uses_the_prebuilt_tui_bundle(self) -> None:
+        self.assertIn(f"if [ -s {TUI_ENTRY} ]; then", START_SCRIPT)
+        self.assertIn(f'export HERMES_TUI_DIR="{TUI_DIR}"', START_SCRIPT)
+        self.assertIn("export HERMES_DISABLE_LAZY_INSTALLS=1", START_SCRIPT)


### PR DESCRIPTION
## Summary

- require the pinned Hermes base image to contain its prebuilt TUI bundle
- re-export `HERMES_TUI_DIR` into interactive OpenShell sessions
- keep lazy installs disabled so the TUI never needs runtime npm access
- document new-session and continue-session commands

## Why

The pinned base image already contains `/opt/hermes/ui-tui/dist/entry.js`, but OpenShell's interactive exec environment strips most `HERMES_*` variables. Without `HERMES_TUI_DIR`, `hermes chat --tui` falls back to a runtime `npm install`, which the enforced sandbox network policy correctly blocks.

## Validation

- all 30 Hermes recipe unit tests
- shell syntax validation for `agents/hermes/start.sh`
- SPDX license-header and maintainer-taxonomy checks
- pinned-image check confirming the prebuilt bundle and `HERMES_TUI_DIR`
- `hermes chat --tui --help` smoke test against the pinned base image

Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>
