### PR TITLE
feat(slack): add guided delivery diagnostic

### DIFF
--- a/examples/recipes/nvidia/developer-community-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/README.md
@@ -595,6 +595,20 @@ unless you remove the compose volumes.
 
 The plumbing checks below confirm the bridge and skill scripts are wired correctly. For an end-to-end walkthrough that exercises each skill via Slack DM and Outlook email, see [docs/verify-functionality.md](docs/verify-functionality.md). For a cross-channel, multi-user demo where one user teaches the agent a new skill and a different user invokes it from a different channel after a full sandbox rebuild, see [docs/collective-wisdom.md](docs/collective-wisdom.md).
 
+For a bounded Slack transport check that identifies the last confirmed delivery
+stage, run the guided diagnostic after sandbox creation:
+
+```console
+$ python3 scripts/slack_delivery_diagnostic.py --mode dm
+$ python3 scripts/slack_delivery_diagnostic.py \
+    --mode slash --slash-command /alice-nemoclaw
+```
+
+The command asks the operator to send the generated test value. It does not
+send a Slack message as the operator. See
+[Set Up Slack — Verify End-to-End Delivery](docs/set-up-slack.md#verify-end-to-end-delivery)
+for the stage definitions, privacy boundary, and failure guidance.
+
 ```console
 $ set -a; . ./.env; set +a
 

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/Dockerfile
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/Dockerfile
@@ -165,6 +165,11 @@ RUN chmod 755 /usr/local/lib/nemoclaw/bin/hermes
 COPY agents/hermes/refresh-placeholders.py /usr/local/lib/nemoclaw/refresh-placeholders.py
 RUN chmod 755 /usr/local/lib/nemoclaw/refresh-placeholders.py
 
+# The same script runs on the host and inside the sandbox. The host performs
+# the guided Slack API check; the sandbox reads only sanitized stage markers.
+COPY scripts/slack_delivery_diagnostic.py /usr/local/lib/nemoclaw/slack-delivery-diagnostic.py
+RUN chmod 755 /usr/local/lib/nemoclaw/slack-delivery-diagnostic.py
+
 COPY agents/hermes/patches/ /usr/local/lib/nemoclaw-patches/
 COPY agents/hermes/tests/verify-rich-block-renderer.py /tmp/verify-rich-block-renderer.py
 

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/patches/sitecustomize.py
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/patches/sitecustomize.py
@@ -18,6 +18,18 @@ import re
 import sys
 
 
+_PATCH_ROOT = os.path.dirname(os.path.abspath(__file__))
+if _PATCH_ROOT not in sys.path:
+    sys.path.insert(0, _PATCH_ROOT)
+
+from slack_diagnostic import (
+    copy_adapter_instrumentation,
+    diagnostic_id,
+    install_adapter_instrumentation,
+    record_stage,
+)
+
+
 LOGGER = logging.getLogger("nemoclaw.slack_compat")
 
 
@@ -38,6 +50,7 @@ def _patch_slack_adapter() -> None:
             from gateway.platforms.slack import SlackAdapter
         from gateway.platforms.base import SendResult
 
+        diagnostic_installed = install_adapter_instrumentation(SlackAdapter)
         if SlackAdapter.__dict__.get("_nemoclaw_slack_compat_installed"):
             return
 
@@ -282,6 +295,13 @@ def _patch_slack_adapter() -> None:
 
         async def _patched_connect(self, *args, **kwargs):
             result = await _orig_connect(self, *args, **kwargs)
+            if diagnostic_installed:
+                record_stage(
+                    "",
+                    "socket_mode_connection",
+                    status="confirmed" if result else "failed",
+                    error_type="" if result else "ConnectFailure",
+                )
             app = getattr(self, "_app", None)
             if app is not None and getattr(
                 self, "_nemoclaw_unknown_command_app", None
@@ -289,6 +309,18 @@ def _patch_slack_adapter() -> None:
 
                 @app.command(re.compile(".+"))
                 async def _handle_unknown_command(ack, command, respond):
+                    test_id = diagnostic_id(command.get("text", ""))
+                    if test_id and callable(
+                        getattr(self, "_handle_slash_command", None)
+                    ):
+                        await ack(
+                            response_type="ephemeral",
+                            text="Slack delivery diagnostic received.",
+                        )
+                        diagnostic_command = dict(command)
+                        diagnostic_command["command"] = "/hermes"
+                        await self._handle_slash_command(diagnostic_command)
+                        return
                     await ack()
                     command_name = command.get("command", "this command")
                     await respond(
@@ -362,6 +394,7 @@ def _patch_slack_registry_factory() -> None:
                         template.__dict__["_nemoclaw_handle_clarify_action"]
                     )
                 adapter_class._nemoclaw_slack_compat_installed = True
+            copy_adapter_instrumentation(template, adapter_class)
             return adapter
 
         _create_adapter_with_slack_compat._nemoclaw_slack_registry_compat = True

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/patches/slack_diagnostic.py
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/patches/slack_diagnostic.py
@@ -1,0 +1,314 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Sanitized stage instrumentation for guided Slack delivery diagnostics."""
+
+from __future__ import annotations
+
+import os
+import re
+import stat
+import time
+from pathlib import Path
+from typing import Any
+
+
+DIAGNOSTIC_LOG = Path("/tmp/nemoclaw-slack-diagnostic.jsonl")
+SOCKET_STATUS = Path("/tmp/nemoclaw-slack-socket-status.json")
+DIAGNOSTIC_TTL_SECONDS = 600
+DIAGNOSTIC_LOG_MAX_BYTES = 1024 * 1024
+_DIAGNOSTIC_RE = re.compile(
+    r"(?<![A-Z0-9])NC-[A-F0-9]{8}(?![A-Z0-9])",
+    re.IGNORECASE,
+)
+_STAGES = {
+    "socket_mode_connection",
+    "inbound_event_receipt",
+    "hermes_dispatch",
+    "inference",
+    "outbound_response",
+}
+_STATUSES = {"started", "confirmed", "failed"}
+
+
+def diagnostic_id(text: Any) -> str:
+    """Return the first diagnostic ID in *text* without retaining other text."""
+    match = _DIAGNOSTIC_RE.search(str(text or ""))
+    return match.group(0).upper() if match else ""
+
+
+def _open_log() -> int:
+    parent = DIAGNOSTIC_LOG.parent
+    parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    if DIAGNOSTIC_LOG.is_symlink():
+        raise OSError("diagnostic log path is a symbolic link")
+
+    flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(DIAGNOSTIC_LOG, flags, 0o600)
+    file_stat = os.fstat(descriptor)
+    if not stat.S_ISREG(file_stat.st_mode):
+        os.close(descriptor)
+        raise OSError("diagnostic log path is not a regular file")
+    os.fchmod(descriptor, 0o600)
+    if file_stat.st_size > DIAGNOSTIC_LOG_MAX_BYTES:
+        os.ftruncate(descriptor, 0)
+    return descriptor
+
+
+def _write_socket_status(payload: bytes) -> None:
+    if SOCKET_STATUS.is_symlink():
+        return
+    flags = os.O_CREAT | os.O_TRUNC | os.O_WRONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = -1
+    try:
+        descriptor = os.open(SOCKET_STATUS, flags, 0o600)
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            return
+        os.fchmod(descriptor, 0o600)
+        os.write(descriptor, payload)
+    except OSError:
+        return
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def record_stage(
+    test_id: str,
+    stage: str,
+    *,
+    status: str = "confirmed",
+    error_type: str = "",
+) -> None:
+    """Append one bounded event without message content or credentials."""
+    if stage not in _STAGES or status not in _STATUSES:
+        return
+    normalized_id = diagnostic_id(test_id) if test_id else ""
+    if test_id and not normalized_id:
+        return
+
+    import json
+
+    event = {
+        "diagnostic_id": normalized_id,
+        "stage": stage,
+        "status": status,
+        "timestamp": round(time.time(), 3),
+        "pid": os.getpid(),
+    }
+    if error_type:
+        event["error_type"] = re.sub(r"[^A-Za-z0-9_.-]", "", error_type)[:80]
+
+    encoded = (json.dumps(event, sort_keys=True) + "\n").encode()
+    if stage == "socket_mode_connection":
+        _write_socket_status(encoded)
+
+    descriptor = -1
+    try:
+        descriptor = _open_log()
+        os.write(descriptor, encoded)
+    except OSError:
+        # Diagnostics must never interrupt Slack delivery.
+        return
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def _event_text(event: Any) -> str:
+    if isinstance(event, dict):
+        return str(event.get("text") or "")
+    return str(getattr(event, "text", "") or "")
+
+
+def _event_route(event: Any) -> tuple[str, str, str]:
+    metadata = getattr(event, "metadata", None) or {}
+    source = getattr(event, "source", None)
+    team_id = str(
+        metadata.get("slack_team_id")
+        or getattr(source, "scope_id", "")
+        or ""
+    )
+    channel_id = str(
+        metadata.get("slack_channel_id")
+        or getattr(source, "chat_id", "")
+        or ""
+    )
+    thread_id = str(
+        metadata.get("slack_thread_ts")
+        or getattr(source, "thread_id", "")
+        or getattr(event, "message_id", "")
+        or ""
+    )
+    return team_id, channel_id, thread_id
+
+
+def _remember_route(adapter: Any, event: Any, test_id: str) -> None:
+    routes = getattr(adapter, "_nemoclaw_diagnostic_routes", None)
+    if routes is None:
+        routes = {}
+        adapter._nemoclaw_diagnostic_routes = routes
+
+    now = time.monotonic()
+    for key, (_stored_id, created) in list(routes.items()):
+        if now - created > DIAGNOSTIC_TTL_SECONDS:
+            routes.pop(key, None)
+
+    team_id, channel_id, thread_id = _event_route(event)
+    if not channel_id:
+        return
+    routes[(team_id, channel_id, thread_id)] = (test_id, now)
+    routes[(team_id, channel_id, "")] = (test_id, now)
+    if team_id:
+        routes[("", channel_id, thread_id)] = (test_id, now)
+        routes[("", channel_id, "")] = (test_id, now)
+
+
+def _route_id(adapter: Any, chat_id: str, metadata: Any) -> str:
+    routes = getattr(adapter, "_nemoclaw_diagnostic_routes", {})
+    metadata = metadata or {}
+    team_id = str(metadata.get("slack_team_id") or "")
+    thread_id = str(
+        metadata.get("slack_thread_ts")
+        or metadata.get("thread_id")
+        or ""
+    )
+    channel_id = str(chat_id or metadata.get("slack_channel_id") or "")
+    now = time.monotonic()
+    for key in (
+        (team_id, channel_id, thread_id),
+        (team_id, channel_id, ""),
+        ("", channel_id, thread_id),
+        ("", channel_id, ""),
+    ):
+        stored = routes.get(key)
+        if stored and now - stored[1] <= DIAGNOSTIC_TTL_SECONDS:
+            return str(stored[0])
+    return ""
+
+
+def install_adapter_instrumentation(adapter_class: type) -> bool:
+    """Install feature-detected hooks on a Hermes Slack adapter class."""
+    if adapter_class.__dict__.get("_nemoclaw_slack_diagnostic_installed"):
+        return True
+
+    method_names = (
+        "_handle_slack_message",
+        "_handle_slash_command",
+        "handle_message",
+        "set_message_handler",
+        "send",
+    )
+    originals = {name: getattr(adapter_class, name, None) for name in method_names}
+    if not all(callable(method) for method in originals.values()):
+        return False
+
+    async def _diagnostic_slack_message(self, event, payload=None):
+        test_id = diagnostic_id(_event_text(event))
+        if test_id:
+            record_stage(test_id, "inbound_event_receipt")
+        return await originals["_handle_slack_message"](self, event, payload)
+
+    async def _diagnostic_slash_command(self, command):
+        test_id = diagnostic_id(_event_text(command))
+        if test_id:
+            record_stage(test_id, "inbound_event_receipt")
+        return await originals["_handle_slash_command"](self, command)
+
+    async def _diagnostic_handle_message(self, event):
+        test_id = diagnostic_id(_event_text(event))
+        if test_id:
+            _remember_route(self, event, test_id)
+            record_stage(test_id, "hermes_dispatch")
+        return await originals["handle_message"](self, event)
+
+    def _diagnostic_set_message_handler(self, handler):
+        if getattr(handler, "_nemoclaw_slack_diagnostic_handler", False):
+            return originals["set_message_handler"](self, handler)
+
+        async def _diagnostic_handler(event):
+            test_id = diagnostic_id(_event_text(event))
+            if not test_id:
+                return await handler(event)
+            record_stage(test_id, "inference", status="started")
+            try:
+                result = await handler(event)
+            except Exception as error:
+                record_stage(
+                    test_id,
+                    "inference",
+                    status="failed",
+                    error_type=type(error).__name__,
+                )
+                raise
+            record_stage(test_id, "inference")
+            return result
+
+        _diagnostic_handler._nemoclaw_slack_diagnostic_handler = True
+        return originals["set_message_handler"](self, _diagnostic_handler)
+
+    async def _diagnostic_send(
+        self,
+        chat_id,
+        content,
+        reply_to=None,
+        metadata=None,
+    ):
+        test_id = _route_id(self, chat_id, metadata)
+        try:
+            result = await originals["send"](
+                self,
+                chat_id,
+                content,
+                reply_to=reply_to,
+                metadata=metadata,
+            )
+        except Exception as error:
+            if test_id:
+                record_stage(
+                    test_id,
+                    "outbound_response",
+                    status="failed",
+                    error_type=type(error).__name__,
+                )
+            raise
+
+        if test_id:
+            record_stage(
+                test_id,
+                "outbound_response",
+                status=("confirmed" if getattr(result, "success", False) else "failed"),
+                error_type=("" if getattr(result, "success", False) else "SendResultFailure"),
+            )
+        return result
+
+    patched_methods = {
+        "_handle_slack_message": _diagnostic_slack_message,
+        "_handle_slash_command": _diagnostic_slash_command,
+        "handle_message": _diagnostic_handle_message,
+        "set_message_handler": _diagnostic_set_message_handler,
+        "send": _diagnostic_send,
+    }
+    for name, method in patched_methods.items():
+        setattr(adapter_class, name, method)
+    adapter_class._nemoclaw_slack_diagnostic_methods = tuple(patched_methods)
+    adapter_class._nemoclaw_slack_diagnostic_installed = True
+    return True
+
+
+def copy_adapter_instrumentation(template_class: type, runtime_class: type) -> bool:
+    """Copy installed hooks to Hermes's namespaced runtime adapter class."""
+    method_names = template_class.__dict__.get(
+        "_nemoclaw_slack_diagnostic_methods",
+        (),
+    )
+    if not method_names:
+        return False
+    for name in method_names:
+        setattr(runtime_class, name, template_class.__dict__[name])
+    runtime_class._nemoclaw_slack_diagnostic_methods = tuple(method_names)
+    runtime_class._nemoclaw_slack_diagnostic_installed = True
+    return True

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/tests/test_slack_interactive_compat.py
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/tests/test_slack_interactive_compat.py
@@ -68,6 +68,7 @@ def make_adapter(*, native_clarify: bool = False):
             self.client = FakeClient()
             self.config = SimpleNamespace(extra={})
             self.authorized = True
+            self.slash_commands = []
 
         async def connect(self, *args, **kwargs):
             self._app = FakeApp()
@@ -81,6 +82,9 @@ def make_adapter(*, native_clarify: bool = False):
 
         def _is_interactive_user_authorized(self, user_id, **kwargs):
             return self.authorized and user_id == "U123"
+
+        async def _handle_slash_command(self, command):
+            self.slash_commands.append(command)
 
     if native_clarify:
         async def native_send_clarify(self, **kwargs):
@@ -183,6 +187,64 @@ class SlackInteractiveCompatTest(unittest.TestCase):
             ["section", "actions"],
             [block["type"] for block in adapter.client.posts[-1]["blocks"]],
         )
+
+    def test_custom_slash_diagnostic_enters_the_hermes_message_path(self) -> None:
+        adapter_cls = make_adapter()
+        load_patch(adapter_cls, "_nvteam_sitecustomize_diagnostic_slash_test")
+        adapter = adapter_cls()
+        asyncio.run(adapter.connect())
+        callback = adapter._app.commands[-1][1]
+        acknowledgements = []
+        responses = []
+
+        async def ack(**kwargs):
+            acknowledgements.append(kwargs)
+
+        async def respond(message):
+            responses.append(message)
+
+        asyncio.run(
+            callback(
+                ack,
+                {
+                    "command": "/alice-nemoclaw",
+                    "text": "NemoClaw delivery diagnostic NC-1234ABCD",
+                },
+                respond,
+            )
+        )
+
+        self.assertEqual(
+            acknowledgements,
+            [{"response_type": "ephemeral", "text": "Slack delivery diagnostic received."}],
+        )
+        self.assertEqual(adapter.slash_commands[0]["command"], "/hermes")
+        self.assertEqual(responses, [])
+
+    def test_other_custom_slash_commands_keep_the_help_response(self) -> None:
+        adapter_cls = make_adapter()
+        load_patch(adapter_cls, "_nvteam_sitecustomize_unknown_slash_test")
+        adapter = adapter_cls()
+        asyncio.run(adapter.connect())
+        callback = adapter._app.commands[-1][1]
+        responses = []
+
+        async def ack(**kwargs):
+            self.assertEqual(kwargs, {})
+
+        async def respond(message):
+            responses.append(message)
+
+        asyncio.run(
+            callback(
+                ack,
+                {"command": "/alice-nemoclaw", "text": "ordinary request"},
+                respond,
+            )
+        )
+
+        self.assertEqual(adapter.slash_commands, [])
+        self.assertIn("don't recognize", responses[0])
 
     def test_adds_buttons_and_resolves_an_authorized_choice(self) -> None:
         adapter_cls = make_adapter()

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/docs/set-up-slack.md
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/docs/set-up-slack.md
@@ -150,9 +150,68 @@ The script (auto-sources `.env` if needed) does the following for Slack:
 
 If you change Slack credentials after a sandbox already exists, run `bash scripts/tear-down.sh && bash scripts/bring-up.sh` so the providers and image are rebuilt with the new values.
 
-## Confirm Delivery
+## Verify End-to-End Delivery
 
-After the sandbox is running, send a direct message to your bot in Slack from your allowlisted account. It should respond within a few seconds.
+The setup preflight calls `apps.connections.open`. That check proves that the
+app-level token can reach Slack and create a Socket Mode URL. It does not prove
+that Slack can deliver an event to the running Hermes gateway.
+
+After the sandbox is running, start the guided direct-message diagnostic from
+the example root:
+
+```console
+$ python3 scripts/slack_delivery_diagnostic.py --mode dm
+```
+
+The command prints a unique test value and asks you to send one direct message
+to the bot. It does not send a message as you. The delivery wait is 90 seconds
+by default, and the command reports the last confirmed stage:
+
+| Stage | What it confirms |
+| --- | --- |
+| Slack API access | The bot access token can call `auth.test`. |
+| Socket Mode connection | The running Hermes process completed a Socket Mode connection. |
+| Inbound event receipt | The adapter received the test event from Slack. |
+| Hermes dispatch | The event passed adapter filtering and entered the Hermes message path. |
+| Inference | The Hermes message handler completed without an exception. |
+| Outbound response | The Slack adapter confirmed a send. |
+
+When `SLACK_ALLOWED_IDS` contains members, send the direct message from an
+allowlisted member. When the value is empty, the documented allow-all mode is
+supported. The command reports the authorization mode and member count, but it
+does not print member IDs.
+
+To verify the custom slash command from your app manifest, run a separate test.
+Replace the command name with the value that you configured:
+
+```console
+$ python3 scripts/slack_delivery_diagnostic.py \
+    --mode slash --slash-command /alice-nemoclaw
+```
+
+Then run the printed slash command in Slack. The compatibility shim forwards
+only a message that contains the generated diagnostic value through the normal
+Hermes inference path. Other unknown slash commands keep their existing help
+response.
+
+The sandbox records only the diagnostic value, stage, status, timestamp,
+process ID, and exception class in a mode-0600 bounded log. It does not record
+the message body, Slack credentials, workspace name, or unrelated history. The
+diagnostic uses the existing Slack permissions. It does not restart the gateway
+or rebuild the sandbox. Use `--timeout <seconds>` to change the bounded wait.
+
+Rebuild the sandbox before the first diagnostic after you update this recipe.
+The sandbox image contains the stage instrumentation and the sandbox-side
+reader.
+
+The optional response monitor serves a different purpose. It detects some
+unanswered direct messages after delivery and can request host-side recovery.
+It does not prove the slash-command path or identify the last completed stage.
+
+## Manual Inspection
+
+You can also send a direct message to the bot from an allowlisted account. It
+should respond within a few seconds.
 
 To inspect Hermes activity inside the sandbox:
 

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/slack_delivery_diagnostic.py
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/slack_delivery_diagnostic.py
@@ -1,0 +1,474 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Run a guided, operator-originated Slack delivery diagnostic."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import secrets
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+EXAMPLE_DIR = Path(__file__).resolve().parents[1]
+ENV_FILE = EXAMPLE_DIR / ".env"
+SANDBOX_SCRIPT = "/usr/local/lib/nemoclaw/slack-delivery-diagnostic.py"
+DIAGNOSTIC_LOG = Path("/tmp/nemoclaw-slack-diagnostic.jsonl")
+SOCKET_STATUS = Path("/tmp/nemoclaw-slack-socket-status.json")
+STAGE_ORDER = (
+    "socket_mode_connection",
+    "inbound_event_receipt",
+    "hermes_dispatch",
+    "inference",
+    "outbound_response",
+)
+STAGE_LABELS = {
+    "slack_api_access": "Slack API access",
+    "socket_mode_connection": "Socket Mode connection",
+    "inbound_event_receipt": "inbound event receipt",
+    "hermes_dispatch": "Hermes dispatch",
+    "inference": "inference",
+    "outbound_response": "outbound response",
+}
+FAILURE_ACTIONS = {
+    "missing_inbound_event": (
+        "Confirm the app's event subscription or slash command, then check that "
+        "Socket Mode remains enabled in Slack."
+    ),
+    "dispatch_filter": (
+        "Confirm that the sending member is in SLACK_ALLOWED_IDS, or leave the "
+        "allowlist empty only when workspace-wide access is intended."
+    ),
+    "inference_timeout": (
+        "Check the Hermes gateway and inference route. A busy session can also "
+        "delay dispatch until the diagnostic timeout."
+    ),
+    "inference_failure": (
+        "Check the configured inference provider, model, and gateway logs."
+    ),
+    "outbound_response_timeout": (
+        "Check Slack chat:write access, app installation, and outbound policy."
+    ),
+    "outbound_response_failure": (
+        "Check Slack chat:write access, app installation, and outbound policy."
+    ),
+}
+
+
+def read_env(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    if not path.exists():
+        return values
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip().strip('"').strip("'")
+    return values
+
+
+def authorization_description(raw: str) -> str:
+    member_count = len([item for item in raw.split(",") if item.strip()])
+    if member_count:
+        noun = "member" if member_count == 1 else "members"
+        return f"explicit allowlist ({member_count} {noun})"
+    return "allow-all (no SLACK_ALLOWED_IDS value)"
+
+
+def slack_api_access(token: str, timeout: float = 10.0) -> tuple[bool, str]:
+    if not token:
+        return False, "SLACK_BOT_TOKEN is missing from .env"
+    if not token.startswith("xoxb-"):
+        return False, "SLACK_BOT_TOKEN must be a bot access token"
+
+    request = urllib.request.Request(
+        "https://slack.com/api/auth.test",
+        data=b"",
+        method="POST",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            payload = json.loads(response.read(16384))
+    except (TimeoutError, socket.timeout):
+        return False, f"Slack API did not respond within {timeout:g} seconds"
+    except urllib.error.HTTPError as error:
+        if error.code in {401, 403}:
+            return False, "Slack rejected the bot access token"
+        return False, f"Slack API returned HTTP {error.code}"
+    except urllib.error.URLError:
+        return False, "Slack API is unreachable or its TLS certificate is invalid"
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return False, "Slack API returned an invalid response"
+
+    if not isinstance(payload, dict):
+        return False, "Slack API returned an invalid response"
+    if payload.get("ok") is not True:
+        error = str(payload.get("error") or "unknown_error")
+        if error in {"invalid_auth", "not_authed", "token_expired", "token_revoked"}:
+            return False, "Slack rejected the bot access token"
+        return False, f"Slack auth.test failed ({error})"
+    return True, ""
+
+
+def read_events(path: Path = DIAGNOSTIC_LOG) -> list[dict[str, Any]]:
+    try:
+        if path.is_symlink() or not path.is_file():
+            return []
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+
+    events: list[dict[str, Any]] = []
+    for line in lines[-5000:]:
+        try:
+            event = json.loads(line)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if isinstance(event, dict):
+            events.append(event)
+    return events
+
+
+def read_socket_status(path: Path = SOCKET_STATUS) -> dict[str, Any] | None:
+    try:
+        if path.is_symlink() or not path.is_file():
+            return None
+        event = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, TypeError):
+        return None
+    return event if isinstance(event, dict) else None
+
+
+def _pid_is_running(raw_pid: Any) -> bool:
+    try:
+        pid = int(raw_pid)
+        if pid <= 0:
+            return False
+        os.kill(pid, 0)
+    except (OSError, TypeError, ValueError):
+        return False
+    return True
+
+
+def socket_connection_status(events: list[dict[str, Any]]) -> dict[str, Any]:
+    connection_events = [
+        event
+        for event in events
+        if event.get("stage") == "socket_mode_connection"
+        and not event.get("diagnostic_id")
+    ]
+    if not connection_events:
+        return {
+            "ok": False,
+            "last_stage": "slack_api_access",
+            "category": "missing_instrumentation",
+        }
+    latest = max(
+        connection_events,
+        key=lambda event: float(event.get("timestamp") or 0),
+    )
+    connected = latest.get("status") == "confirmed" and _pid_is_running(
+        latest.get("pid")
+    )
+    return {
+        "ok": connected,
+        "last_stage": (
+            "socket_mode_connection" if connected else "slack_api_access"
+        ),
+        "category": "" if connected else "socket_mode_connection_failure",
+    }
+
+
+def evaluate_delivery(
+    events: list[dict[str, Any]],
+    *,
+    timed_out: bool,
+    now: float | None = None,
+    failure_settle_seconds: float = 2.0,
+) -> dict[str, Any]:
+    now = time.time() if now is None else now
+    latest: dict[str, dict[str, Any]] = {}
+    for event in events:
+        stage = str(event.get("stage") or "")
+        if stage in STAGE_ORDER[1:]:
+            latest[stage] = event
+
+    confirmed = [
+        stage
+        for stage in STAGE_ORDER[1:]
+        if latest.get(stage, {}).get("status") == "confirmed"
+    ]
+    last_stage = "socket_mode_connection"
+    for stage in STAGE_ORDER[1:]:
+        if stage in confirmed:
+            last_stage = stage
+
+    inference = latest.get("inference", {})
+    outbound = latest.get("outbound_response", {})
+    if inference.get("status") == "failed":
+        return {
+            "ok": False,
+            "pending": False,
+            "category": "inference_failure",
+            "last_stage": "hermes_dispatch",
+            "confirmed": confirmed,
+        }
+    if (
+        inference.get("status") == "confirmed"
+        and outbound.get("status") == "confirmed"
+    ):
+        return {
+            "ok": True,
+            "pending": False,
+            "category": "",
+            "last_stage": "outbound_response",
+            "confirmed": confirmed,
+        }
+    if (
+        inference.get("status") == "confirmed"
+        and outbound.get("status") == "failed"
+    ):
+        failure_age = now - float(outbound.get("timestamp") or now)
+        if timed_out or failure_age >= failure_settle_seconds:
+            return {
+                "ok": False,
+                "pending": False,
+                "category": "outbound_response_failure",
+                "last_stage": "inference",
+                "confirmed": confirmed,
+            }
+    if not timed_out:
+        return {
+            "ok": False,
+            "pending": True,
+            "category": "",
+            "last_stage": last_stage,
+            "confirmed": confirmed,
+        }
+
+    inbound = latest.get("inbound_event_receipt", {})
+    dispatch = latest.get("hermes_dispatch", {})
+    if inbound.get("status") != "confirmed":
+        category = "missing_inbound_event"
+        last_stage = "socket_mode_connection"
+    elif dispatch.get("status") != "confirmed":
+        category = "dispatch_filter"
+        last_stage = "inbound_event_receipt"
+    elif inference.get("status") != "confirmed":
+        category = "inference_timeout"
+        last_stage = "hermes_dispatch"
+    else:
+        category = "outbound_response_timeout"
+        last_stage = "inference"
+    return {
+        "ok": False,
+        "pending": False,
+        "category": category,
+        "last_stage": last_stage,
+        "confirmed": confirmed,
+    }
+
+
+def watch_delivery(test_id: str, timeout: float) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        matching = [
+            event
+            for event in read_events()
+            if event.get("diagnostic_id") == test_id
+        ]
+        result = evaluate_delivery(matching, timed_out=False)
+        if not result["pending"]:
+            return result
+        time.sleep(0.25)
+    matching = [
+        event
+        for event in read_events()
+        if event.get("diagnostic_id") == test_id
+    ]
+    return evaluate_delivery(matching, timed_out=True)
+
+
+def _parse_helper_json(output: str) -> dict[str, Any] | None:
+    for line in reversed(output.splitlines()):
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            return payload
+    return None
+
+
+def run_sandbox_helper(
+    sandbox: str,
+    arguments: list[str],
+    timeout: float,
+) -> dict[str, Any] | None:
+    command = [
+        "openshell",
+        "sandbox",
+        "exec",
+        "--name",
+        sandbox,
+        "--",
+        "python3",
+        SANDBOX_SCRIPT,
+        *arguments,
+    ]
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    return _parse_helper_json(result.stdout)
+
+
+def _print_confirmed(stage: str) -> None:
+    print(f"[confirmed] {STAGE_LABELS[stage]}", flush=True)
+
+
+def run_operator_diagnostic(args: argparse.Namespace) -> int:
+    env = read_env(ENV_FILE)
+    token = env.get("SLACK_BOT_TOKEN", "")
+    api_ok, api_error = slack_api_access(token, args.api_timeout)
+    if not api_ok:
+        print(f"[failed] Slack API access: {api_error}", file=sys.stderr)
+        return 2
+    _print_confirmed("slack_api_access")
+
+    status = run_sandbox_helper(args.sandbox, ["--sandbox-status"], 15)
+    if not status:
+        print(
+            "[failed] Could not read diagnostic instrumentation from the sandbox. "
+            "Rebuild the sandbox with this version of the recipe.",
+            file=sys.stderr,
+        )
+        return 3
+    if not status.get("ok"):
+        print(
+            "[failed] Last confirmed stage: Slack API access. "
+            "Check the Hermes gateway and Socket Mode connection.",
+            file=sys.stderr,
+        )
+        return 4
+    _print_confirmed("socket_mode_connection")
+
+    test_id = f"NC-{secrets.token_hex(4).upper()}"
+    auth_mode = authorization_description(env.get("SLACK_ALLOWED_IDS", ""))
+    print(f"Authorization mode: {auth_mode}")
+    if args.mode == "dm":
+        print("Send this direct message to the bot:")
+        print(f"  NemoClaw delivery diagnostic {test_id}. Reply with the same code.")
+    else:
+        print("Run this configured slash command in Slack:")
+        print(
+            f"  {args.slash_command} NemoClaw delivery diagnostic {test_id}. "
+            "Reply with the same code."
+        )
+    print(f"Waiting up to {args.timeout:g} seconds...", flush=True)
+
+    result = run_sandbox_helper(
+        args.sandbox,
+        ["--sandbox-watch", test_id, "--timeout", str(args.timeout)],
+        args.timeout + 15,
+    )
+    if not result:
+        print(
+            "[failed] The bounded sandbox diagnostic did not return a result.",
+            file=sys.stderr,
+        )
+        return 5
+
+    for stage in STAGE_ORDER[1:]:
+        if stage in result.get("confirmed", []):
+            _print_confirmed(stage)
+    if result.get("ok"):
+        print("Slack delivery diagnostic passed.")
+        return 0
+
+    category = str(result.get("category") or "inference_timeout")
+    last_stage = str(result.get("last_stage") or "socket_mode_connection")
+    action = FAILURE_ACTIONS.get(category, "Check the Hermes gateway logs.")
+    print(
+        f"[failed] Last confirmed stage: {STAGE_LABELS.get(last_stage, last_stage)}. "
+        f"{action}",
+        file=sys.stderr,
+    )
+    return 6
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Trace an operator-originated Slack message through Hermes",
+    )
+    parser.add_argument("--mode", choices=("dm", "slash"), default="dm")
+    parser.add_argument(
+        "--slash-command",
+        help="Configured Slack command, for example /alice-nemoclaw",
+    )
+    parser.add_argument(
+        "--sandbox",
+        default=os.environ.get("SANDBOX_NAME", "hermes-direct"),
+    )
+    parser.add_argument("--timeout", type=float, default=90.0)
+    parser.add_argument("--api-timeout", type=float, default=10.0)
+    parser.add_argument("--sandbox-status", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--sandbox-watch", metavar="ID", help=argparse.SUPPRESS)
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    if (
+        not math.isfinite(args.timeout)
+        or not math.isfinite(args.api_timeout)
+        or args.timeout <= 0
+        or args.api_timeout <= 0
+    ):
+        parser.error("timeouts must be finite and greater than zero")
+
+    if args.sandbox_status:
+        events = read_events()
+        socket_status = read_socket_status()
+        if socket_status:
+            events.append(socket_status)
+        result = socket_connection_status(events)
+        print(json.dumps(result, sort_keys=True))
+        return 0 if result["ok"] else 1
+    if args.sandbox_watch:
+        if not re.fullmatch(r"NC-[A-F0-9]{8}", args.sandbox_watch):
+            parser.error("invalid diagnostic ID")
+        result = watch_delivery(args.sandbox_watch, args.timeout)
+        print(json.dumps(result, sort_keys=True))
+        return 0 if result["ok"] else 1
+
+    if args.mode == "slash":
+        if not args.slash_command:
+            parser.error("--slash-command is required for --mode slash")
+        if not re.fullmatch(r"/[a-z0-9][a-z0-9-]{0,31}", args.slash_command):
+            parser.error("--slash-command must be lowercase and hyphen-separated")
+    return run_operator_diagnostic(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/tests/test_slack_delivery_diagnostic.py
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/tests/test_slack_delivery_diagnostic.py
@@ -1,0 +1,212 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import stat
+import sys
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+
+RECIPE_DIR = Path(__file__).resolve().parents[2]
+SCRIPT = RECIPE_DIR / "scripts/slack_delivery_diagnostic.py"
+INSTRUMENTATION = RECIPE_DIR / "agents/hermes/patches/slack_diagnostic.py"
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+DIAGNOSTIC = load_module("slack_delivery_diagnostic", SCRIPT)
+INSTRUMENT = load_module("slack_diagnostic_instrumentation", INSTRUMENTATION)
+
+
+def stage(name: str, status: str = "confirmed", timestamp: float = 100.0):
+    return {
+        "diagnostic_id": "NC-1234ABCD",
+        "stage": name,
+        "status": status,
+        "timestamp": timestamp,
+    }
+
+
+class SlackDeliveryEvaluationTest(TestCase):
+    def test_success_confirms_complete_delivery_path(self) -> None:
+        result = DIAGNOSTIC.evaluate_delivery(
+            [
+                stage("inbound_event_receipt"),
+                stage("hermes_dispatch"),
+                stage("inference", "started"),
+                stage("inference"),
+                stage("outbound_response"),
+            ],
+            timed_out=False,
+        )
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["last_stage"], "outbound_response")
+
+    def test_timeout_after_dispatch_identifies_inference(self) -> None:
+        result = DIAGNOSTIC.evaluate_delivery(
+            [
+                stage("inbound_event_receipt"),
+                stage("hermes_dispatch"),
+                stage("inference", "started"),
+            ],
+            timed_out=True,
+        )
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["category"], "inference_timeout")
+        self.assertEqual(result["last_stage"], "hermes_dispatch")
+
+    def test_missing_inbound_event_stops_at_socket_mode(self) -> None:
+        result = DIAGNOSTIC.evaluate_delivery([], timed_out=True)
+
+        self.assertEqual(result["category"], "missing_inbound_event")
+        self.assertEqual(result["last_stage"], "socket_mode_connection")
+
+    def test_inference_failure_stops_at_dispatch(self) -> None:
+        result = DIAGNOSTIC.evaluate_delivery(
+            [
+                stage("inbound_event_receipt"),
+                stage("hermes_dispatch"),
+                stage("inference", "failed"),
+            ],
+            timed_out=False,
+        )
+
+        self.assertEqual(result["category"], "inference_failure")
+        self.assertEqual(result["last_stage"], "hermes_dispatch")
+
+    def test_outbound_failure_stops_at_inference(self) -> None:
+        result = DIAGNOSTIC.evaluate_delivery(
+            [
+                stage("inbound_event_receipt"),
+                stage("hermes_dispatch"),
+                stage("inference"),
+                stage("outbound_response", "failed", 100.0),
+            ],
+            timed_out=False,
+            now=103.0,
+        )
+
+        self.assertEqual(result["category"], "outbound_response_failure")
+        self.assertEqual(result["last_stage"], "inference")
+
+    def test_allowlist_description_does_not_print_member_ids(self) -> None:
+        description = DIAGNOSTIC.authorization_description("U123,U456")
+
+        self.assertEqual(description, "explicit allowlist (2 members)")
+        self.assertNotIn("U123", description)
+        self.assertEqual(
+            DIAGNOSTIC.authorization_description(""),
+            "allow-all (no SLACK_ALLOWED_IDS value)",
+        )
+
+
+class SlackDeliveryInstrumentationTest(TestCase):
+    def test_stage_log_keeps_only_sanitized_fields(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "diagnostic.jsonl"
+            with patch.object(INSTRUMENT, "DIAGNOSTIC_LOG", log_path):
+                INSTRUMENT.record_stage(
+                    "private text NC-1234ABCD unrelated text",
+                    "inference",
+                    status="failed",
+                    error_type="RuntimeError",
+                )
+
+            event = json.loads(log_path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                set(event),
+                {
+                    "diagnostic_id",
+                    "stage",
+                    "status",
+                    "timestamp",
+                    "pid",
+                    "error_type",
+                },
+            )
+            self.assertEqual(event["diagnostic_id"], "NC-1234ABCD")
+            self.assertNotIn("private text", repr(event))
+            self.assertNotIn("unrelated text", repr(event))
+            self.assertEqual(stat.S_IMODE(log_path.stat().st_mode), 0o600)
+
+    def test_adapter_hooks_record_stages_without_message_content(self) -> None:
+        class FakeAdapter:
+            async def _handle_slack_message(self, event, payload=None):
+                return None
+
+            async def _handle_slash_command(self, command):
+                return None
+
+            async def handle_message(self, event):
+                return None
+
+            def set_message_handler(self, handler):
+                self._message_handler = handler
+
+            async def send(self, chat_id, content, reply_to=None, metadata=None):
+                return SimpleNamespace(success=True)
+
+        private_text = "private request NC-1234ABCD with unrelated content"
+        event = SimpleNamespace(
+            text=private_text,
+            source=SimpleNamespace(chat_id="D123", thread_id="171.001"),
+            metadata={
+                "slack_team_id": "T123",
+                "slack_channel_id": "D123",
+                "slack_thread_ts": "171.001",
+            },
+            message_id="171.001",
+        )
+
+        self.assertTrue(INSTRUMENT.install_adapter_instrumentation(FakeAdapter))
+        adapter = FakeAdapter()
+
+        async def handler(message):
+            return "response"
+
+        with patch.object(INSTRUMENT, "record_stage") as record:
+            adapter.set_message_handler(handler)
+            asyncio.run(adapter._handle_slack_message({"text": private_text}))
+            asyncio.run(adapter.handle_message(event))
+            asyncio.run(adapter._message_handler(event))
+            asyncio.run(
+                adapter.send(
+                    "D123",
+                    "response",
+                    metadata={
+                        "slack_team_id": "T123",
+                        "slack_thread_ts": "171.001",
+                    },
+                )
+            )
+
+        serialized_calls = repr(record.call_args_list)
+        self.assertIn("inbound_event_receipt", serialized_calls)
+        self.assertIn("hermes_dispatch", serialized_calls)
+        self.assertIn("inference", serialized_calls)
+        self.assertIn("outbound_response", serialized_calls)
+        self.assertNotIn("private request", serialized_calls)
+        self.assertNotIn("unrelated content", serialized_calls)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Related Issue

Closes #66

## Description

The existing Slack preflight proves that an app-level token can create a Socket
Mode URL, but it cannot prove that an operator-originated event reaches Hermes,
inference, and the outbound Slack API. The response monitor also checks only
some unanswered direct messages after the fact.

This change adds a bounded, operator-triggered diagnostic for direct messages
and configured custom slash commands. It reports the last confirmed stage:
Slack API access, Socket Mode connection, inbound event receipt, Hermes
dispatch, inference, or outbound response. The script does not send as the
operator and remains separate from restart and rebuild behavior.

The example-owned adapter instrumentation writes only a random diagnostic ID,
stage, status, timestamp, process ID, and exception class to bounded mode-0600
state. It does not record Slack message bodies, credentials, workspace names,
or unrelated history. Existing allowlisted and allow-all authorization remains
authoritative.

The Slack setup guide and recipe verification section document the commands,
stage meanings, privacy boundary, and distinction from component health checks.

## Verification

- [x] `python3 scripts/check_license_headers.py --check` — all 370 checked source files passed.
- [x] `python3 scripts/check_label_taxonomy.py --check` — 64 labels are valid; no governance metadata changed.
- [x] `git diff --check origin/main...HEAD` — passed.
- [x] Relevant example setup or syntax checks — `python3 -m pytest -q examples/recipes/nvidia/developer-community-chief-of-staff/scripts/tests examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/tests` passed with 113 tests and 6 subtests in an isolated test environment.
- [x] `python3 -m py_compile examples/recipes/nvidia/developer-community-chief-of-staff/scripts/slack_delivery_diagnostic.py examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/patches/slack_diagnostic.py examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/patches/sitecustomize.py` — passed.
- [x] `docker buildx build --check -f agents/hermes/Dockerfile .` from the recipe directory — completed with no warnings.
- [x] `bash examples/recipes/nvidia/developer-community-chief-of-staff/scripts/tests/test-enterprise-ca-staging.sh` — passed.
- [x] `bash examples/recipes/nvidia/developer-community-chief-of-staff/scripts/tests/test-snapshot-safety.sh` — passed.

Not completed:

- A live DM or slash-command diagnostic was not run because this checkout has no configured Slack credentials and running recipe sandbox.
- A full sandbox image build was not run. The Buildx Dockerfile check validated the Dockerfile and `COPY` inputs without executing all build stages.
- `test-host-ca-bundle.sh` fails identically on `origin/main` before this change because it searches for `apt-get update -qq`, while the current Dockerfile contains `apt-get update`. The new diagnostic does not change that line or host CA behavior.

## Documentation Writer Review

- [x] Documentation writer review completed for the final changes
- Result: `docs-updated`
- Evidence or justification: Updated `examples/recipes/nvidia/developer-community-chief-of-staff/docs/set-up-slack.md` and the recipe `README.md` with the final command interface, stage definitions, security boundary, timeouts, and failure guidance.
- Reviewer: Codex
- [x] Changed user-facing text follows the
  [writing guide](https://github.com/NVIDIA/nemoclaw-community/blob/main/WRITING.md)
  and
  [controlled-word list](https://github.com/NVIDIA/nemoclaw-community/blob/main/.agents/skills/_shared/controlled-words.md).
- [x] A public contributor can understand the changed text without internal
  company context.
- [ ] I reviewed any agent-generated text before submission.

## Release And Compliance

- [x] No secrets or credentials are included, including API keys, access tokens,
  passwords, local `.env` files, private certificates, or token caches.
- [x] No nonpublic project names, environment names, hostnames, URLs, ticket
  identifiers, workspace paths, logs, screenshots, or configuration values are
  included.
- [x] Third-party dependency changes are reflected in `THIRD-PARTY-NOTICES` — no dependency changes are included.
- [x] Public content uses sanitized examples and placeholders instead of private
  values.
- [x] I added my DCO sign-off declaration to this pull request description.

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>
