### PR TITLE
docs: add public writing safeguards

### DIFF
--- a/.agents/skills/_shared/controlled-words.md
+++ b/.agents/skills/_shared/controlled-words.md
@@ -1,0 +1,70 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# NemoClaw Community Controlled Words
+
+Use these terms in changed explanatory text. This list improves consistency; it
+does not detect every secret, credential, or nonpublic identifier. Review all
+content before publication.
+
+Keep literal commands, code identifiers, API fields, quoted output, and official
+third-party names exact. Add a short explanation when a literal term is not
+clear to a public reader.
+
+Apply the list to changed text. Put unrelated terminology cleanup in a focused
+follow-up pull request.
+
+| Use | Avoid or clarify | Guidance |
+| --- | --- | --- |
+| NemoClaw | Nemoclaw, Nemo Claw | Use the official product name. |
+| NemoClaw Community | community NemoClaw, community repo | Use for this project or repository. |
+| OpenShell | Openshell, Open Shell | Use the official product name. |
+| example | demo, sample | Use for an independently deployable contribution. Use `demo` only when demonstration is the explicit purpose. |
+| recipe | workflow, example | Use for content under `examples/recipes/`. Do not use it as a synonym for every example. |
+| contributor | developer, submitter | Use for a person who contributes a change. Use a more specific role when necessary. |
+| maintainer | owner, administrator | Use for a project maintainer. Use `administrator` only for a system permission. |
+| pull request | PR on first use | Write `pull request (PR)` before using `PR` in longer text. |
+| repository | repo | Prefer `repository` in explanatory text. Literal names and commands can use `repo`. |
+| setup | set up | Use `setup` as a noun or adjective. Use `set up` as a verb. |
+| cleanup | clean up | Use `cleanup` as a noun or adjective. Use `clean up` as a verb. |
+| sign in | log in, login | Use `sign in` as a verb. Preserve literal command and interface labels. |
+| environment variable | env var | Use the full term on first use. |
+| API key | token, credential | Use the precise credential type. Do not publish its value. |
+| access token | API key, credential | Use the precise credential type. Do not publish its value. |
+| secret | credential | Use `secret` for a value that must remain confidential. Use `credential` for authentication material. |
+| certificate authority (CA) | certificate provider | Define `CA` on first use. |
+| CA certificate | CA cert | Prefer the full term in explanatory text. |
+| sandbox | container, virtual machine | Use the runtime's documented boundary. These terms are not interchangeable. |
+| policy | configuration | Use `policy` for enforced permissions or restrictions. |
+| allowlist | whitelist | Use inclusive terminology. |
+| blocklist | blacklist | Use inclusive terminology. |
+| primary | master | Use `primary` for a general role. Preserve the literal Git branch name. |
+
+## Public Replacements
+
+Do not add actual internal terms to this public list. Replace nonpublic details
+with the most accurate generic term:
+
+| Use | For |
+| --- | --- |
+| enterprise environment | A nonpublic development or deployment environment. |
+| private service | A service that public contributors cannot access. |
+| private endpoint | A nonpublic URL or hostname. |
+| private certificate authority | A certificate authority that is not publicly available. |
+| internal tracking system | A nonpublic issue or work-tracking system. |
+| maintainer team | A nonpublic team or distribution-list name. |
+
+Do not preserve the original nonpublic name in parentheses, examples, test data,
+commit messages, or review comments.
+
+## Maintain the List
+
+Add an entry when it resolves recurring ambiguity, separates concepts whose
+difference affects behavior, or preserves an official public name. Confirm the
+term against current code, commands, tests, and public documentation.
+
+Do not add every acceptable English word. Do not use this list to rename a
+command, identifier, schema field, user-interface label, or third-party product.
+Such a rename requires a separate interface decision.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,11 +19,36 @@ Describe what changed and why.
 - [ ] `git diff --check`
 - [ ] Relevant example setup or syntax checks
 
