### PR TITLE
feat(slack): ground summaries in source history

### DIFF
--- a/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/skills/slack-channel-summarizer/SKILL.md
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/skills/slack-channel-summarizer/SKILL.md
@@ -5,21 +5,22 @@ description: Read and summarize Slack channel history from inside the NemoClaw s
 
 # slack-channel-summarizer
 
-Use this skill to resolve a Slack channel and read its history.
+Use this skill to resolve a Slack channel and produce a summary that is bounded
+to retrieved history and linked to source messages.
 
 ## When to use
 
-- Summarize recent activity in a channel
-- Review conversation history for a time range
-- Check what was discussed in a channel before answering a question
+- Summarize recent activity in a channel.
+- Review conversation history for a time range.
+- Check what was discussed in a channel before answering a question.
 
 ## Instructions
 
-- The best way to access slack given the sandbox is through the provided python scripts.
-- Direct curl requests, or Python scripts, are unlikely to succeed
-- The SLACK_BOT_TOKEN contains a placeholder env var that is resolved by the sandbox on egress
-- Only refer to helper scripts that actually exist in this sandbox image
-
+- Use the provided Python helpers. Do not use direct `curl` requests or create
+  another Slack client.
+- `SLACK_BOT_TOKEN` contains a placeholder that OpenShell resolves on egress.
+- Do not print the access token or include it in a command argument.
+- Summarize only messages returned by `fetch_slack_history.py`.
 
 ## Procedure
 
@@ -32,47 +33,87 @@ If the request comes from a tagged Slack channel and the runtime context already
 gives you the current channel ID, treat that as the resolved channel ID for
 phrases like "this channel".
 
-Otherwise, use your slack channel finder skill.
+Otherwise, use your Slack channel finder skill.
 
-### 2. Read channel history
+### 2. Read bounded channel history
 
-Use the existing channel-description helper with the resolved channel ID. It
-includes recent human messages and channel metadata that are sufficient for a
-summary:
+For a recent-message request, run:
 
 ```bash
-/usr/bin/python3 /sandbox/.hermes-data/skills/slack-channel-finder/scripts/describe_slack_channel.py \
-  --channel-id CHANNEL_ID --history-limit 15
+/usr/bin/python3 /sandbox/.hermes-data/skills/slack-channel-summarizer/scripts/fetch_slack_history.py \
+  --channel-id CHANNEL_ID --message-limit 10 --page-cap 10
 ```
 
-Useful variants:
+For a time range, pass inclusive `--oldest` and `--latest` boundaries as Slack
+timestamps or ISO 8601 timestamps. For example:
 
 ```bash
-/usr/bin/python3 /sandbox/.hermes-data/skills/slack-channel-finder/scripts/describe_slack_channel.py \
-  --channel-id CHANNEL_ID --history-limit 30 --replies
+oldest="$(date -u -d '7 days ago' +%s)"
+latest="$(date -u +%s)"
+/usr/bin/python3 /sandbox/.hermes-data/skills/slack-channel-summarizer/scripts/fetch_slack_history.py \
+  --channel-id CHANNEL_ID \
+  --oldest "$oldest" --latest "$latest" \
+  --message-limit 100 --page-cap 10 \
+  --replies --thread-cap 10 --reply-limit 20 --thread-page-cap 3
 ```
 
-```bash
-/usr/bin/python3 /sandbox/.hermes-data/skills/slack-channel-finder/scripts/describe_slack_channel.py \
-  --channel-id CHANNEL_ID --history-limit 15 --resolve-users
-```
+The helper filters bot and system messages while it paginates. The limits and
+page caps bound the amount of channel and thread history that it returns. The
+hard maxima are 200 human channel messages, 25 history pages, 10 thread roots,
+20 human replies per thread, and 5 pages per thread.
 
-Interpret common failures explicitly:
+### 3. Check the evidence contract
 
-- `not_in_channel`
-  The bot is not a member of that channel.
-- `missing_scope` with `needed=channels:history`
-  The bot cannot read public-channel history.
-- `missing_scope` with `needed=groups:history`
-  The bot cannot read private-channel history.
-- `channel_not_found`
-  The ID is wrong or unavailable to the token.
+Read these fields before you summarize:
 
-### 3. Summarize
+- `ok`: required history and source links were retrieved.
+- `empty`: the completed query returned no matching human messages.
+- `coverage.requested_range`: boundaries sent to Slack.
+- `coverage.retrieved_range`: oldest and latest messages inspected.
+- `coverage.inspected_messages`, `coverage.human_messages`, and
+  `coverage.pages`: the amount of history processed.
+- `coverage.complete` and `coverage.truncation_reasons`: whether the history
+  query reached its boundary without hitting a cap.
+- `threads.complete` and `threads.truncation_reasons`: whether requested thread
+  expansion reached its bounds.
+- `messages[].timestamp`, `messages[].permalink`, and `messages[].citation`:
+  source metadata for each message.
+- `messages[].text_truncated`: whether the helper capped that message's text.
+- `messages[].thread_replies[]`: bounded replies. Each reply includes
+  `thread_root_ts` so that its relationship to the root is explicit.
 
-Summarize only what the user asked for. Good defaults are:
+Do not summarize when `ok` is `false`. Report the returned `stage`, `error`, and
+actionable fields instead. Common errors include:
 
-- time range covered
-- main topics
-- active participants
-- decisions or action items
+- `invalid_auth`: check the configured bot access token.
+- `not_in_channel`: invite the bot to the channel.
+- `missing_scope`: add the scope named in `needed`, then reinstall the app.
+- `rate_limited`: wait for the returned `retry_after` interval.
+- `channel_not_found`: check the channel ID and the bot's access.
+
+An `ok: true` result with `empty: true` and `coverage.complete: true` means that
+the requested range contains no matching human messages. If
+`coverage.complete` is false, disclose the truncation reasons. Do not describe
+an incomplete empty result as no channel activity.
+
+### 4. Write the grounded summary
+
+Start with a short coverage statement that gives the requested range, retrieved
+range, number of messages inspected, number of human messages used, and any
+history or thread truncation.
+
+Use only retrieved message text for these sections:
+
+- Main topics
+- Active participants
+- Decisions and action items
+- Unresolved questions
+
+Copy the `citation` value at the end of every factual bullet about a theme,
+decision, action item, or unresolved question. Cite more than one representative
+message when a conclusion combines several messages. A citation is a Slack
+permalink and preserves the workspace's existing access controls.
+
+If there is not enough retrieved evidence for a requested conclusion, say that
+the retrieved messages do not establish it. Do not add general patterns,
+background assumptions, or conclusions from channel metadata alone.

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/skills/slack-channel-summarizer/scripts/fetch_slack_history.py
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/skills/slack-channel-summarizer/scripts/fetch_slack_history.py
@@ -19,7 +19,6 @@ from typing import Any
 
 from slack_api_common import get_slack_bot_token
 
-
 API_BASE = "https://slack.com/api"
 CHANNEL_ID_RE = re.compile(r"^[CGD][A-Z0-9]{8,}$")
 MAX_MESSAGE_LIMIT = 200
@@ -114,7 +113,7 @@ def slack_get(token: str, method: str, params: dict[str, str]) -> dict[str, Any]
             "error": "http_error",
             "http_status": error.code,
         }
-    except urllib.error.URLError:
+    except OSError:
         return {"ok": False, "error": "network_error"}
     except (UnicodeDecodeError, json.JSONDecodeError):
         return {"ok": False, "error": "invalid_json"}
@@ -157,7 +156,9 @@ def normalize_time_boundary(value: str) -> str:
         try:
             instant = dt.datetime.fromisoformat(iso_value)
         except ValueError as error:
-            raise ValueError("expected a Slack timestamp or ISO 8601 timestamp") from error
+            raise ValueError(
+                "expected a Slack timestamp or ISO 8601 timestamp"
+            ) from error
         if instant.tzinfo is None:
             instant = instant.replace(tzinfo=dt.timezone.utc)
         parsed = Decimal(str(instant.timestamp()))
@@ -341,7 +342,9 @@ def fetch_history_pages(
             "history",
         )
         raw_messages = data.get("messages", [])
