### PR TITLE
docs(shrike-security): link the design walkthrough for the recipe

### DIFF
--- a/examples/recipes/partners/shrike/shrike-security/README.md
+++ b/examples/recipes/partners/shrike/shrike-security/README.md
@@ -22,6 +22,8 @@ sandbox could tamper with it. The independent controls remain the OpenShell
 egress policy + credential provider (`providers/shrike.yaml`), which hold even
 if the in-sandbox plugin is subverted.
 
+Background and design walkthrough: [Securing NemoClaw Agents with Shrike](https://shrikesecurity.com/blog/securing-nemoclaw-agents).
+
 ## Intended users and support boundary
 
 For operators running OpenClaw agents inside NemoClaw who want an action-level


### PR DESCRIPTION
Adds a one-line pointer from the shrike-security recipe README to the design walkthrough published at https://shrikesecurity.com/blog/securing-nemoclaw-agents — background on the recipe's four-layer pattern for anyone evaluating it. Docs-only change.

Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>