+## Documentation Writer Review
+
+<!--
+Required for code and documentation changes after implementation and applicable
+validation are complete. Record changed documentation paths as evidence. For
+`no-docs-needed`, explain why users are not affected. A blocked result is not
+ready to merge.
+-->
+- [ ] Documentation writer review completed for the final changes
+- Result: `docs-updated` | `no-docs-needed` | `blocked`
+- Evidence or justification:
+- Reviewer:
+- [ ] Changed user-facing text follows the
+  [writing guide](https://github.com/NVIDIA/nemoclaw-community/blob/main/WRITING.md)
+  and
+  [controlled-word list](https://github.com/NVIDIA/nemoclaw-community/blob/main/.agents/skills/_shared/controlled-words.md).
+- [ ] A public contributor can understand the changed text without internal
+  company context.
+- [ ] I reviewed any agent-generated text before submission.
+
 ## Release And Compliance
 
-- [ ] No secrets, local `.env` files, private certificates, snapshots, or token caches are included.
+- [ ] No secrets or credentials are included, including API keys, access tokens,
+  passwords, local `.env` files, private certificates, or token caches.
+- [ ] No nonpublic project names, environment names, hostnames, URLs, ticket
+  identifiers, workspace paths, logs, screenshots, or configuration values are
+  included.
 - [ ] Third-party dependency changes are reflected in `THIRD-PARTY-NOTICES`.
-- [ ] Public documentation is free of internal-only links or private workspace details.
+- [ ] Public content uses sanitized examples and placeholders instead of private
+  values.
 - [ ] I added my DCO sign-off declaration to this pull request description.
 
 <!-- Replace the example values and add an uncommented line in this format: Signed-off-by: Your Name <your.email@example.com> -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Use one of these methods to contribute:
 - Contribute a new example.
 - Report a reproducible problem.
 
-For a problem report, identify the example. Give the environment details.
+For a problem report, identify the example. Give sanitized environment details.
 
 Select an example from the [example catalog](examples/README.md). Read the
 example's README. Follow all linked setup and check instructions.
@@ -144,6 +144,38 @@ Apply these requirements to all pull requests:
   caches, generated snapshots, generated runtime state, or private workspace
   details.
 - Do not add internal-only links to public documentation.
+
+## Write for a Public Repository
+
+Write all repository content for a public audience. This rule applies to issues,
+pull requests, review comments, commit messages, code comments, documentation,
+tests, logs, generated artifacts, and uploaded files.
+
+Follow [WRITING.md](WRITING.md) for plain-language guidance. Use the approved
+terms in the
+[controlled-word list](.agents/skills/_shared/controlled-words.md). These rules
+apply to content written by people and coding agents.
+
+Before you publish content, remove or replace all nonpublic information,
+including:
+
+- Internal project, environment, profile, host, service, team, or distribution
+  list names.
+- Private URLs, repository paths, ticket identifiers, and workspace paths.
+- Screenshots, logs, configuration values, or commands that expose nonpublic
+  information.
+- Company-specific shorthand that a public contributor cannot understand.
+
+Use a public, generic description when the exact internal name is not required.
+For example, use `enterprise environment`, `private certificate authority`, or
+`internal tracking system` as appropriate. Do not publish the original value in
+an example, quotation, test fixture, commit history, or pull request discussion.
+
+If public text cannot describe the change safely, coordinate privately with a
+maintainer before submission. Coding agents must inspect their proposed output
+against these rules before they post or commit it. A human contributor remains
+responsible for reviewing agent-generated content before merge. Automated
+checks and controlled words do not replace these reviews.
 
 Use these rules during checks:
 

--- a/WRITING.md
+++ b/WRITING.md
@@ -1,0 +1,105 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# NemoClaw Community Writing Guide
+
+Use this guide for clear, consistent, public communication. It uses the
+plain-language principles in
+[ASD-STE100 Issue 9](https://www.asd-ste100.org/assets/files/ASD-STE100_ISSUE9.pdf),
+but this project does not claim ASD-STE100 compliance.
+
+## Scope
+
+Apply this guide to changed explanatory text, including:
+
+- Documentation and examples.
+- User-facing messages and command help.
+- Code comments and test descriptions.
+- Issues, pull request descriptions, review comments, and commit messages.
+- Contributor guidance and coding-agent output.
+
+Do not rewrite literal commands, source identifiers, API fields, quoted output,
+or official third-party names only to satisfy this guide. Explain an unfamiliar
+literal value when readers need context.
+
+## Protect Nonpublic Information
+
+This is a public repository. Do not include secrets, credentials, or nonpublic
+identifiers in repository content or GitHub discussions.
+
+Replace internal jargon and private names with accurate public terms. Remove
+private URLs, hostnames, paths, ticket identifiers, environment names, team
+names, logs, screenshots, and configuration values before publication. Do not
+use realistic secret values as examples.
+
+Use obvious placeholders such as `<api-key>`, `<organization>`,
+`example.internal`, or `/path/to/project`. Confirm that a sanitized example
+cannot be mistaken for a working credential or a real private endpoint.
+
+If an exact internal value is necessary to investigate a problem, use an
+approved private channel. Do not add the value to a public issue or pull
+request.
+
+## Use Controlled Terms
+
+Use one term for one concept. Choose the shortest familiar term that preserves
+the technical meaning. Prefer terms already visible in the user interface,
+command line, public documentation, and nearby code.
+
+Use the
+[controlled-word list](.agents/skills/_shared/controlled-words.md) for project
+terms. If a required public term is missing, propose an update to the list in
+the same pull request.
+
+Do not use a controlled-word substitution when it would change a literal
+identifier or an official product, protocol, API, or third-party name.
+
+## Keep Claims Accurate
+
+- Verify commands, defaults, and behavior against current source, tests, or
+  scripts.
+- Name the exact boundary for security, persistence, compatibility, and support
+  claims.
+- State the failure or fallback result for a conditional or best-effort control.
+- Identify the credential type without including the credential value.
+- Do not describe a change as safe, ready, supported, or tested without naming
+  the condition or evidence that establishes the claim.
+
+## Write Direct Sentences
+
+- State the actor and the action.
+- Use active voice when it makes the actor clearer.
+- Put conditions before the action when the condition determines the result.
+- Use short sentences. Split sentences that contain several independent ideas.
+- Use concrete nouns and verbs.
+- Use `must` for requirements, `can` for capability, and `may` for permission.
+- Avoid vague modifiers such as `simple`, `easy`, `obvious`, `just`, and
+  `usually` unless they add measurable information.
+- Define an abbreviation the first time that you use it, unless the abbreviation
+  is more familiar than its expanded form.
+
+## Write Procedures
+
+- Introduce the goal before the steps.
+- Put one action in each numbered step.
+- Show commands exactly as users must enter them.
+- State where to run a command and what successful output means.
+- Identify prerequisites before the procedure.
+- Describe cleanup and any persistent changes.
+
+## Review Changed Text
+
+Before submission, confirm that changed text:
+
+- Is understandable without private company context.
+- Uses the controlled terms consistently.
+- Contains no secrets, credentials, or nonpublic identifiers.
+- Matches the implemented behavior and current user interface.
+- Distinguishes requirements from recommendations.
+- Uses placeholders for private or user-specific values.
+
+Writing findings are normally review suggestions. Treat a finding as blocking
+when ambiguity or disclosure can affect security, privacy, data safety,
+behavior, testing, licensing, or release decisions.


### PR DESCRIPTION
## Description

- Add a public writing guide based on NemoClaw's ASD-STE100-style guidance.
- Add a controlled-word list for project terms and safe public replacements.
- Require people and coding agents to remove nonpublic jargon and identifiers.
- Require documentation writer review and explicit secret, credential, and public-content checks in the pull request template.

## Verification

- [x] `python3 scripts/check_license_headers.py --check`
- [x] `python3 scripts/check_label_taxonomy.py --check`
- [x] `git diff --check`
- [x] Runtime tests are not applicable to documentation and template changes.

## Documentation Writer Review

- [x] Documentation writer review completed for the final changes
- Result: `docs-updated`
- Evidence: `CONTRIBUTING.md`, `WRITING.md`, `.agents/skills/_shared/controlled-words.md`, and `.github/PULL_REQUEST_TEMPLATE.md`
- Reviewer: Codex Desktop
- [x] Changed text follows the writing guide and controlled-word list.
- [x] A public contributor can understand the changed text without internal company context.
- [x] Agent-generated text was inspected before submission.

## Release And Compliance

- [x] No secrets or credentials are included.
- [x] No nonpublic names, endpoints, identifiers, paths, logs, screenshots, or configuration values are included.
- [x] No third-party dependencies changed.
- [x] Public content uses sanitized examples and placeholders instead of private values.

Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>