-        if not isinstance(raw_messages, list):
+        if not isinstance(raw_messages, list) or not all(
+            isinstance(message, dict) for message in raw_messages
+        ):
             raise SlackApiFailure("history", "invalid_messages")
 
         pages += 1
@@ -689,7 +692,11 @@ def main() -> int:
 
     token = get_slack_bot_token()
     if not token:
-        print(json.dumps({"ok": False, "stage": "authentication", "error": "missing_token"}))
+        print(
+            json.dumps(
+                {"ok": False, "stage": "authentication", "error": "missing_token"}
+            )
+        )
         return 1
 
     result = collect_channel_history(

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/skills/slack-channel-summarizer/scripts/fetch_slack_history.py
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/skills/slack-channel-summarizer/scripts/fetch_slack_history.py
@@ -1,0 +1,712 @@
+#!/usr/bin/python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Fetch bounded Slack history with coverage and source-link metadata."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Callable
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from slack_api_common import get_slack_bot_token
+
+
+API_BASE = "https://slack.com/api"
+CHANNEL_ID_RE = re.compile(r"^[CGD][A-Z0-9]{8,}$")
+MAX_MESSAGE_LIMIT = 200
+MAX_PAGE_CAP = 25
+MAX_THREAD_CAP = 10
+MAX_REPLY_LIMIT = 20
+MAX_THREAD_PAGE_CAP = 5
+MAX_PAGE_SIZE = 100
+MAX_TEXT_CHARS = 4000
+
+SKIP_SUBTYPES = {
+    "bot_message",
+    "channel_archive",
+    "channel_join",
+    "channel_leave",
+    "channel_name",
+    "channel_purpose",
+    "channel_topic",
+    "channel_unarchive",
+    "ekm_access_denied",
+    "message_deleted",
+    "message_replied",
+    "tombstone",
+}
+
+ApiCall = Callable[[str, str, dict[str, str]], dict[str, Any]]
+
+
+class SlackApiFailure(RuntimeError):
+    """A sanitized Slack API or transport failure."""
+
+    def __init__(
+        self,
+        stage: str,
+        error: str,
+        *,
+        needed: str | None = None,
+        provided: str | None = None,
+        retry_after: str | None = None,
+        http_status: int | None = None,
+    ) -> None:
+        super().__init__(error)
+        self.stage = stage
+        self.error = error
+        self.needed = needed
+        self.provided = provided
+        self.retry_after = retry_after
+        self.http_status = http_status
+
+    def result(self, channel_id: str) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "ok": False,
+            "channel_id": channel_id,
+            "stage": self.stage,
+            "error": self.error,
+        }
+        for key, value in (
+            ("needed", self.needed),
+            ("provided", self.provided),
+            ("retry_after", self.retry_after),
+            ("http_status", self.http_status),
+        ):
+            if value not in (None, ""):
+                result[key] = value
+        return result
+
+
+def slack_get(token: str, method: str, params: dict[str, str]) -> dict[str, Any]:
+    """Call one Slack Web API GET method without exposing the access token."""
+    query = urllib.parse.urlencode(params)
+    request = urllib.request.Request(
+        f"{API_BASE}/{method}?{query}",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+        },
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        if error.code == 429:
+            return {
+                "ok": False,
+                "error": "rate_limited",
+                "http_status": 429,
+                "retry_after": error.headers.get("Retry-After"),
+            }
+        return {
+            "ok": False,
+            "error": "http_error",
+            "http_status": error.code,
+        }
+    except urllib.error.URLError:
+        return {"ok": False, "error": "network_error"}
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return {"ok": False, "error": "invalid_json"}
+
+
+def checked_call(
+    api_call: ApiCall,
+    token: str,
+    method: str,
+    params: dict[str, str],
+    stage: str,
+) -> dict[str, Any]:
+    data = api_call(token, method, params)
+    if not isinstance(data, dict):
+        raise SlackApiFailure(stage, "invalid_response")
+    if not data.get("ok"):
+        error_code = str(data.get("error") or "unknown_error")
+        if error_code == "ratelimited":
+            error_code = "rate_limited"
+        raise SlackApiFailure(
+            stage,
+            error_code,
+            needed=data.get("needed"),
+            provided=data.get("provided"),
+            retry_after=data.get("retry_after"),
+            http_status=data.get("http_status"),
+        )
+    return data
+
+
+def normalize_time_boundary(value: str) -> str:
+    """Normalize a Slack timestamp or ISO 8601 timestamp for API use."""
+    raw = value.strip()
+    if not raw:
+        return ""
+    try:
+        parsed = Decimal(raw)
+    except InvalidOperation:
+        iso_value = raw[:-1] + "+00:00" if raw.endswith("Z") else raw
+        try:
+            instant = dt.datetime.fromisoformat(iso_value)
+        except ValueError as error:
+            raise ValueError("expected a Slack timestamp or ISO 8601 timestamp") from error
+        if instant.tzinfo is None:
+            instant = instant.replace(tzinfo=dt.timezone.utc)
+        parsed = Decimal(str(instant.timestamp()))
+    if not parsed.is_finite() or parsed < 0:
+        raise ValueError("timestamp must be a finite non-negative value")
+    normalized = format(parsed, "f")
+    if "." in normalized:
+        normalized = normalized.rstrip("0").rstrip(".")
+    return normalized
+
+
+def timestamp_iso(value: str, stage: str = "history") -> str:
+    try:
+        instant = dt.datetime.fromtimestamp(float(value), tz=dt.timezone.utc)
+    except (OverflowError, OSError, ValueError) as error:
+        raise SlackApiFailure(stage, "invalid_message_timestamp") from error
+    return instant.isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def citation_for(timestamp: str, user_id: str, permalink: str) -> str:
+    """Return a Markdown citation that identifies one retrieved Slack message."""
+    instant = dt.datetime.fromtimestamp(float(timestamp), tz=dt.timezone.utc)
+    label = instant.strftime("%Y-%m-%d %H:%M UTC")
+    return f"[{label} — {user_id}]({permalink})"
+
+
+def is_human_message(message: dict[str, Any]) -> bool:
+    if message.get("bot_id") or message.get("subtype") in SKIP_SUBTYPES:
+        return False
+    if not message.get("user"):
+        return False
+    return bool(str(message.get("text") or "").strip())
+
+
+def next_cursor(data: dict[str, Any]) -> str:
+    metadata = data.get("response_metadata") or {}
+    if not isinstance(metadata, dict):
+        return ""
+    return str(metadata.get("next_cursor") or "").strip()
+
+
+def range_metadata(oldest: str, latest: str) -> dict[str, str | None]:
+    return {
+        "oldest": oldest or None,
+        "oldest_timestamp": timestamp_iso(oldest) if oldest else None,
+        "latest": latest or None,
+        "latest_timestamp": timestamp_iso(latest) if latest else None,
+    }
+
+
+def update_range(current: list[Decimal], messages: list[dict[str, Any]]) -> None:
+    for message in messages:
+        try:
+            timestamp = Decimal(str(message.get("ts") or ""))
+            if timestamp.is_finite():
+                current.append(timestamp)
+        except InvalidOperation:
+            continue
+
+
+def message_timestamp(message: dict[str, Any], stage: str) -> Decimal:
+    try:
+        timestamp = Decimal(str(message.get("ts") or ""))
+    except InvalidOperation as error:
+        raise SlackApiFailure(stage, "invalid_message_timestamp") from error
+    if not timestamp.is_finite():
+        raise SlackApiFailure(stage, "invalid_message_timestamp")
+    return timestamp
+
+
+def reply_count(message: dict[str, Any]) -> int:
+    try:
+        return max(0, int(message.get("reply_count") or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def permalink_for(
+    api_call: ApiCall,
+    token: str,
+    channel_id: str,
+    timestamp: str,
+    cache: dict[str, str],
+) -> str:
+    if timestamp in cache:
+        return cache[timestamp]
+    data = checked_call(
+        api_call,
+        token,
+        "chat.getPermalink",
+        {"channel": channel_id, "message_ts": timestamp},
+        "permalink",
+    )
+    permalink = str(data.get("permalink") or "").strip()
+    if not permalink:
+        raise SlackApiFailure("permalink", "missing_permalink")
+    cache[timestamp] = permalink
+    return permalink
+
+
+def source_message(
+    message: dict[str, Any],
+    *,
+    channel_id: str,
+    api_call: ApiCall,
+    token: str,
+    permalink_cache: dict[str, str],
+    root_timestamp: str | None = None,
+    stage: str = "history",
+) -> dict[str, Any]:
+    timestamp = str(message.get("ts") or "").strip()
+    if not timestamp:
+        raise SlackApiFailure(stage, "missing_message_timestamp")
+    iso_timestamp = timestamp_iso(timestamp, stage)
+    user_id = str(message.get("user") or "unknown-user")
+    permalink = permalink_for(
+        api_call,
+        token,
+        channel_id,
+        timestamp,
+        permalink_cache,
+    )
+    raw_text = str(message.get("text") or "")
+    rendered: dict[str, Any] = {
+        "ts": timestamp,
+        "timestamp": iso_timestamp,
+        "user_id": user_id,
+        "text": raw_text[:MAX_TEXT_CHARS],
+        "text_truncated": len(raw_text) > MAX_TEXT_CHARS,
+        "permalink": permalink,
+        "citation": citation_for(timestamp, user_id, permalink),
+        "reply_count": reply_count(message),
+    }
+    thread_timestamp = root_timestamp or str(message.get("thread_ts") or "").strip()
+    if thread_timestamp:
+        rendered["thread_root_ts"] = thread_timestamp
+    return rendered
+
+
+def fetch_history_pages(
+    api_call: ApiCall,
+    token: str,
+    channel_id: str,
+    *,
+    oldest: str,
+    latest: str,
+    message_limit: int,
+    page_cap: int,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    selected: list[dict[str, Any]] = []
+    inspected_timestamps: list[Decimal] = []
+    inspected_messages = 0
+    pages = 0
+    cursor = ""
+    has_more = False
+    fallback_latest = ""
+    fallback_unavailable = False
+    page_latest = latest
+    workspace_history_limited = False
+    extra_human_message = False
+    page_size = min(MAX_PAGE_SIZE, message_limit)
+
+    while pages < page_cap:
+        params = {
+            "channel": channel_id,
+            "limit": str(page_size),
+            "inclusive": "false" if fallback_latest else "true",
+        }
+        if oldest:
+            params["oldest"] = oldest
+        if page_latest:
+            params["latest"] = page_latest
+        if cursor:
+            params["cursor"] = cursor
+
+        data = checked_call(
+            api_call,
+            token,
+            "conversations.history",
+            params,
+            "history",
+        )
+        raw_messages = data.get("messages", [])
+        if not isinstance(raw_messages, list):
+            raise SlackApiFailure("history", "invalid_messages")
+
+        pages += 1
+        inspected_messages += len(raw_messages)
+        update_range(inspected_timestamps, raw_messages)
+        for message in raw_messages:
+            if not isinstance(message, dict) or not is_human_message(message):
+                continue
+            message_timestamp(message, "history")
+            if len(selected) < message_limit:
+                selected.append(message)
+            else:
+                extra_human_message = True
+
+        cursor = next_cursor(data)
+        has_more = bool(data.get("has_more"))
+        fallback_latest = ""
+        fallback_unavailable = False
+        if has_more and not cursor:
+            page_timestamps: list[Decimal] = []
+            update_range(page_timestamps, raw_messages)
+            if page_timestamps:
+                candidate = min(page_timestamps)
+                if (not oldest or candidate > Decimal(oldest)) and (
+                    not page_latest or candidate < Decimal(page_latest)
+                ):
+                    fallback_latest = format(candidate, "f")
+                else:
+                    fallback_unavailable = True
+            else:
+                fallback_unavailable = True
+        workspace_history_limited = workspace_history_limited or bool(
+            data.get("is_limited")
+        )
+        if len(selected) >= message_limit:
+            break
+        if cursor:
+            continue
+        if fallback_latest and pages < page_cap:
+            page_latest = fallback_latest
+            continue
+        if not cursor:
+            break
+
+    truncation_reasons: list[str] = []
+    if len(selected) >= message_limit and (extra_human_message or cursor or has_more):
+        truncation_reasons.append("message_limit")
+    if (
+        (cursor or fallback_latest)
+        and pages >= page_cap
+        and "message_limit" not in truncation_reasons
+    ):
+        truncation_reasons.append("page_cap")
+    if has_more and not cursor and fallback_unavailable:
+        truncation_reasons.append("history_has_more_without_cursor")
+    if workspace_history_limited:
+        truncation_reasons.append("workspace_history_limit")
+
+    retrieved_oldest = str(min(inspected_timestamps)) if inspected_timestamps else ""
+    retrieved_latest = str(max(inspected_timestamps)) if inspected_timestamps else ""
+    coverage = {
+        "requested_range": range_metadata(oldest, latest),
+        "retrieved_range": range_metadata(retrieved_oldest, retrieved_latest),
+        "pages": pages,
+        "inspected_messages": inspected_messages,
+        "human_messages": len(selected),
+        "message_limit": message_limit,
+        "page_cap": page_cap,
+        "complete": not truncation_reasons,
+        "truncated": bool(truncation_reasons),
+        "truncation_reasons": truncation_reasons,
+    }
+    selected.sort(key=lambda message: message_timestamp(message, "history"))
+    return selected, coverage
+
+
+def fetch_thread_replies(
+    api_call: ApiCall,
+    token: str,
+    channel_id: str,
+    root_timestamp: str,
+    *,
+    reply_limit: int,
+    page_cap: int,
+    permalink_cache: dict[str, str],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    selected: list[dict[str, Any]] = []
+    inspected_messages = 0
+    pages = 0
+    cursor = ""
+    has_more = False
+    extra_human_reply = False
+    page_size = min(MAX_PAGE_SIZE, reply_limit + 1)
+
+    while pages < page_cap:
+        params = {
+            "channel": channel_id,
+            "ts": root_timestamp,
+            "limit": str(page_size),
+            "inclusive": "true",
+        }
+        if cursor:
+            params["cursor"] = cursor
+        data = checked_call(
+            api_call,
+            token,
+            "conversations.replies",
+            params,
+            "thread_replies",
+        )
+        raw_messages = data.get("messages", [])
+        if not isinstance(raw_messages, list):
+            raise SlackApiFailure("thread_replies", "invalid_messages")
+
+        pages += 1
+        for message in raw_messages:
+            if not isinstance(message, dict):
+                continue
+            if str(message.get("ts") or "") == root_timestamp:
+                continue
+            inspected_messages += 1
+            if not is_human_message(message):
+                continue
+            message_timestamp(message, "thread_replies")
+            if len(selected) < reply_limit:
+                selected.append(message)
+            else:
+                extra_human_reply = True
+
+        cursor = next_cursor(data)
+        has_more = bool(data.get("has_more"))
+        if len(selected) >= reply_limit or not cursor:
+            break
+
+    truncation_reasons: list[str] = []
+    if len(selected) >= reply_limit and (extra_human_reply or cursor or has_more):
+        truncation_reasons.append("reply_limit")
+    if cursor and pages >= page_cap and "reply_limit" not in truncation_reasons:
+        truncation_reasons.append("thread_page_cap")
+    if has_more and not cursor:
+        truncation_reasons.append("replies_have_more_without_cursor")
+
+    selected.sort(key=lambda message: message_timestamp(message, "thread_replies"))
+    replies = [
+        source_message(
+            message,
+            channel_id=channel_id,
+            api_call=api_call,
+            token=token,
+            permalink_cache=permalink_cache,
+            root_timestamp=root_timestamp,
+            stage="thread_replies",
+        )
+        for message in selected
+    ]
+    coverage = {
+        "root_ts": root_timestamp,
+        "pages": pages,
+        "inspected_messages": inspected_messages,
+        "human_replies": len(replies),
+        "reply_limit": reply_limit,
+        "page_cap": page_cap,
+        "complete": not truncation_reasons,
+        "truncated": bool(truncation_reasons),
+        "truncation_reasons": truncation_reasons,
+    }
+    return replies, coverage
+
+
+def collect_channel_history(
+    token: str,
+    channel_id: str,
+    *,
+    oldest: str = "",
+    latest: str = "",
+    message_limit: int = 50,
+    page_cap: int = 10,
+    include_replies: bool = False,
+    thread_cap: int = 10,
+    reply_limit: int = 20,
+    thread_page_cap: int = 3,
+    api_call: ApiCall = slack_get,
+) -> dict[str, Any]:
+    """Return bounded, source-linked history or one sanitized failure."""
+    try:
+        raw_messages, coverage = fetch_history_pages(
+            api_call,
+            token,
+            channel_id,
+            oldest=oldest,
+            latest=latest,
+            message_limit=message_limit,
+            page_cap=page_cap,
+        )
+        permalink_cache: dict[str, str] = {}
+        messages = [
+            source_message(
+                message,
+                channel_id=channel_id,
+                api_call=api_call,
+                token=token,
+                permalink_cache=permalink_cache,
+            )
+            for message in raw_messages
+        ]
+
+        thread_result: dict[str, Any] = {
+            "requested": include_replies,
+            "roots_available": 0,
+            "roots_expanded": 0,
+            "replies_included": 0,
+            "thread_cap": thread_cap,
+            "reply_limit": reply_limit,
+            "page_cap_per_thread": thread_page_cap,
+            "complete": True,
+            "truncated": False,
+            "truncation_reasons": [],
+            "items": [],
+        }
+        if include_replies:
+            roots = [
+                (raw, rendered)
+                for raw, rendered in zip(raw_messages, messages)
+                if reply_count(raw) > 0
+                and (
+                    not raw.get("thread_ts")
+                    or str(raw.get("thread_ts")) == str(raw.get("ts"))
+                )
+            ]
+            thread_result["roots_available"] = len(roots)
+            for raw, rendered in roots[:thread_cap]:
+                replies, reply_coverage = fetch_thread_replies(
+                    api_call,
+                    token,
+                    channel_id,
+                    str(raw.get("ts") or ""),
+                    reply_limit=reply_limit,
+                    page_cap=thread_page_cap,
+                    permalink_cache=permalink_cache,
+                )
+                rendered["thread_replies"] = replies
+                thread_result["items"].append(reply_coverage)
+                thread_result["roots_expanded"] += 1
+                thread_result["replies_included"] += len(replies)
+
+            reasons: list[str] = []
+            if len(roots) > thread_cap:
+                reasons.append("thread_cap")
+            for item in thread_result["items"]:
+                for reason in item["truncation_reasons"]:
+                    if reason not in reasons:
+                        reasons.append(reason)
+            thread_result["complete"] = not reasons
+            thread_result["truncated"] = bool(reasons)
+            thread_result["truncation_reasons"] = reasons
+
+        return {
+            "ok": True,
+            "channel_id": channel_id,
+            "empty": not messages,
+            "coverage": coverage,
+            "threads": thread_result,
+            "messages": messages,
+        }
+    except SlackApiFailure as error:
+        return error.result(channel_id)
+
+
+def bounded_positive_int(name: str, maximum: int) -> Callable[[str], int]:
+    def parse(value: str) -> int:
+        parsed = int(value)
+        if parsed < 1 or parsed > maximum:
+            raise argparse.ArgumentTypeError(f"{name} must be between 1 and {maximum}")
+        return parsed
+
+    return parse
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--channel-id", required=True, help="Slack channel ID")
+    parser.add_argument(
+        "--oldest",
+        default="",
+        help="Oldest inclusive Slack timestamp or ISO 8601 timestamp",
+    )
+    parser.add_argument(
+        "--latest",
+        default="",
+        help="Latest inclusive Slack timestamp or ISO 8601 timestamp",
+    )
+    parser.add_argument(
+        "--message-limit",
+        type=bounded_positive_int("message limit", MAX_MESSAGE_LIMIT),
+        default=50,
+        help=f"Maximum human messages to return (default 50; maximum {MAX_MESSAGE_LIMIT})",
+    )
+    parser.add_argument(
+        "--page-cap",
+        type=bounded_positive_int("page cap", MAX_PAGE_CAP),
+        default=10,
+        help=f"Maximum history pages to inspect (default 10; maximum {MAX_PAGE_CAP})",
+    )
+    parser.add_argument(
+        "--replies",
+        action="store_true",
+        help="Include bounded thread replies",
+    )
+    parser.add_argument(
+        "--thread-cap",
+        type=bounded_positive_int("thread cap", MAX_THREAD_CAP),
+        default=10,
+        help=f"Maximum thread roots to expand (default 10; maximum {MAX_THREAD_CAP})",
+    )
+    parser.add_argument(
+        "--reply-limit",
+        type=bounded_positive_int("reply limit", MAX_REPLY_LIMIT),
+        default=20,
+        help=f"Maximum human replies per thread (default 20; maximum {MAX_REPLY_LIMIT})",
+    )
+    parser.add_argument(
+        "--thread-page-cap",
+        type=bounded_positive_int("thread page cap", MAX_THREAD_PAGE_CAP),
+        default=3,
+        help=(
+            "Maximum pages to inspect per thread "
+            f"(default 3; maximum {MAX_THREAD_PAGE_CAP})"
+        ),
+    )
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    if not CHANNEL_ID_RE.fullmatch(args.channel_id):
+        parser.error("--channel-id must be a Slack channel ID such as C0123456789")
+    try:
+        oldest = normalize_time_boundary(args.oldest)
+        latest = normalize_time_boundary(args.latest)
+    except ValueError as error:
+        parser.error(str(error))
+    if oldest and latest and Decimal(oldest) > Decimal(latest):
+        parser.error("--oldest must not be later than --latest")
+
+    token = get_slack_bot_token()
+    if not token:
+        print(json.dumps({"ok": False, "stage": "authentication", "error": "missing_token"}))
+        return 1
+
+    result = collect_channel_history(
+        token,
+        args.channel_id,
+        oldest=oldest,
+        latest=latest,
+        message_limit=args.message_limit,
+        page_cap=args.page_cap,
+        include_replies=args.replies,
+        thread_cap=args.thread_cap,
+        reply_limit=args.reply_limit,
+        thread_page_cap=args.thread_page_cap,
+    )
+    print(json.dumps(result, ensure_ascii=False))
+    return 0 if result.get("ok") else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/tests/test_slack_summary_history.py
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/tests/test_slack_summary_history.py
@@ -3,10 +3,17 @@
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import io
+import json
 import sys
+import threading
+import urllib.parse
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from unittest import TestCase
+from unittest.mock import patch
 
 
 HERMES_DIR = Path(__file__).resolve().parents[1]
@@ -56,6 +63,159 @@ class ScriptedApi:
 
 
 class SlackSummaryHistoryTest(TestCase):
+    def test_cli_uses_real_http_for_history_permalinks_and_threads(self) -> None:
+        class SlackHandler(BaseHTTPRequestHandler):
+            requests = []
+
+            def log_message(self, _format, *args) -> None:
+                pass
+
+            def respond(self, payload) -> None:
+                body = json.dumps(payload).encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def do_GET(self) -> None:
+                parsed = urllib.parse.urlparse(self.path)
+                query = {
+                    key: values[-1]
+                    for key, values in urllib.parse.parse_qs(parsed.query).items()
+                }
+                type(self).requests.append(
+                    (parsed.path, query, self.headers.get("Authorization"))
+                )
+
+                if parsed.path == "/api/conversations.history":
+                    if query.get("cursor") == "history-page-2":
+                        self.respond(
+                            {
+                                "ok": True,
+                                "messages": [message("1700000100.000001", "Oldest")],
+                                "response_metadata": {"next_cursor": ""},
+                            }
+                        )
+                    else:
+                        self.respond(
+                            {
+                                "ok": True,
+                                "messages": [
+                                    message("1700000300.000001", "bot", bot_id="B123"),
+                                    message(
+                                        "1700000200.000001",
+                                        "Root",
+                                        reply_count=1,
+                                        thread_ts="1700000200.000001",
+                                    ),
+                                ],
+                                "response_metadata": {
+                                    "next_cursor": "history-page-2"
+                                },
+                            }
+                        )
+                    return
+
+                if parsed.path == "/api/conversations.replies":
+                    self.respond(
+                        {
+                            "ok": True,
+                            "messages": [
+                                message(
+                                    "1700000200.000001",
+                                    "Root",
+                                    reply_count=1,
+                                    thread_ts="1700000200.000001",
+                                ),
+                                message(
+                                    "1700000210.000001",
+                                    "Reply",
+                                    user="U22222222",
+                                    thread_ts="1700000200.000001",
+                                ),
+                            ],
+                            "response_metadata": {"next_cursor": ""},
+                        }
+                    )
+                    return
+
+                if parsed.path == "/api/chat.getPermalink":
+                    self.respond(permalink(query["message_ts"]))
+                    return
+
+                self.respond({"ok": False, "error": "unexpected_method"})
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), SlackHandler)
+        server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+        server_thread.start()
+        output = io.StringIO()
+        arguments = [
+            str(SCRIPT),
+            "--channel-id",
+            "C12345678",
+            "--oldest",
+            "1700000000",
+            "--latest",
+            "1700000400",
+            "--message-limit",
+            "2",
+            "--page-cap",
+            "3",
+            "--replies",
+            "--thread-cap",
+            "1",
+            "--reply-limit",
+            "2",
+            "--thread-page-cap",
+            "2",
+        ]
+        try:
+            with (
+                patch.object(HISTORY, "API_BASE", f"http://127.0.0.1:{server.server_port}/api"),
+                patch.object(HISTORY, "get_slack_bot_token", return_value="test-token"),
+                patch.object(sys, "argv", arguments),
+                contextlib.redirect_stdout(output),
+            ):
+                exit_code = HISTORY.main()
+        finally:
+            server.shutdown()
+            server.server_close()
+            server_thread.join(timeout=5)
+
+        result = json.loads(output.getvalue())
+        self.assertEqual(0, exit_code)
+        self.assertTrue(result["ok"])
+        self.assertEqual(2, result["coverage"]["pages"])
+        self.assertEqual(3, result["coverage"]["inspected_messages"])
+        self.assertTrue(result["coverage"]["complete"])
+        self.assertEqual(["Oldest", "Root"], [item["text"] for item in result["messages"]])
+        self.assertEqual(
+            ["Reply"],
+            [item["text"] for item in result["messages"][1]["thread_replies"]],
+        )
+        self.assertTrue(result["threads"]["complete"])
+        self.assertNotIn("test-token", output.getvalue())
+        self.assertEqual(
+            [
+                "/api/conversations.history",
+                "/api/conversations.history",
+                "/api/chat.getPermalink",
+                "/api/chat.getPermalink",
+                "/api/conversations.replies",
+                "/api/chat.getPermalink",
+            ],
+            [request[0] for request in SlackHandler.requests],
+        )
+        self.assertEqual(
+            "history-page-2",
+            SlackHandler.requests[1][1]["cursor"],
+        )
+        self.assertEqual(
+            {"Bearer test-token"},
+            {request[2] for request in SlackHandler.requests},
+        )
+
     def test_paginates_across_filtered_messages_and_applies_time_range(self) -> None:
         api = ScriptedApi(
             [

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/tests/test_slack_summary_history.py
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/tests/test_slack_summary_history.py
@@ -1,0 +1,492 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest import TestCase
+
+
+HERMES_DIR = Path(__file__).resolve().parents[1]
+SKILL_DIR = HERMES_DIR / "skills/slack-channel-summarizer"
+SCRIPT = SKILL_DIR / "scripts/fetch_slack_history.py"
+sys.path.insert(0, str(SCRIPT.parent))
+SPEC = importlib.util.spec_from_file_location("fetch_slack_history", SCRIPT)
+assert SPEC and SPEC.loader
+HISTORY = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = HISTORY
+SPEC.loader.exec_module(HISTORY)
+
+
+def message(
+    timestamp: str,
+    text: str,
+    *,
+    user: str = "U12345678",
+    **extra,
+):
+    return {"ts": timestamp, "text": text, "user": user, **extra}
+
+
+def permalink(timestamp: str):
+    return {
+        "ok": True,
+        "permalink": f"https://example.slack.com/archives/C12345678/p{timestamp.replace('.', '')}",
+    }
+
+
+class ScriptedApi:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def __call__(self, token, method, params):
+        self.calls.append((token, method, dict(params)))
+        if not self.responses:
+            raise AssertionError(f"unexpected Slack API call: {method}")
+        expected_method, response = self.responses.pop(0)
+        if method != expected_method:
+            raise AssertionError(f"expected {expected_method}, got {method}")
+        return response
+
+    def assert_complete(self, test):
+        test.assertEqual([], self.responses)
+
+
+class SlackSummaryHistoryTest(TestCase):
+    def test_paginates_across_filtered_messages_and_applies_time_range(self) -> None:
+        api = ScriptedApi(
+            [
+                (
+                    "conversations.history",
+                    {
+                        "ok": True,
+                        "messages": [
+                            message("1700000300.000001", "bot", bot_id="B123"),
+                            message("1700000200.000001", "Second"),
+                        ],
+                        "response_metadata": {"next_cursor": "next-page"},
+                    },
+                ),
+                (
+                    "conversations.history",
+                    {
+                        "ok": True,
+                        "messages": [message("1700000100.000001", "First")],
+                        "response_metadata": {"next_cursor": ""},
+                    },
+                ),
+                ("chat.getPermalink", permalink("1700000100.000001")),
+                ("chat.getPermalink", permalink("1700000200.000001")),
+            ]
+        )
+
+        result = HISTORY.collect_channel_history(
+            "token-placeholder",
+            "C12345678",
+            oldest="1700000000",
+            latest="1700000400",
+            message_limit=2,
+            page_cap=3,
+            api_call=api,
+        )
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(["First", "Second"], [item["text"] for item in result["messages"]])
+        self.assertEqual(2, result["coverage"]["pages"])
+        self.assertEqual(3, result["coverage"]["inspected_messages"])
+        self.assertEqual(2, result["coverage"]["human_messages"])
+        self.assertTrue(result["coverage"]["complete"])
+        self.assertEqual(
+            "1700000000",
+            result["coverage"]["requested_range"]["oldest"],
+        )
+        self.assertEqual(
+            "1700000300.000001",
+            result["coverage"]["retrieved_range"]["latest"],
+        )
+        first_params = api.calls[0][2]
+        second_params = api.calls[1][2]
+        self.assertEqual("1700000000", first_params["oldest"])
+        self.assertEqual("1700000400", first_params["latest"])
+        self.assertEqual("2", first_params["limit"])
+        self.assertEqual("next-page", second_params["cursor"])
+        api.assert_complete(self)
+
+    def test_message_limit_reports_truncation(self) -> None:
+        api = ScriptedApi(
+            [
+                (
+                    "conversations.history",
+                    {
+                        "ok": True,
+                        "messages": [
+                            message("1700000100.000001", "One"),
+                            message("1700000200.000001", "Two"),
+                            message("1700000300.000001", "Three"),
+                        ],
+                        "response_metadata": {"next_cursor": ""},
+                    },
+                ),
+                ("chat.getPermalink", permalink("1700000100.000001")),
+                ("chat.getPermalink", permalink("1700000200.000001")),
+            ]
+        )
+
+        result = HISTORY.collect_channel_history(
+            "token-placeholder",
+            "C12345678",
+            message_limit=2,
+            page_cap=2,
+            api_call=api,
+        )
+
+        self.assertEqual(2, len(result["messages"]))
+        self.assertTrue(result["coverage"]["truncated"])
+        self.assertEqual(["message_limit"], result["coverage"]["truncation_reasons"])
+        api.assert_complete(self)
+
+    def test_time_pagination_is_used_when_cursor_is_unavailable(self) -> None:
+        api = ScriptedApi(
+            [
+                (
+                    "conversations.history",
+                    {
+                        "ok": True,
+                        "messages": [
+                            message("1700000300.000001", "Newest"),
+                            message("1700000200.000001", "bot", bot_id="B123"),
+                        ],
+                        "has_more": True,
+                        "response_metadata": {"next_cursor": ""},
+                    },
+                ),
+                (
+                    "conversations.history",
+                    {
+                        "ok": True,
+                        "messages": [message("1700000100.000001", "Oldest")],
+                        "has_more": False,
+                        "response_metadata": {"next_cursor": ""},
+                    },
+                ),
+                ("chat.getPermalink", permalink("1700000100.000001")),
+                ("chat.getPermalink", permalink("1700000300.000001")),
+            ]
+        )
+
+        result = HISTORY.collect_channel_history(
+            "token-placeholder",
+            "C12345678",
+            oldest="1700000000",
+            latest="1700000400",
+            message_limit=3,
+            page_cap=3,
+            api_call=api,
+        )
+
+        self.assertTrue(result["coverage"]["complete"])
+        self.assertEqual(2, result["coverage"]["pages"])
+        self.assertEqual("1700000200.000001", api.calls[1][2]["latest"])
+        self.assertEqual("false", api.calls[1][2]["inclusive"])
+        self.assertEqual(
+            ["Oldest", "Newest"],
+            [item["text"] for item in result["messages"]],
+        )
+        api.assert_complete(self)
+
+    def test_page_cap_reports_incomplete_empty_coverage(self) -> None:
+        api = ScriptedApi(
+            [
+                (
+                    "conversations.history",
+                    {
+                        "ok": True,
+                        "messages": [message("1700000100.000001", "bot", bot_id="B123")],
+                        "response_metadata": {"next_cursor": "more"},
+                    },
+                )
+            ]
+        )
+
+        result = HISTORY.collect_channel_history(
+            "token-placeholder",
+            "C12345678",
+            message_limit=2,
+            page_cap=1,
+            api_call=api,
+        )
+
+        self.assertTrue(result["ok"])
+        self.assertTrue(result["empty"])
+        self.assertFalse(result["coverage"]["complete"])
+        self.assertEqual(["page_cap"], result["coverage"]["truncation_reasons"])
+
+    def test_workspace_history_limit_reports_incomplete_coverage(self) -> None:
+        api = ScriptedApi(
+            [
+                (
+                    "conversations.history",
+                    {
+                        "ok": True,
+                        "messages": [],
+                        "is_limited": True,
+                        "response_metadata": {"next_cursor": ""},
+                    },
+                )
+            ]
+        )
+
+        result = HISTORY.collect_channel_history(
+            "token-placeholder",
+            "C12345678",
+            api_call=api,
+        )
+
+        self.assertFalse(result["coverage"]["complete"])
+        self.assertEqual(
+            ["workspace_history_limit"],
+            result["coverage"]["truncation_reasons"],
+        )
+
+    def test_empty_history_is_distinct_from_failure(self) -> None:
+        api = ScriptedApi(
+            [
+                (
+                    "conversations.history",
+                    {
+                        "ok": True,
+                        "messages": [],
+                        "response_metadata": {"next_cursor": ""},
+                    },
+                )
+            ]
+        )
+
+        result = HISTORY.collect_channel_history(
+            "token-placeholder",
+            "C12345678",
+            api_call=api,
+        )
+
+        self.assertTrue(result["ok"])
+        self.assertTrue(result["empty"])
+        self.assertTrue(result["coverage"]["complete"])
+        self.assertEqual([], result["messages"])
+
+    def test_slack_failures_are_fail_closed_and_classified(self) -> None:
+        cases = [
+            ("invalid_auth", {}),
+            ("missing_scope", {"needed": "channels:history", "provided": "channels:read"}),
+            ("not_in_channel", {}),
+            ("ratelimited", {"retry_after": "30", "http_status": 429}),
+            ("internal_error", {}),
+        ]
+        for error, details in cases:
+            with self.subTest(error=error):
+                api = ScriptedApi(
+                    [("conversations.history", {"ok": False, "error": error, **details})]
+                )
+                result = HISTORY.collect_channel_history(
+                    "token-placeholder",
+                    "C12345678",
+                    api_call=api,
+                )
+                self.assertFalse(result["ok"])
+                self.assertEqual("history", result["stage"])
+                expected_error = "rate_limited" if error == "ratelimited" else error
+                self.assertEqual(expected_error, result["error"])
+                self.assertNotIn("messages", result)
+                self.assertNotIn("token-placeholder", repr(result))
+
+    def test_thread_replies_paginate_and_keep_root_relationship(self) -> None:
+        root = message(
+            "1700000100.000001",
+            "Root",
+            reply_count=3,
+            thread_ts="1700000100.000001",
+        )
+        api = ScriptedApi(
+            [
+                (
+                    "conversations.history",
+                    {
+                        "ok": True,
+                        "messages": [root],
+                        "response_metadata": {"next_cursor": ""},
+                    },
+                ),
+                ("chat.getPermalink", permalink("1700000100.000001")),
+                (
+                    "conversations.replies",
+                    {
+                        "ok": True,
+                        "messages": [
+                            root,
+                            message("1700000110.000001", "bot", bot_id="B123"),
+                            message("1700000120.000001", "Reply one", user="U22222222"),
+                        ],
+                        "response_metadata": {"next_cursor": "reply-page"},
+                    },
+                ),
+                (
+                    "conversations.replies",
+                    {
+                        "ok": True,
+                        "messages": [
+                            message("1700000130.000001", "Reply two", user="U33333333")
+                        ],
+                        "response_metadata": {"next_cursor": ""},
+                    },
+                ),
+                ("chat.getPermalink", permalink("1700000120.000001")),
+                ("chat.getPermalink", permalink("1700000130.000001")),
+            ]
+        )
+
+        result = HISTORY.collect_channel_history(
+            "token-placeholder",
+            "C12345678",
+            include_replies=True,
+            reply_limit=2,
+            thread_page_cap=3,
+            api_call=api,
+        )
+
+        replies = result["messages"][0]["thread_replies"]
+        self.assertEqual(["Reply one", "Reply two"], [item["text"] for item in replies])
+        self.assertEqual(
+            ["1700000100.000001", "1700000100.000001"],
+            [item["thread_root_ts"] for item in replies],
+        )
+        self.assertEqual(2, result["threads"]["items"][0]["pages"])
+        self.assertEqual(3, result["threads"]["items"][0]["inspected_messages"])
+        self.assertTrue(result["threads"]["complete"])
+        api.assert_complete(self)
+
+    def test_thread_cap_is_reported(self) -> None:
+        first = message("1700000100.000001", "First root", reply_count=1)
+        second = message("1700000200.000001", "Second root", reply_count=1)
+        reply = message("1700000110.000001", "Reply")
+        api = ScriptedApi(
+            [
+                (
+                    "conversations.history",
+                    {
+                        "ok": True,
+                        "messages": [first, second],
+                        "response_metadata": {"next_cursor": ""},
+                    },
+                ),
+                ("chat.getPermalink", permalink("1700000100.000001")),
+                ("chat.getPermalink", permalink("1700000200.000001")),
+                (
+                    "conversations.replies",
+                    {
+                        "ok": True,
+                        "messages": [first, reply],
+                        "response_metadata": {"next_cursor": ""},
+                    },
+                ),
+                ("chat.getPermalink", permalink("1700000110.000001")),
+            ]
+        )
+
+        result = HISTORY.collect_channel_history(
+            "token-placeholder",
+            "C12345678",
+            include_replies=True,
+            thread_cap=1,
+            api_call=api,
+        )
+
+        self.assertEqual(2, result["threads"]["roots_available"])
+        self.assertEqual(1, result["threads"]["roots_expanded"])
+        self.assertTrue(result["threads"]["truncated"])
+        self.assertIn("thread_cap", result["threads"]["truncation_reasons"])
+        self.assertNotIn("thread_replies", result["messages"][1])
+
+    def test_permalink_failure_is_fail_closed(self) -> None:
+        api = ScriptedApi(
+            [
+                (
+                    "conversations.history",
+                    {
+                        "ok": True,
+                        "messages": [message("1700000100.000001", "Evidence")],
+                        "response_metadata": {"next_cursor": ""},
+                    },
+                ),
+                ("chat.getPermalink", {"ok": False, "error": "missing_scope"}),
+            ]
+        )
+
+        result = HISTORY.collect_channel_history(
+            "token-placeholder",
+            "C12345678",
+            api_call=api,
+        )
+
+        self.assertFalse(result["ok"])
+        self.assertEqual("permalink", result["stage"])
+        self.assertEqual("missing_scope", result["error"])
+        self.assertNotIn("messages", result)
+
+    def test_message_text_truncation_is_explicit(self) -> None:
+        long_text = "x" * (HISTORY.MAX_TEXT_CHARS + 1)
+        api = ScriptedApi(
+            [
+                (
+                    "conversations.history",
+                    {
+                        "ok": True,
+                        "messages": [message("1700000100.000001", long_text)],
+                        "response_metadata": {"next_cursor": ""},
+                    },
+                ),
+                ("chat.getPermalink", permalink("1700000100.000001")),
+            ]
+        )
+
+        result = HISTORY.collect_channel_history(
+            "token-placeholder",
+            "C12345678",
+            api_call=api,
+        )
+
+        rendered = result["messages"][0]
+        self.assertEqual(HISTORY.MAX_TEXT_CHARS, len(rendered["text"]))
+        self.assertTrue(rendered["text_truncated"])
+
+    def test_citation_format_uses_timestamp_user_and_permalink(self) -> None:
+        citation = HISTORY.citation_for(
+            "0",
+            "U12345678",
+            "https://example.slack.com/archives/C12345678/p0",
+        )
+        self.assertEqual(
+            "[1970-01-01 00:00 UTC — U12345678]"
+            "(https://example.slack.com/archives/C12345678/p0)",
+            citation,
+        )
+
+    def test_time_boundaries_accept_slack_and_iso_formats(self) -> None:
+        self.assertEqual("1700000000", HISTORY.normalize_time_boundary("1700000000"))
+        self.assertEqual("1700000000.25", HISTORY.normalize_time_boundary("1700000000.250000"))
+        self.assertEqual("0", HISTORY.normalize_time_boundary("1970-01-01T00:00:00Z"))
+
+    def test_skill_requires_coverage_and_source_citations(self) -> None:
+        skill = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+        self.assertIn("fetch_slack_history.py", skill)
+        self.assertIn("Copy the `citation` value", skill)
+        self.assertIn("Do not summarize when `ok` is `false`", skill)
+        self.assertIn("coverage.complete", skill)
+        self.assertIn("threads.complete", skill)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/tests/test_slack_summary_history.py
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/tests/test_slack_summary_history.py
@@ -15,7 +15,6 @@ from pathlib import Path
 from unittest import TestCase
 from unittest.mock import patch
 
-
 HERMES_DIR = Path(__file__).resolve().parents[1]
 SKILL_DIR = HERMES_DIR / "skills/slack-channel-summarizer"
 SCRIPT = SKILL_DIR / "scripts/fetch_slack_history.py"
@@ -110,9 +109,7 @@ class SlackSummaryHistoryTest(TestCase):
                                         thread_ts="1700000200.000001",
                                     ),
                                 ],
-                                "response_metadata": {
-                                    "next_cursor": "history-page-2"
-                                },
+                                "response_metadata": {"next_cursor": "history-page-2"},
                             }
                         )
                     return
