### PR TITLE
fix(outlook): sort thread messages locally

### DIFF
--- a/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/skills/outlook-email-search/scripts/get_thread.py
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/skills/outlook-email-search/scripts/get_thread.py
@@ -70,13 +70,18 @@ def fetch_thread(conversation_id: str, top: int) -> list[dict]:
     params = urllib.parse.urlencode({
         "$filter": f"conversationId eq '{safe_id}'",
         "$select": "id,subject,from,receivedDateTime,body,conversationId",
-        "$orderby": "receivedDateTime asc",
         "$top": str(min(top, 50)),
     })
     path = f"{mailbox}/messages?{params}"
 
     data = _graph_get(path)
-    messages = data.get("value", [])
+    # Microsoft Graph rejects $filter on conversationId combined with $orderby
+    # as an InefficientFilter query. Thread responses are small and capped at 50,
+    # so sort them locally after the compatible filtered request succeeds.
+    messages = sorted(
+        data.get("value", []),
+        key=lambda msg: msg.get("receivedDateTime", ""),
+    )
 
     results = []
     for msg in messages:

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/tests/test_outlook_get_thread.py
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/tests/test_outlook_get_thread.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import urllib.parse
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import patch
+
+SCRIPT = (
+    Path(__file__).parents[2]
+    / "agents/hermes/skills/outlook-email-search/scripts/get_thread.py"
+)
+SPEC = importlib.util.spec_from_file_location("outlook_get_thread", SCRIPT)
+assert SPEC and SPEC.loader
+GET_THREAD = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = GET_THREAD
+SPEC.loader.exec_module(GET_THREAD)
+
+
+class OutlookGetThreadTest(TestCase):
+    def test_filtered_request_is_sorted_locally(self) -> None:
+        graph_response = {
+            "value": [
+                {
+                    "id": "latest",
+                    "receivedDateTime": "2026-08-15T12:00:00Z",
+                    "body": {"contentType": "text", "content": "Latest"},
+                },
+                {
+                    "id": "earliest",
+                    "receivedDateTime": "2026-08-15T10:00:00Z",
+                    "body": {"contentType": "text", "content": "Earliest"},
+                },
+                {
+                    "id": "middle",
+                    "receivedDateTime": "2026-08-15T11:00:00Z",
+                    "body": {"contentType": "text", "content": "Middle"},
+                },
+            ]
+        }
+
+        with patch.object(GET_THREAD, "_graph_get", return_value=graph_response) as get_:
+            messages = GET_THREAD.fetch_thread("conversation'quoted", 100)
+
+        path = get_.call_args.args[0]
+        query = urllib.parse.parse_qs(urllib.parse.urlsplit(path).query)
+        self.assertEqual(
+            query["$filter"],
+            ["conversationId eq 'conversation''quoted'"],
+        )
+        self.assertNotIn("$orderby", query)
+        self.assertEqual(query["$top"], ["50"])
+        self.assertEqual(
+            [message["id"] for message in messages],
+            ["earliest", "middle", "latest"],
+        )
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Related Issue

Closes #62

## Description

Microsoft Graph rejects a `conversationId` filter combined with server-side
`receivedDateTime` ordering as an `InefficientFilter` query. This change keeps
the conversation filter, removes the incompatible `$orderby`, and sorts the
capped response locally before formatting it.

The Outlook thread command keeps its existing arguments and output schema. A
regression test verifies quote escaping, the retained filter, the 50-message
cap, the absence of `$orderby`, and chronological output from an out-of-order
Graph response.

## Verification

- [x] `python3 scripts/check_license_headers.py --check` — all 368 checked source files passed.
- [x] `python3 scripts/check_label_taxonomy.py --check` — 64 labels are valid; no governance metadata changed.
- [x] `git diff --check origin/main...HEAD` — passed.
- [x] Relevant example setup or syntax checks — `python3 -m pytest -q examples/recipes/nvidia/developer-community-chief-of-staff/scripts/tests examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/tests` passed with 104 tests and 6 subtests in an isolated test environment.
- [x] `python3 -m unittest examples/recipes/nvidia/developer-community-chief-of-staff/scripts/tests/test_outlook_get_thread.py` — passed.

No live Microsoft Graph request was made. The regression does not require an
external service and mocks the Graph response at the existing request boundary.

## Documentation Writer Review

- [x] Documentation writer review completed for the final changes
- Result: `no-docs-needed`
- Evidence or justification: The command-line arguments, JSON output, setup, and permissions are unchanged. The change restores the documented thread-fetch behavior and adds a code comment plus regression test.
- Reviewer: Codex
- [x] Changed user-facing text follows the
  [writing guide](https://github.com/NVIDIA/nemoclaw-community/blob/main/WRITING.md)
  and
  [controlled-word list](https://github.com/NVIDIA/nemoclaw-community/blob/main/.agents/skills/_shared/controlled-words.md).
- [x] A public contributor can understand the changed text without internal
  company context.
- [ ] I reviewed any agent-generated text before submission.

## Release And Compliance

- [x] No secrets or credentials are included, including API keys, access tokens,
  passwords, local `.env` files, private certificates, or token caches.
- [x] No nonpublic project names, environment names, hostnames, URLs, ticket
  identifiers, workspace paths, logs, screenshots, or configuration values are
  included.
- [x] Third-party dependency changes are reflected in `THIRD-PARTY-NOTICES` — no dependency changes are included.
- [x] Public content uses sanitized examples and placeholders instead of private
  values.
- [x] I added my DCO sign-off declaration to this pull request description.

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>