@@ -172,7 +169,9 @@ class SlackSummaryHistoryTest(TestCase):
         ]
         try:
             with (
-                patch.object(HISTORY, "API_BASE", f"http://127.0.0.1:{server.server_port}/api"),
+                patch.object(
+                    HISTORY, "API_BASE", f"http://127.0.0.1:{server.server_port}/api"
+                ),
                 patch.object(HISTORY, "get_slack_bot_token", return_value="test-token"),
                 patch.object(sys, "argv", arguments),
                 contextlib.redirect_stdout(output),
@@ -189,7 +188,9 @@ class SlackSummaryHistoryTest(TestCase):
         self.assertEqual(2, result["coverage"]["pages"])
         self.assertEqual(3, result["coverage"]["inspected_messages"])
         self.assertTrue(result["coverage"]["complete"])
-        self.assertEqual(["Oldest", "Root"], [item["text"] for item in result["messages"]])
+        self.assertEqual(
+            ["Oldest", "Root"], [item["text"] for item in result["messages"]]
+        )
         self.assertEqual(
             ["Reply"],
             [item["text"] for item in result["messages"][1]["thread_replies"]],
@@ -254,7 +255,9 @@ class SlackSummaryHistoryTest(TestCase):
         )
 
         self.assertTrue(result["ok"])
-        self.assertEqual(["First", "Second"], [item["text"] for item in result["messages"]])
+        self.assertEqual(
+            ["First", "Second"], [item["text"] for item in result["messages"]]
+        )
         self.assertEqual(2, result["coverage"]["pages"])
         self.assertEqual(3, result["coverage"]["inspected_messages"])
         self.assertEqual(2, result["coverage"]["human_messages"])
@@ -364,7 +367,9 @@ class SlackSummaryHistoryTest(TestCase):
                     "conversations.history",
                     {
                         "ok": True,
-                        "messages": [message("1700000100.000001", "bot", bot_id="B123")],
+                        "messages": [
+                            message("1700000100.000001", "bot", bot_id="B123")
+                        ],
                         "response_metadata": {"next_cursor": "more"},
                     },
                 )
@@ -439,7 +444,10 @@ class SlackSummaryHistoryTest(TestCase):
     def test_slack_failures_are_fail_closed_and_classified(self) -> None:
         cases = [
             ("invalid_auth", {}),
-            ("missing_scope", {"needed": "channels:history", "provided": "channels:read"}),
+            (
+                "missing_scope",
+                {"needed": "channels:history", "provided": "channels:read"},
+            ),
             ("not_in_channel", {}),
             ("ratelimited", {"retry_after": "30", "http_status": 429}),
             ("internal_error", {}),
@@ -447,7 +455,12 @@ class SlackSummaryHistoryTest(TestCase):
         for error, details in cases:
             with self.subTest(error=error):
                 api = ScriptedApi(
-                    [("conversations.history", {"ok": False, "error": error, **details})]
+                    [
+                        (
+                            "conversations.history",
+                            {"ok": False, "error": error, **details},
+                        )
+                    ]
                 )
                 result = HISTORY.collect_channel_history(
                     "token-placeholder",
@@ -460,6 +473,70 @@ class SlackSummaryHistoryTest(TestCase):
                 self.assertEqual(expected_error, result["error"])
                 self.assertNotIn("messages", result)
                 self.assertNotIn("token-placeholder", repr(result))
+
+    def test_transport_errors_return_sanitized_failure(self) -> None:
+        for transport_error in (
+            TimeoutError("private timeout detail"),
+            OSError("private transport detail"),
+        ):
+            with (
+                self.subTest(error=transport_error.__class__.__name__),
+                patch.object(
+                    HISTORY.urllib.request,
+                    "urlopen",
+                    side_effect=transport_error,
+                ),
+            ):
+                result = HISTORY.collect_channel_history(
+                    "token-placeholder",
+                    "C12345678",
+                )
+
+            self.assertEqual(
+                {
+                    "ok": False,
+                    "channel_id": "C12345678",
+                    "stage": "history",
+                    "error": "network_error",
+                },
+                result,
+            )
+            self.assertNotIn("token-placeholder", repr(result))
+            self.assertNotIn(str(transport_error), repr(result))
+
+    def test_malformed_history_message_returns_sanitized_failure(self) -> None:
+        malformed_value = "private malformed message"
+        api = ScriptedApi(
+            [
+                (
+                    "conversations.history",
+                    {
+                        "ok": True,
+                        "messages": [malformed_value],
+                        "response_metadata": {"next_cursor": ""},
+                    },
+                )
+            ]
+        )
+
+        result = HISTORY.collect_channel_history(
+            "token-placeholder",
+            "C12345678",
+            api_call=api,
+        )
+
+        self.assertEqual(
+            {
+                "ok": False,
+                "channel_id": "C12345678",
+                "stage": "history",
+                "error": "invalid_messages",
+            },
+            result,
+        )
+        self.assertNotIn("token-placeholder", repr(result))
+        self.assertNotIn(malformed_value, repr(result))
+        api.assert_complete(self)
 
     def test_thread_replies_paginate_and_keep_root_relationship(self) -> None:
         root = message(
@@ -634,7 +711,9 @@ class SlackSummaryHistoryTest(TestCase):
 
     def test_time_boundaries_accept_slack_and_iso_formats(self) -> None:
         self.assertEqual("1700000000", HISTORY.normalize_time_boundary("1700000000"))
-        self.assertEqual("1700000000.25", HISTORY.normalize_time_boundary("1700000000.250000"))
+        self.assertEqual(
+            "1700000000.25", HISTORY.normalize_time_boundary("1700000000.250000")
+        )
         self.assertEqual("0", HISTORY.normalize_time_boundary("1970-01-01T00:00:00Z"))
 
     def test_skill_requires_coverage_and_source_citations(self) -> None:

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/docs/verify-functionality.md
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/docs/verify-functionality.md
@@ -151,8 +151,15 @@ In either case, the agent may **loop trying to satisfy "from my inbox"** rather 
 
 > Pick any channel the bot is a member of and summarize the most recent 10 messages.
 
-**Expected:** agent uses `users.conversations` to pick a member channel, then `conversations.history` with `limit=10`, then a short summary.
-**Verify:** reply names the chosen channel by ID (`C…`) and gives a bulleted summary covering ≤10 messages. **If the bot isn't in any channels yet**, the skill correctly reports `not_in_channel` and asks to be invited — that's also a valid pass; invite `@myuser_nemoclaw` to a channel and retry.
+**Expected:** agent uses `users.conversations` to pick a member channel, then
+`fetch_slack_history.py --message-limit 10`. The helper can make more than one
+`conversations.history` request when bot or system messages consume a page.
+
+**Verify:** reply names the chosen channel by ID (`C…`), states the number of
+messages and pages inspected, and gives a bulleted summary covering at most 10
+human messages. Each factual bullet ends with a Slack source link. If the bot is
+not a member, the skill reports `not_in_channel` and asks to be invited. Invite
+`@myuser_nemoclaw` to a channel and retry.
 
 #### Q6 — realistic
 
@@ -160,8 +167,29 @@ In either case, the agent may **loop trying to satisfy "from my inbox"** rather 
 
 > Summarize the last 7 days of this channel — main topics, who's most active, and any unresolved questions.
 
-**Expected:** agent uses the thread's channel ID directly, pulls history with `oldest=` set to 7 days ago, replies in-thread.
-**Verify:** reply has sections for time range, main topics, active participants, and decisions/action items — the documented summary structure. Bonus credibility: a participant name you recognize.
+**Expected:** agent uses the thread's channel ID directly and runs
+`fetch_slack_history.py` with `--oldest` set to seven days ago, `--latest` set
+to the current time, and bounded pagination. The agent uses `--replies` when
+thread context is required and replies in-thread.
+
+**Verify:** reply starts with the requested and retrieved ranges, messages and
+pages inspected, and any history or thread truncation. It has sections for main
+topics, active participants, decisions and action items, and unresolved
+questions. Every factual bullet about a theme, decision, action item, or
+unresolved question links to a representative Slack message. Open at least two
+links and confirm that they support the associated statements.
+
+#### Q6b — fail-closed
+
+Remove the bot from a test channel or use a channel ID that the bot cannot
+read. Then ask the agent to summarize that channel.
+
+**Expected:** the helper returns `ok: false` with an error such as
+`not_in_channel` or `channel_not_found`.
+
+**Verify:** the agent reports the retrieval failure and remediation. It does
+not produce a summary, infer channel activity, or describe the failure as an
+empty successful range.
 
 ---
 


### PR DESCRIPTION
## Related Issue

Closes #69

## Description

The Slack channel summarizer previously delegated history reads to the channel
description helper. That helper makes one history request, filters after the
API limit, converts several required-read failures into empty arrays, and does
not provide coverage or source-link metadata. An agent could therefore treat a
partial or failed retrieval as sufficient evidence for a summary.

This change adds a dedicated, bounded `fetch_slack_history.py` helper. It:

- accepts inclusive `oldest` and `latest` time boundaries;
- paginates with Slack cursors and the documented time-based fallback;
- continues past bot and system messages until it reaches the requested human
  message limit, range boundary, or explicit page cap;
- returns requested and retrieved ranges, pages and messages inspected, and
  explicit truncation reasons;
- fails closed for authentication, scope, membership, rate-limit, transport,
  history, thread, and permalink failures;
- converts direct timeout and OS-level transport exceptions into a sanitized
  `network_error` result;
- rejects a malformed non-object in Slack's `messages` array as a sanitized
  `history` / `invalid_messages` result before coverage is calculated;
- adds a human-readable timestamp, Slack permalink, and ready-to-copy Markdown
  citation to each returned message;
- optionally expands thread replies within documented root, reply, and page
  caps while preserving each reply's root relationship; and
- does not write message content, access tokens, or results to logs or
  persistent state.

The summarizer skill now requires a coverage statement, source citations for
factual conclusions, explicit disclosure of incomplete history or threads, and
no summary when retrieval fails. The verification guide covers both a
source-linked summary and fail-closed behavior.

Slack permalinks preserve the workspace's existing access controls. This
change uses the recipe's existing Slack provider and adds no dependency or new
credential scope.

## Verification

- [x] `python3 scripts/check_license_headers.py --check` — all 372 checked source files passed.
- [x] `python3 scripts/check_label_taxonomy.py --check` — 64 labels are valid; no governance metadata changed.
- [x] `git diff --check origin/main...HEAD` — passed.
- [x] Relevant example setup or syntax checks — `python -m pytest -q examples/recipes/nvidia/developer-community-chief-of-staff/scripts/tests examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/tests` passed with 130 tests and 13 subtests in a disposable test environment.
- [x] `python3 -m unittest -v examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/tests/test_slack_summary_history.py` — all 17 focused tests and 7 subtests passed.
- [x] `ruff check --select E4,E7,E9,F,I,UP` and `ruff format --check` on the new helper and test file — passed.
- [x] `test_cli_uses_real_http_for_history_permalinks_and_threads` — exercised the real CLI entry point and `urllib` HTTP requests against a local Slack-compatible server, including cursor pagination, bot filtering, permalinks, thread replies, JSON output, and token non-disclosure.
- [x] `python3 -m py_compile examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/skills/slack-channel-summarizer/scripts/fetch_slack_history.py examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/tests/test_slack_summary_history.py` — passed.
- [x] `python3 examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/skills/slack-channel-summarizer/scripts/fetch_slack_history.py --help` — passed.
- [x] `docker buildx build --check -f agents/hermes/Dockerfile .` from the recipe directory — completed with no warnings.

Not completed:

- A live Slack history query was not run because this checkout and process have no
  configured Slack access token, and the only running OpenShell sandbox has no Slack provider.
- A full sandbox image build was not run. The Buildx Dockerfile check validated
  the Dockerfile and skill copy context without executing all build stages.

## Documentation Writer Review

- [x] Documentation writer review completed for the final changes
- Result: `docs-updated`
- Evidence or justification: Updated `examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/skills/slack-channel-summarizer/SKILL.md` and `examples/recipes/nvidia/developer-community-chief-of-staff/docs/verify-functionality.md` with the final helper interface, evidence contract, hard caps, failure behavior, citation requirement, and verification steps.
- Reviewer: Codex
- [x] Changed user-facing text follows the
  [writing guide](https://github.com/NVIDIA/nemoclaw-community/blob/main/WRITING.md)
  and
  [controlled-word list](https://github.com/NVIDIA/nemoclaw-community/blob/main/.agents/skills/_shared/controlled-words.md).
- [x] A public contributor can understand the changed text without internal
  company context.
- [ ] I reviewed any agent-generated text before submission.

## Release And Compliance

- [x] No secrets or credentials are included, including API keys, access tokens,
  passwords, local `.env` files, private certificates, or token caches.
- [x] No nonpublic project names, environment names, hostnames, URLs, ticket
  identifiers, workspace paths, logs, screenshots, or configuration values are
  included.
- [x] Third-party dependency changes are reflected in `THIRD-PARTY-NOTICES` — no dependency changes are included.
- [x] Public content uses sanitized examples and placeholders instead of private
  values.
- [x] I added my DCO sign-off declaration to this pull request description.

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>
