### PR TITLE
feat(setup): add guided configuration and preflight

### DIFF
--- a/examples/recipes/nvidia/developer-community-chief-of-staff/.env.example
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/.env.example
@@ -1,8 +1,14 @@
-# Copy to .env and fill in real values, then:
+# Recommended setup:
+#   python3 scripts/configure.py       # guided Slack, Outlook, or combined setup
+#   python3 scripts/preflight.py       # read-only local checks
+#   python3 scripts/preflight.py --external  # optional bounded service checks
+#
+# For advanced manual setup, copy this file to .env and fill in real values.
+# Then run:
 #   bash scripts/00-host-services.sh   # phoenix, postgres, ETLs, postgrest (+ relay when ATIF_EXPORT_MODE=relay; + minio when ATIF_RELAY_BACKEND=minio)
 #   bash scripts/bring-up.sh           # OpenShell gateway, v2 providers, sandbox
 #
-# Both scripts auto-source .env, so `cp .env.example .env` and run is enough.
+# Lifecycle scripts auto-source .env.
 # Prereq: `openshell settings set --global --key providers_v2_enabled --value true --yes` (02-providers.sh enforces this and prints the command if missing).
 
 # ── Inference (the agent's LLM) ──────────────────────────────────────────

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/README.md
@@ -11,6 +11,12 @@ and Slack channels; you interact with it via Outlook email and/or Slack.
 Outlook is the recommended primary channel, but either is enough on its own —
 at least one of the two must be configured.
 
+For first-time setup, use the
+[guided configuration and preflight](docs/guided-setup.md). The commands ask
+only for credentials required by the selected messaging profile, preserve
+unselected existing `.env` content, redact credentials, and detect missing
+prerequisites before bring-up.
+
 ## Deployment model
 
 This is a personal agent designed to run on a **managed image/VM provisioned by
@@ -285,13 +291,50 @@ application and a dedicated agent mailbox per [docs/set-up-outlook-bridge.md](do
 
 This example will download and install additional third-party open source software projects. Review the license terms of these open source projects before use. The repository-level `THIRD-PARTY-NOTICES` file tracks the expected inventory.
 
-### Phase 2 — Pre-populate `.env` with what you know upfront
+### Phase 2 — Configure and check the recipe
+
+```console
+$ python3 scripts/configure.py
+$ python3 scripts/preflight.py
+```
+
+The configurator guides you through a Slack-only, Outlook-only, or combined
+profile. It hides credential input and writes `.env` with owner-only
+permissions. If `.env` exists, the command changes only the selected keys and
+preserves comments, advanced settings, and other values. Use `--replace` only
+when you intend to replace the file with a minimal configuration.
+
+The default preflight performs configuration and local host checks. It does
+not create services, providers, or sandboxes, and it does not contact the
+configured inference or Slack services. When the local checks pass, run the
+optional bounded external checks:
+
+```console
+$ python3 scripts/preflight.py --external
+```
+
+The external mode reuses `inference_preflight.py` and
+`slack_socket_preflight.py`. It sends the same bounded validation requests that
+provider setup uses. Each preflight result prints the exact next command.
+
+For deterministic automation, supply the required values through the process
+environment or an existing `.env`, then select a profile:
+
+```console
+$ python3 scripts/configure.py --non-interactive --profile slack
+```
+
+Do not place credential values in command arguments. See
+[Guided Configuration and Preflight](docs/guided-setup.md) for profile inputs,
+automation, replacement behavior, JSON output, and the external-check boundary.
+
+Advanced manual configuration remains supported:
 
 ```console
 $ cp .env.example .env
 ```
 
-Now edit `.env` and fill in everything you already have:
+Edit `.env` and fill in everything you need:
 
 - `COMPATIBLE_API_KEY` — your inference key
 - **At least one messaging channel** — Outlook or Slack (or both):

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/docs/guided-setup.md
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/docs/guided-setup.md
@@ -1,0 +1,196 @@
+---
+title:
+  page: "Guided Configuration and Preflight"
+  nav: "Guided Setup"
+description:
+  main: "Create a minimal Slack, Outlook, or combined configuration and run redacted prerequisite checks before starting services or a sandbox."
+  agent: "Explains the developer-community-chief-of-staff recipe's guided configure.py and read-only preflight.py commands, including safe .env preservation, non-interactive inputs, local and external check boundaries, redaction, and next actions. Use when setting up or diagnosing this recipe before bring-up."
+keywords: ["nemoclaw guided setup", "nemoclaw preflight", "hermes configuration", "openshell prerequisites"]
+topics: ["generative_ai", "ai_agents"]
+tags: ["hermes", "openshell", "slack", "outlook", "setup", "preflight"]
+content:
+  type: how_to
+  difficulty: beginner
+  audience: ["developer", "engineer"]
+status: published
+---
+
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+![NVIDIA](../assets/nvidia_header.png)
+
+# Guided Configuration and Preflight
+
+Use the guided configurator to create a minimal `.env`. Then use the preflight
+to find configuration and host problems before `bring-up.sh` starts services,
+creates providers, or builds a sandbox.
+
+The configurator does not register external applications or grant access. Set
+up the required Slack app or Microsoft Entra application before you enter its
+values. You also need an inference API key with access to the selected model.
+
+## Run Guided Configuration
+
+From the recipe root, run:
+
+```console
+$ python3 scripts/configure.py
+```
+
+Select one messaging profile:
+
+| Profile | Required inputs |
+| --- | --- |
+| `slack` | Inference API key, Slack bot access token, Slack app-level token |
+| `outlook` | Inference API key, tenant ID, client ID, agent mailbox, reply-to mailbox |
+| `both` | All Slack and Outlook inputs above |
+
+The command proposes these non-secret defaults:
+
+| Setting | Default |
+| --- | --- |
+| Sandbox name | `hermes-direct` |
+| OpenShell gateway | `openshell` |
+| Gateway endpoint | `https://127.0.0.1:17670` for `openshell`; `http://127.0.0.1:17670` for `snap-docker` |
+| Inference model | `nvidia/nemotron-3-super-120b-a12b` |
+
+Credential prompts do not echo their values. The final summary confirms that
+the required credentials are configured without printing them.
+
+### Existing `.env` behavior
+
+If `.env` exists, the configurator preserves every comment, unknown setting,
+and unselected value. Press Enter at a prompt to keep the current value. Enter
+a new value to change that key.
+
+The command fails instead of guessing when the file contains duplicate
+assignments, invalid shell quoting, command lines, or unsupported shell
+operators and expansions. It writes a successful result atomically and sets its
+permissions to owner read/write (`0600`).
+
+Use `--replace` only when you intend to discard unselected values and create a
+minimal file:
+
+```console
+$ python3 scripts/configure.py --profile slack --replace
+```
+
+`.env.example` remains the complete reference for advanced settings. Manual
+copy-and-edit setup remains supported.
+
+## Run Non-Interactive Configuration
+
+Non-interactive mode is deterministic and does not accept credential values as
+command arguments. Supply required values through the process environment or
+an existing `.env` and select the profile:
+
+```console
+$ python3 scripts/configure.py --non-interactive --profile slack
+```
+
+For a new Slack configuration, the environment must contain:
+
+- `COMPATIBLE_API_KEY` or `OPENAI_API_KEY`
+- `SLACK_BOT_TOKEN`
+- `SLACK_APP_TOKEN`
+
+For Outlook, it must contain the inference key and all four values:
+
+- `OUTLOOK_TENANT_ID`
+- `OUTLOOK_CLIENT_ID`
+- `OUTLOOK_TARGET_MAILBOX`
+- `OUTLOOK_REPLY_TO`
+
+Use all Slack and Outlook values for `--profile both`. Existing file values
+take precedence so automation cannot overwrite a configured credential merely
+because the parent process contains a different value. Use `--replace` with a
+controlled environment when replacement is intentional.
+
+These optional command arguments contain only non-secret values:
+
+```console
+$ python3 scripts/configure.py --non-interactive --profile slack \
+    --sandbox-name hermes-direct \
+    --gateway openshell \
+    --gateway-endpoint https://127.0.0.1:17670 \
+    --model nvidia/nemotron-3-super-120b-a12b
+```
+
+## Run Local Preflight
+
+Run the default preflight before bring-up:
+
+```console
+$ python3 scripts/preflight.py
+```
+
+This mode does not contact configured external services. It performs these
+read-only checks:
+
+- Parses `.env` without executing it and checks owner-only permissions.
+- Checks Slack, Outlook, inference, GitHub, and optional-component values.
+- Checks Python, Git, Docker, Docker Compose, OpenShell, curl, and OpenSSL.
+- Checks the Docker daemon, configured gateway reachability and registration,
+  and the gateway-scoped provider-v2 setting.
+- Checks the local ports used by Phoenix, OpenTelemetry, the source API,
+  PostgreSQL, and enabled optional services.
+- Reports enabled and skipped integrations and the exact next command.
+
+An occupied recipe port is a warning because an existing deployment can own
+it. Confirm that the listener belongs to this recipe before bring-up.
+
+The preflight does not install software, modify gateway settings, select or
+register a gateway, create providers, start services, or create a sandbox.
+
+## Run Optional External Checks
+
+After local checks pass, explicitly allow bounded service checks:
+
+```console
+$ python3 scripts/preflight.py --external
+```
+
+External mode reuses the checks that `02-providers.sh` uses:
+
+- When inference validation is enabled, `inference_preflight.py` sends one
+  bounded structured-tool request to the configured inference endpoint.
+- When Slack is enabled, `slack_socket_preflight.py` calls Slack
+  `apps.connections.open` to validate the app-level token and
+  `connections:write` scope. Slack returns a temporary Socket Mode URL; the
+  preflight does not print it or open the WebSocket.
+- Outlook device-code sign-in remains an explicit bring-up step and is reported
+  as skipped.
+
+Neither mode creates a service, provider, or sandbox. External mode does
+contact the selected services, so run it only when you have authorization and
+valid credentials.
+
+## Use Redacted JSON in Automation
+
+Use `--json` for machine-readable output:
+
+```console
+$ python3 scripts/preflight.py --json
+```
+
+The JSON includes resolved non-secret defaults, check scope, status, detail,
+remediation, and `next_command`. Credential values are omitted and are also
+removed from captured error details.
+
+Exit codes are:
+
+| Code | Meaning |
+| --- | --- |
+| `0` | No check failed. Warnings and explicit skips can remain. |
+| `1` | One or more configuration or prerequisite checks failed. |
+| `2` | The command arguments or `.env` syntax are invalid. |
+
+Follow the printed `next_command`. After `--external` completes without a
+failure, the next command is:
+
+```console
+$ bash scripts/bring-up.sh
+```

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/configure.py
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/configure.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Create or update a minimal configuration for this recipe."""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import os
+import sys
+from collections.abc import Callable, Mapping
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+EXAMPLE_DIR = SCRIPT_DIR.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from lib.configuration import (  # noqa: E402
+    DEFAULTS,
+    GATEWAY_ENDPOINTS,
+    SECRET_KEYS,
+    ConfigurationError,
+    EnvDocument,
+    enabled_profiles,
+    parse_env_text,
+    profile_errors,
+    profile_keys,
+    read_env,
+    render_updates,
+    resolved_values,
+    write_env,
+)
+
+LABELS = {
+    "COMPATIBLE_API_KEY": "Inference API key",
+    "NEMOCLAW_MODEL": "Inference model",
+    "OPENAI_API_KEY": "Inference API key",
+    "OPENSHELL_GATEWAY": "OpenShell gateway name",
+    "OPENSHELL_GATEWAY_ENDPOINT": "OpenShell gateway endpoint",
+    "OUTLOOK_CLIENT_ID": "Microsoft Entra client ID",
+    "OUTLOOK_REPLY_TO": "Reply-to mailbox",
+    "OUTLOOK_TARGET_MAILBOX": "Agent mailbox",
+    "OUTLOOK_TENANT_ID": "Microsoft Entra tenant ID",
+    "SANDBOX_NAME": "Sandbox name",
+    "SLACK_APP_TOKEN": "Slack app-level token",
+    "SLACK_BOT_TOKEN": "Slack bot access token",
+}
+
+
+def prompt_choice(
+    prompt: str,
+    choices: tuple[str, ...],
+    *,
+    default: str,
+    input_fn: Callable[[str], str],
+) -> str:
+    while True:
+        answer = (
+            input_fn(f"{prompt} ({'/'.join(choices)}) [{default}]: ").strip().lower()
+        )
+        selected = answer or default
+        if selected in choices:
+            return selected
+        print(f"Choose one of: {', '.join(choices)}", file=sys.stderr)
+
+
+def prompt_value(
+    key: str,
+    current: str,
+    *,
+    required: bool,
+    input_fn: Callable[[str], str],
+    secret_fn: Callable[[str], str],
+) -> str:
+    label = LABELS.get(key, key)
+    secret = key in SECRET_KEYS
+    while True:
+        if secret:
+            state = "configured; Enter keeps it" if current else "required"
+            answer = secret_fn(f"{label} [{state}]: ")
+        else:
+            state = current or ("required" if required else "optional")
+            answer = input_fn(f"{label} [{state}]: ")
+        if answer:
+            return answer.strip()
+        if current or not required:
+            return current
+        print(f"{label} is required.", file=sys.stderr)
+
+
+def infer_profile(document: EnvDocument) -> str:
+    profiles = enabled_profiles(document.values)
+    if profiles == ("Slack",):
+        return "slack"
+    if profiles == ("Outlook",):
+        return "outlook"
+    if len(profiles) == 2:
+        return "both"
+    return "slack"
+
+
+def collect_interactive_updates(
+    document: EnvDocument,
+    environment: Mapping[str, str],
+    *,
+    profile: str | None,
+    replacements: Mapping[str, str],
+    input_fn: Callable[[str], str] = input,
+    secret_fn: Callable[[str], str] = getpass.getpass,
+) -> tuple[str, dict[str, str]]:
+    current = resolved_values(document, environment)
+    selected_profile = profile or prompt_choice(
+        "Messaging profile",
+        ("slack", "outlook", "both"),
+        default=infer_profile(document),
+        input_fn=input_fn,
+    )
+    sandbox_name = prompt_value(
+        "SANDBOX_NAME",
+        replacements.get("SANDBOX_NAME", current["SANDBOX_NAME"]),
+        required=True,
+        input_fn=input_fn,
+        secret_fn=secret_fn,
+    )
+    gateway = prompt_value(
+        "OPENSHELL_GATEWAY",
+        replacements.get("OPENSHELL_GATEWAY", current["OPENSHELL_GATEWAY"]),
+        required=True,
+        input_fn=input_fn,
+        secret_fn=secret_fn,
+    )
+    explicit_endpoint = document.values.get(
+        "OPENSHELL_GATEWAY_ENDPOINT"
+    ) or environment.get("OPENSHELL_GATEWAY_ENDPOINT", "")
+    gateway_endpoint = prompt_value(
+        "OPENSHELL_GATEWAY_ENDPOINT",
+        replacements.get(
+            "OPENSHELL_GATEWAY_ENDPOINT",
+            explicit_endpoint or GATEWAY_ENDPOINTS.get(gateway, ""),
+        ),
+        required=True,
+        input_fn=input_fn,
+        secret_fn=secret_fn,
+    )
+    model = prompt_value(
+        "NEMOCLAW_MODEL",
+        replacements.get("NEMOCLAW_MODEL", current["NEMOCLAW_MODEL"]),
+        required=True,
+        input_fn=input_fn,
+        secret_fn=secret_fn,
+    )
+    updates: dict[str, str] = {
+        "SANDBOX_NAME": sandbox_name,
+        "OPENSHELL_GATEWAY": gateway,
+        "OPENSHELL_GATEWAY_ENDPOINT": gateway_endpoint,
+        "NEMOCLAW_MODEL": model,
+        "NEMOCLAW_INFERENCE_PREFLIGHT": current.get(
+            "NEMOCLAW_INFERENCE_PREFLIGHT", "1"
+        ),
+        "GITHUB_READONLY_REPO": current.get(
+            "GITHUB_READONLY_REPO", DEFAULTS["GITHUB_READONLY_REPO"]
+        ),
+    }
+    inference_key_name = "COMPATIBLE_API_KEY"
+    inference_key = current.get(inference_key_name, "")
+    if not inference_key and current.get("OPENAI_API_KEY"):
+        inference_key_name = "OPENAI_API_KEY"
+        inference_key = current[inference_key_name]
+    updates[inference_key_name] = prompt_value(
+        inference_key_name,
+        inference_key,
+        required=True,
+        input_fn=input_fn,
+        secret_fn=secret_fn,
+    )
+
+    for key in profile_keys(selected_profile):
+        updates[key] = prompt_value(
+            key,
+            replacements.get(key, current.get(key, "")),
+            required=True,
+            input_fn=input_fn,
+            secret_fn=secret_fn,
+        )
+    if selected_profile in {"slack", "both"}:
+        updates["NEMOCLAW_SLACK_RICH_BLOCKS"] = current.get(
+            "NEMOCLAW_SLACK_RICH_BLOCKS", "true"
+        )
+    if selected_profile in {"outlook", "both"}:
+        updates["OUTLOOK_LOGIN_CACHE"] = current.get("OUTLOOK_LOGIN_CACHE", "1")
+    return selected_profile, updates
+
+
+def collect_non_interactive_updates(
+    document: EnvDocument,
+    environment: Mapping[str, str],
+    *,
+    profile: str,
+    replacements: Mapping[str, str],
+    replace: bool,
+) -> dict[str, str]:
+    existing = {} if replace else document.values
+    current = resolved_values(
+        EnvDocument(lines=(), values=dict(existing), line_indexes={}), environment
+    )
+    updates = {
+        "SANDBOX_NAME": replacements.get("SANDBOX_NAME", current["SANDBOX_NAME"]),
+        "OPENSHELL_GATEWAY": replacements.get(
+            "OPENSHELL_GATEWAY", current["OPENSHELL_GATEWAY"]
+        ),
+        "NEMOCLAW_MODEL": replacements.get("NEMOCLAW_MODEL", current["NEMOCLAW_MODEL"]),
+        "NEMOCLAW_INFERENCE_PREFLIGHT": current.get(
+            "NEMOCLAW_INFERENCE_PREFLIGHT", "1"
+        ),
+        "GITHUB_READONLY_REPO": current.get(
+            "GITHUB_READONLY_REPO", DEFAULTS["GITHUB_READONLY_REPO"]
+        ),
+    }
+    explicit_endpoint = existing.get("OPENSHELL_GATEWAY_ENDPOINT") or environment.get(
+        "OPENSHELL_GATEWAY_ENDPOINT", ""
+    )
+    gateway_endpoint = (
+        replacements.get("OPENSHELL_GATEWAY_ENDPOINT")
+        or explicit_endpoint
+        or GATEWAY_ENDPOINTS.get(updates["OPENSHELL_GATEWAY"], "")
+    )
+    if not gateway_endpoint:
+        raise ConfigurationError(
+            "non-interactive setup requires OPENSHELL_GATEWAY_ENDPOINT for a custom gateway"
+        )
+    updates["OPENSHELL_GATEWAY_ENDPOINT"] = gateway_endpoint
+
+    inference_key_name = "COMPATIBLE_API_KEY"
+    inference_key = current.get(inference_key_name, "")
+    if not inference_key and current.get("OPENAI_API_KEY"):
+        inference_key_name = "OPENAI_API_KEY"
+        inference_key = current["OPENAI_API_KEY"]
+    if not inference_key:
+        raise ConfigurationError(
+            "non-interactive setup requires COMPATIBLE_API_KEY or OPENAI_API_KEY "
+            "in the environment or existing configuration"
+        )
+    updates[inference_key_name] = inference_key
+
+    missing: list[str] = []
+    for key in profile_keys(profile):
+        value = current.get(key, "")
+        if not value:
+            missing.append(key)
+        else:
+            updates[key] = value
+    if missing:
+        raise ConfigurationError(
+            "non-interactive setup is missing required inputs: " + ", ".join(missing)
+        )
+    if profile in {"slack", "both"}:
+        updates["NEMOCLAW_SLACK_RICH_BLOCKS"] = current.get(
+            "NEMOCLAW_SLACK_RICH_BLOCKS", "true"
+        )
+    if profile in {"outlook", "both"}:
+        updates["OUTLOOK_LOGIN_CACHE"] = current.get("OUTLOOK_LOGIN_CACHE", "1")
+    return updates
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", choices=("slack", "outlook", "both"))
+    parser.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help="Read required credentials from the environment or existing file",
+    )
+    parser.add_argument(
+        "--replace",
+        action="store_true",
+        help="Replace the target with a minimal file instead of preserving unselected lines",
+    )
+    parser.add_argument("--env-file", type=Path, default=EXAMPLE_DIR / ".env")
+    parser.add_argument("--sandbox-name")
+    parser.add_argument("--gateway", choices=("openshell", "snap-docker"))
+    parser.add_argument("--gateway-endpoint")
+    parser.add_argument("--model")
+    return parser
+
+
+def print_prerequisites(profile: str) -> None:
+    print("External prerequisites:")
+    print("  - An inference API key and access to the configured model")
+    if profile in {"slack", "both"}:
+        print(
+            "  - A Slack app with Socket Mode, a bot access token, and an app-level token"
+        )
+    if profile in {"outlook", "both"}:
+        print(
+            "  - A Microsoft Entra application, mailbox permission, and administrator consent"
+        )
+
+
+def print_summary(path: Path, values: Mapping[str, str]) -> None:
+    profiles = enabled_profiles(values)
+    print(f"Configuration written: {path}")
+    print("File permissions: owner read/write only")
+    print(f"Messaging profiles: {', '.join(profiles) or 'none'}")
+    print(f"Sandbox: {values.get('SANDBOX_NAME', DEFAULTS['SANDBOX_NAME'])}")
+    print(f"Gateway: {values.get('OPENSHELL_GATEWAY', DEFAULTS['OPENSHELL_GATEWAY'])}")
+    print(f"Model: {values.get('NEMOCLAW_MODEL', DEFAULTS['NEMOCLAW_MODEL'])}")
+    print("Credentials: configured values are redacted")
+    print("Next command: python3 scripts/preflight.py")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.non_interactive and not args.profile:
+        print("--profile is required with --non-interactive", file=sys.stderr)
+        return 2
+    replacements = {
+        key: value
+        for key, value in {
+            "SANDBOX_NAME": args.sandbox_name,
+            "OPENSHELL_GATEWAY": args.gateway,
+            "OPENSHELL_GATEWAY_ENDPOINT": args.gateway_endpoint,
+            "NEMOCLAW_MODEL": args.model,
+        }.items()
+        if value is not None
+    }
+    try:
+        document = read_env(args.env_file)
+        if args.non_interactive:
+            updates = collect_non_interactive_updates(
+                document,
+                os.environ,
+                profile=args.profile,
+                replacements=replacements,
+                replace=args.replace,
+            )
+            selected_profile = args.profile
+        else:
+            selected_profile, updates = collect_interactive_updates(
+                EnvDocument(lines=(), values={}, line_indexes={})
+                if args.replace
+                else document,
+                os.environ,
+                profile=args.profile,
+                replacements=replacements,
+            )
+        candidate_text = render_updates(document, updates, replace=args.replace)
+        candidate = read_candidate(candidate_text)
+        errors = profile_errors(candidate.values)
+        if errors:
+            raise ConfigurationError("; ".join(errors))
+        print_prerequisites(selected_profile)
+        write_env(args.env_file, candidate_text)
+        print_summary(args.env_file, resolved_values(candidate))
+        return 0
+    except ConfigurationError as error:
+        print(f"Configuration failed: {error}", file=sys.stderr)
+        return 2
+    except OSError as error:
+        detail = error.strerror or error.__class__.__name__
+        print(
+            f"Configuration failed: cannot write {args.env_file}: {detail}",
+            file=sys.stderr,
+        )
+        return 2
+
+
+def read_candidate(text: str) -> EnvDocument:
+    return parse_env_text(text)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/lib/configuration.py
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/lib/configuration.py
@@ -53,6 +53,10 @@ SECRET_KEYS = frozenset(
 ASSIGNMENT_RE = re.compile(
     r"^(?P<prefix>\s*(?:export\s+)?)(?P<key>[A-Za-z_][A-Za-z0-9_]*)=(?P<value>.*)$"
 )
+ATIF_RELAY_HOSTNAME_RE = re.compile(
+    r"^([A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?\.)*"
+    r"[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?$"
+)
 
 
 class ConfigurationError(ValueError):
@@ -66,6 +70,38 @@ class EnvDocument:
     lines: tuple[str, ...]
     values: dict[str, str]
     line_indexes: dict[str, int]
+
+
+def parse_atif_relay_endpoint(endpoint: str) -> tuple[str, str, int]:
+    """Validate and canonicalize the HTTPS origin contract from ``_lib.sh``."""
+    prefix = "https://"
+    if not endpoint.startswith(prefix):
+        raise ConfigurationError("ATIF_RELAY_ENDPOINT must be an https:// URL")
+
+    host_port = endpoint[len(prefix) :]
+    if host_port.endswith("/"):
+        host_port = host_port[:-1]
+    if any(character in host_port for character in "/?#@"):
+        raise ConfigurationError(
+            "ATIF_RELAY_ENDPOINT must be an origin with no path, query, "
+            "fragment, or user information"
+        )
+    if host_port.count(":") != 1:
+        raise ConfigurationError(
+            "ATIF_RELAY_ENDPOINT must use a hostname and one explicit port; "
+            "IPv6 literals are not supported"
+        )
+
+    host, raw_port = host_port.split(":", 1)
+    if not ATIF_RELAY_HOSTNAME_RE.fullmatch(host):
+        raise ConfigurationError("ATIF_RELAY_ENDPOINT hostname is invalid")
+    if not re.fullmatch(r"[0-9]{1,5}", raw_port):
+        raise ConfigurationError("ATIF_RELAY_ENDPOINT port must be numeric")
+
+    port = int(raw_port, 10)
+    if not 1 <= port <= 65535:
+        raise ConfigurationError("ATIF_RELAY_ENDPOINT port must be between 1 and 65535")
+    return f"{prefix}{host}:{port}", host, port
 
 
 def split_inline_comment(raw: str) -> tuple[str, str]:

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/lib/configuration.py
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/lib/configuration.py
@@ -1,0 +1,310 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared, side-effect-free configuration helpers for recipe setup tools."""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import stat
+import tempfile
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_MODEL = "nvidia/nemotron-3-super-120b-a12b"
+DEFAULTS = {
+    "SANDBOX_NAME": "hermes-direct",
+    "OPENSHELL_GATEWAY": "openshell",
+    "NEMOCLAW_MODEL": DEFAULT_MODEL,
+    "NEMOCLAW_INFERENCE_PREFLIGHT": "1",
+    "OUTLOOK_LOGIN_CACHE": "1",
+    "NEMOCLAW_SLACK_RICH_BLOCKS": "true",
+    "GITHUB_READONLY_REPO": "NVIDIA/OpenShell",
+}
+GATEWAY_ENDPOINTS = {
+    "openshell": "https://127.0.0.1:17670",
+    "snap-docker": "http://127.0.0.1:17670",
+}
+OUTLOOK_REQUIRED = (
+    "OUTLOOK_TENANT_ID",
+    "OUTLOOK_CLIENT_ID",
+    "OUTLOOK_TARGET_MAILBOX",
+    "OUTLOOK_REPLY_TO",
+)
+SLACK_REQUIRED = ("SLACK_BOT_TOKEN", "SLACK_APP_TOKEN")
+SECRET_KEYS = frozenset(
+    {
+        "ATIF_RELAY_AUTH_TOKEN",
+        "ATIF_RELAY_S3_ACCESS_KEY",
+        "ATIF_RELAY_S3_SECRET_KEY",
+        "COMPATIBLE_API_KEY",
+        "DISCORD_BOT_TOKEN",
+        "GITHUB_TOKEN",
+        "NEMOCLAW_MINIO_ROOT_PASSWORD",
+        "OPENAI_API_KEY",
+        "SLACK_APP_TOKEN",
+        "SLACK_BOT_TOKEN",
+        "TELEGRAM_BOT_TOKEN",
+    }
+)
+ASSIGNMENT_RE = re.compile(
+    r"^(?P<prefix>\s*(?:export\s+)?)(?P<key>[A-Za-z_][A-Za-z0-9_]*)=(?P<value>.*)$"
+)
+
+
+class ConfigurationError(ValueError):
+    """A configuration file cannot be parsed or validated safely."""
+
+
+@dataclass(frozen=True)
+class EnvDocument:
+    """Parsed values plus the original lines needed for a preserving update."""
+
+    lines: tuple[str, ...]
+    values: dict[str, str]
+    line_indexes: dict[str, int]
+
+
+def split_inline_comment(raw: str) -> tuple[str, str]:
+    """Split a shell comment that begins after unquoted, unescaped whitespace."""
+    single_quoted = False
+    double_quoted = False
+    escaped = False
+    at_word_start = False
+    for index, character in enumerate(raw):
+        if escaped:
+            escaped = False
+            at_word_start = False
+            continue
+        if character == "\\" and not single_quoted:
+            escaped = True
+            continue
+        if character == "'" and not double_quoted:
+            single_quoted = not single_quoted
+            at_word_start = False
+            continue
+        if character == '"' and not single_quoted:
+            double_quoted = not double_quoted
+            at_word_start = False
+            continue
+        if (
+            character == "#"
+            and not single_quoted
+            and not double_quoted
+            and at_word_start
+        ):
+            suffix_start = index
+            while suffix_start and raw[suffix_start - 1].isspace():
+                suffix_start -= 1
+            return raw[:suffix_start], raw[suffix_start:]
+        if not single_quoted and not double_quoted and character.isspace():
+            at_word_start = True
+        else:
+            at_word_start = False
+    return raw, ""
+
+
+def reject_executable_shell_syntax(raw: str, key: str) -> None:
+    """Reject shell operators that could execute code when lifecycle scripts source .env."""
+    single_quoted = False
+    double_quoted = False
+    escaped = False
+    for character in raw:
+        if escaped:
+            escaped = False
+            continue
+        if character == "\\" and not single_quoted:
+            escaped = True
+            continue
+        if character == "'" and not double_quoted:
+            single_quoted = not single_quoted
+            continue
+        if character == '"' and not single_quoted:
+            double_quoted = not double_quoted
+            continue
+        if single_quoted:
+            continue
+        if character in "`$":
+            raise ConfigurationError(
+                f"{key} contains an unsupported shell operator or expansion"
+            )
+        if not double_quoted and character in ";&|<>":
+            raise ConfigurationError(
+                f"{key} contains an unsupported shell operator or expansion"
+            )
+
+
+def decode_value(raw: str, key: str) -> str:
+    """Decode one shell-compatible assignment without executing the file."""
+    if "\x00" in raw:
+        raise ConfigurationError(f"{key} contains a NUL byte")
+    raw, _comment = split_inline_comment(raw)
+    reject_executable_shell_syntax(raw, key)
+    if raw == "":
+        return ""
+    try:
+        parts = shlex.split(raw, comments=False, posix=True)
+    except ValueError as error:
+        raise ConfigurationError(f"{key} has invalid shell quoting") from error
+    if len(parts) != 1:
+        raise ConfigurationError(
+            f"{key} must use shell quoting when its value contains spaces"
+        )
+    return parts[0]
+
+
+def parse_env_text(text: str) -> EnvDocument:
+    """Parse assignments while preserving comments, order, and unknown lines."""
+    lines = tuple(text.splitlines())
+    values: dict[str, str] = {}
+    line_indexes: dict[str, int] = {}
+    for index, line in enumerate(lines):
+        match = ASSIGNMENT_RE.fullmatch(line)
+        if not match:
+            if line.strip() and not line.lstrip().startswith("#"):
+                raise ConfigurationError(
+                    f"line {index + 1} is not a supported assignment or comment"
+                )
+            continue
+        key = match.group("key")
+        if key in values:
+            raise ConfigurationError(f"duplicate assignment for {key}")
+        values[key] = decode_value(match.group("value"), key)
+        line_indexes[key] = index
+    return EnvDocument(lines=lines, values=values, line_indexes=line_indexes)
+
+
+def read_env(path: Path) -> EnvDocument:
+    if not path.exists():
+        return EnvDocument(lines=(), values={}, line_indexes={})
+    if not path.is_file():
+        raise ConfigurationError(f"configuration path is not a regular file: {path}")
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as error:
+        raise ConfigurationError(
+            f"configuration file is not valid UTF-8: {path}"
+        ) from error
+    except OSError as error:
+        detail = error.strerror or error.__class__.__name__
+        raise ConfigurationError(
+            f"cannot read configuration file {path}: {detail}"
+        ) from error
+    return parse_env_text(text)
+
+
+def encode_value(value: str) -> str:
+    if "\x00" in value or "\n" in value or "\r" in value:
+        raise ConfigurationError("configuration values must fit on one line")
+    return shlex.quote(value)
+
+
+def render_updates(
+    document: EnvDocument,
+    updates: Mapping[str, str],
+    *,
+    replace: bool = False,
+) -> str:
+    """Render explicit updates and preserve every unselected existing line."""
+    if replace:
+        lines = [
+            "# Generated by scripts/configure.py. Advanced settings remain in .env.example.",
+        ]
+        for key, value in updates.items():
+            lines.append(f"{key}={encode_value(value)}")
+        return "\n".join(lines) + "\n"
+
+    lines = list(document.lines)
+    append_lines: list[str] = []
+    for key, value in updates.items():
+        rendered = f"{key}={encode_value(value)}"
+        if key in document.line_indexes:
+            index = document.line_indexes[key]
+            if document.values[key] == value:
+                continue
+            match = ASSIGNMENT_RE.fullmatch(lines[index])
+            assert match is not None
+            _expression, comment = split_inline_comment(match.group("value"))
+            lines[index] = f"{match.group('prefix')}{rendered}{comment}"
+        else:
+            append_lines.append(rendered)
+    if append_lines:
+        if lines and lines[-1] != "":
+            lines.append("")
+        lines.append("# Added by scripts/configure.py.")
+        lines.extend(append_lines)
+    return "\n".join(lines) + "\n"
+
+
+def write_env(path: Path, text: str) -> None:
+    """Atomically write the secret-bearing file with owner-only permissions."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    file_descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        os.fchmod(file_descriptor, stat.S_IRUSR | stat.S_IWUSR)
+        with os.fdopen(file_descriptor, "w", encoding="utf-8") as stream:
+            stream.write(text)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary_path, path)
+        path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    finally:
+        if temporary_path.exists():
+            temporary_path.unlink()
+
+
+def resolved_values(
+    document: EnvDocument,
+    environment: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Resolve defaults, then process inputs, then the file sourced by bring-up."""
+    result = dict(DEFAULTS)
+    result.update({key: value for key, value in (environment or {}).items() if value})
+    result.update(document.values)
+    gateway = result.get("OPENSHELL_GATEWAY", DEFAULTS["OPENSHELL_GATEWAY"])
+    if not result.get("OPENSHELL_GATEWAY_ENDPOINT") and gateway in GATEWAY_ENDPOINTS:
+        result["OPENSHELL_GATEWAY_ENDPOINT"] = GATEWAY_ENDPOINTS[gateway]
+    return result
+
+
+def profile_keys(profile: str) -> tuple[str, ...]:
+    if profile == "slack":
+        return SLACK_REQUIRED
+    if profile == "outlook":
+        return OUTLOOK_REQUIRED
+    if profile == "both":
+        return OUTLOOK_REQUIRED + SLACK_REQUIRED
+    raise ConfigurationError(f"unknown messaging profile: {profile}")
+
+
+def profile_errors(
+    values: Mapping[str, str], *, require_channel: bool = True
+) -> list[str]:
+    """Return names-only errors for partial or absent messaging profiles."""
+    errors: list[str] = []
+    enabled_profiles = 0
+    for name, required in (("Outlook", OUTLOOK_REQUIRED), ("Slack", SLACK_REQUIRED)):
+        present = [key for key in required if values.get(key)]
+        missing = [key for key in required if not values.get(key)]
+        if present and missing:
+            errors.append(f"partial {name} configuration; missing {', '.join(missing)}")
+        elif present:
+            enabled_profiles += 1
+    if require_channel and enabled_profiles == 0:
+        errors.append("no messaging profile is fully configured")
+    return errors
+
+
+def enabled_profiles(values: Mapping[str, str]) -> tuple[str, ...]:
+    profiles: list[str] = []
+    if all(values.get(key) for key in OUTLOOK_REQUIRED):
+        profiles.append("Outlook")
+    if all(values.get(key) for key in SLACK_REQUIRED):
+        profiles.append("Slack")
+    return tuple(profiles)

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/preflight.py
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/preflight.py
@@ -1,0 +1,888 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run read-only configuration and prerequisite checks before recipe bring-up."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import shutil
+import socket
+import stat
+import subprocess
+import sys
+import urllib.parse
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+EXAMPLE_DIR = SCRIPT_DIR.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import inference_preflight  # noqa: E402
+import slack_socket_preflight  # noqa: E402
+from lib.configuration import (  # noqa: E402
+    DEFAULTS,
+    GATEWAY_ENDPOINTS,
+    OUTLOOK_REQUIRED,
+    SECRET_KEYS,
+    SLACK_REQUIRED,
+    ConfigurationError,
+    enabled_profiles,
+    profile_errors,
+    read_env,
+    resolved_values,
+)
+
+EXPECTED_OPENSHELL_VERSION = "0.0.85"
+REPOSITORY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9-]{0,38}/[A-Za-z0-9._-]+$")
+SLACK_ID_RE = re.compile(r"^[UW][A-Z0-9]{8,}$")
+
+
+@dataclass(frozen=True)
+class Check:
+    name: str
+    scope: str
+    status: str
+    detail: str
+    remediation: str = ""
+
+
+CommandRunner = Callable[[Sequence[str], float], subprocess.CompletedProcess[str]]
+PortAvailable = Callable[[int], bool]
+EndpointReachable = Callable[[str, float], bool]
+
+
+def run_command(
+    command: Sequence[str], timeout: float = 5.0
+) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            list(command),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return subprocess.CompletedProcess(list(command), 124, "", "")
+
+
+def port_is_available(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        try:
+            listener.bind(("0.0.0.0", port))
+        except OSError:
+            return False
+    return True
+
+
+def endpoint_is_reachable(endpoint: str, timeout: float = 2.0) -> bool:
+    parsed = urllib.parse.urlsplit(endpoint)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return False
+    try:
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    except ValueError:
+        return False
+    try:
+        with socket.create_connection((parsed.hostname, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def integer_value(
+    values: Mapping[str, str], key: str, default: int
+) -> tuple[int, str | None]:
+    raw = values.get(key, str(default))
+    try:
+        value = int(raw)
+    except ValueError:
+        return default, f"{key} must be an integer"
+    if not 1 <= value <= 65535:
+        return default, f"{key} must be between 1 and 65535"
+    return value, None
+
+
+def redact(text: str, values: Mapping[str, str]) -> str:
+    sanitized = text
+    for key in SECRET_KEYS:
+        value = values.get(key, "")
+        if value:
+            sanitized = sanitized.replace(value, "<redacted>")
+    return sanitized
+
+
+def credential_status(values: Mapping[str, str]) -> dict[str, str]:
+    """Report credential presence without returning credential values."""
+    inference_key = values.get("OPENAI_API_KEY") or values.get("COMPATIBLE_API_KEY")
+    credentials = {
+        "Inference API key": bool(inference_key),
+        "Slack bot access token": bool(values.get("SLACK_BOT_TOKEN")),
+        "Slack app-level token": bool(values.get("SLACK_APP_TOKEN")),
+        "GitHub access token": bool(values.get("GITHUB_TOKEN")),
+        "ATIF relay access token": bool(values.get("ATIF_RELAY_AUTH_TOKEN")),
+    }
+    return {
+        name: "configured" if configured else "not configured"
+        for name, configured in credentials.items()
+    }
+
+
+def configuration_checks(env_file: Path, values: Mapping[str, str]) -> list[Check]:
+    checks: list[Check] = []
+    if env_file.is_file():
+        permissions = stat.S_IMODE(env_file.stat().st_mode)
+        if permissions & (stat.S_IRWXG | stat.S_IRWXO):
+            checks.append(
+                Check(
+                    "configuration file permissions",
+                    "local",
+                    "FAIL",
+                    "the configuration file is accessible beyond its owner",
+                    f"Run: chmod 600 {env_file}",
+                )
+            )
+        else:
+            checks.append(
+                Check(
+                    "configuration file permissions",
+                    "local",
+                    "PASS",
+                    "owner-only access",
+                )
+            )
+    else:
+        checks.append(
+            Check(
+                "configuration file",
+                "configuration",
+                "FAIL",
+                "the configuration file does not exist",
+                "Run: python3 scripts/configure.py",
+            )
+        )
+
+    errors = profile_errors(values)
+    checks.append(
+        Check(
+            "messaging configuration",
+            "configuration",
+            "FAIL" if errors else "PASS",
+            "; ".join(errors) if errors else ", ".join(enabled_profiles(values)),
+            "Run: python3 scripts/configure.py" if errors else "",
+        )
+    )
+
+    inference_key = values.get("OPENAI_API_KEY") or values.get("COMPATIBLE_API_KEY")
+    inference_setting = values.get("NEMOCLAW_INFERENCE_PREFLIGHT", "1")
+    if inference_setting not in {"0", "1"}:
+        checks.append(
+            Check(
+                "inference configuration",
+                "configuration",
+                "FAIL",
+                "NEMOCLAW_INFERENCE_PREFLIGHT must be 0 or 1",
+                "Set NEMOCLAW_INFERENCE_PREFLIGHT=1, or use 0 only for intentional offline setup",
+            )
+        )
+    elif not inference_key and inference_setting == "1":
+        checks.append(
+            Check(
+                "inference configuration",
+                "configuration",
+                "FAIL",
+                "no inference API key is configured",
+                "Set COMPATIBLE_API_KEY, or use the documented intentional offline bypass",
+            )
+        )
+    else:
+        checks.append(
+            Check(
+                "inference configuration",
+                "configuration",
+                "PASS" if inference_key else "WARN",
+                "API key configured; value redacted"
+                if inference_key
+                else "intentional offline bypass enabled; the agent will have no inference",
+            )
+        )
+
+    endpoint = values.get(
+        "NEMOCLAW_ENDPOINT_URL",
+        values.get("OPENAI_BASE_URL", "https://integrate.api.nvidia.com/v1"),
+    )
+    try:
+        inference_preflight.completion_url(endpoint)
+        endpoint_status = Check(
+            "inference endpoint",
+            "configuration",
+            "PASS",
+            inference_preflight.display_endpoint(endpoint),
+        )
+    except inference_preflight.PreflightError as error:
+        endpoint_status = Check(
+            "inference endpoint",
+            "configuration",
+            "FAIL",
+            str(error),
+            "Set NEMOCLAW_ENDPOINT_URL to HTTPS or an allowed loopback HTTP endpoint",
+        )
+    checks.append(endpoint_status)
+
+    if not values.get("NEMOCLAW_MODEL"):
+        checks.append(
+            Check(
+                "inference model",
+                "configuration",
+                "FAIL",
+                "NEMOCLAW_MODEL is empty",
+                f"Set NEMOCLAW_MODEL={DEFAULTS['NEMOCLAW_MODEL']}",
+            )
+        )
+    else:
+        checks.append(
+            Check(
+                "inference model",
+                "configuration",
+                "PASS",
+                values["NEMOCLAW_MODEL"],
+            )
+        )
+
+    if values.get("NEMOCLAW_SLACK_RICH_BLOCKS", "true") not in {"true", "false"}:
+        checks.append(
+            Check(
+                "Slack rich blocks",
+                "configuration",
+                "FAIL",
+                "NEMOCLAW_SLACK_RICH_BLOCKS must be true or false",
+            )
+        )
+    if all(values.get(key) for key in SLACK_REQUIRED):
+        token_shapes_valid = values["SLACK_BOT_TOKEN"].startswith("xoxb-") and values[
+            "SLACK_APP_TOKEN"
+        ].startswith("xapp-")
+        checks.append(
+            Check(
+                "Slack token formats",
+                "configuration",
+                "PASS" if token_shapes_valid else "FAIL",
+                "bot and app-level token prefixes are valid"
+                if token_shapes_valid
+                else "expected an xoxb- bot access token and xapp- app-level token",
+                "Update the Slack values with the documented token types"
+                if not token_shapes_valid
+                else "",
+            )
+        )
+    if values.get("OUTLOOK_LOGIN_CACHE", "1") not in {"0", "1", "2"}:
+        checks.append(
+            Check(
+                "Outlook login cache",
+                "configuration",
+                "FAIL",
+                "OUTLOOK_LOGIN_CACHE must be 0, 1, or 2",
+            )
+        )
+    repository = values.get("GITHUB_READONLY_REPO", DEFAULTS["GITHUB_READONLY_REPO"])
+    checks.append(
+        Check(
+            "GitHub read-only repository",
+            "configuration",
+            "PASS" if REPOSITORY_RE.fullmatch(repository) else "FAIL",
+            repository
+            if REPOSITORY_RE.fullmatch(repository)
+            else "expected owner/repository",
+            "Set GITHUB_READONLY_REPO to owner/repository"
+            if not REPOSITORY_RE.fullmatch(repository)
+            else "",
+        )
+    )
+
+    slack_ids = [
+        item.strip()
+        for item in values.get("SLACK_ALLOWED_IDS", "").split(",")
+        if item.strip()
+    ]
+    invalid_ids = [item for item in slack_ids if not SLACK_ID_RE.fullmatch(item)]
+    if invalid_ids:
+        checks.append(
+            Check(
+                "Slack allowlist",
+                "configuration",
+                "FAIL",
+                f"{len(invalid_ids)} member ID value(s) have an invalid format",
+                "Use comma-separated Slack member IDs that start with U or W",
+            )
+        )
+    elif all(values.get(key) for key in SLACK_REQUIRED):
+        checks.append(
+            Check(
+                "Slack allowlist",
+                "configuration",
+                "PASS" if slack_ids else "WARN",
+                f"{len(slack_ids)} member ID(s) configured"
+                if slack_ids
+                else "empty allowlist enables responses to every workspace member",
+            )
+        )
+    return checks
+
+
+def tool_checks(
+    values: Mapping[str, str],
+    *,
+    command_runner: CommandRunner,
+    endpoint_reachable: EndpointReachable,
+) -> list[Check]:
+    checks = [
+        Check(
+            "Python version",
+            "local",
+            "PASS" if sys.version_info >= (3, 10) else "FAIL",
+            f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+            "Install Python 3.10 or newer" if sys.version_info < (3, 10) else "",
+        )
+    ]
+    for command in ("git", "docker", "openshell", "curl", "openssl"):
+        path = shutil.which(command)
+        checks.append(
+            Check(
+                f"{command} command",
+                "local",
+                "PASS" if path else "FAIL",
+                "available" if path else "not found in PATH",
+                f"Install {command} and add it to PATH" if not path else "",
+            )
+        )
+
+    if shutil.which("docker"):
+        docker_info = command_runner(("docker", "info"), 8)
+        checks.append(
+            Check(
+                "Docker daemon",
+                "local",
+                "PASS" if docker_info.returncode == 0 else "FAIL",
+                "reachable" if docker_info.returncode == 0 else "not reachable",
+                "Start the Docker daemon" if docker_info.returncode else "",
+            )
+        )
+        compose = command_runner(("docker", "compose", "version"), 5)
+        checks.append(
+            Check(
+                "Docker Compose",
+                "local",
+                "PASS" if compose.returncode == 0 else "FAIL",
+                "available"
+                if compose.returncode == 0
+                else "docker compose is unavailable",
+                "Install the Docker Compose plugin" if compose.returncode else "",
+            )
+        )
+
+    if shutil.which("openshell"):
+        version = command_runner(("openshell", "--version"), 5)
+        version_text = (version.stdout or version.stderr).strip()
+        match = re.search(r"\b(\d+\.\d+\.\d+)\b", version_text)
+        installed = match.group(1) if match else "unknown"
+        status = "PASS" if installed == EXPECTED_OPENSHELL_VERSION else "WARN"
+        checks.append(
+            Check(
+                "OpenShell version",
+                "local",
+                status,
+                installed,
+                f"Install OpenShell {EXPECTED_OPENSHELL_VERSION} for the documented configuration"
+                if status == "WARN"
+                else "",
+            )
+        )
+        gateway = values.get("OPENSHELL_GATEWAY", DEFAULTS["OPENSHELL_GATEWAY"])
+        endpoint = values.get("OPENSHELL_GATEWAY_ENDPOINT") or GATEWAY_ENDPOINTS.get(
+            gateway, ""
+        )
+        if endpoint:
+            reachable = endpoint_reachable(endpoint, 2)
+            checks.append(
+                Check(
+                    "OpenShell gateway endpoint",
+                    "local",
+                    "PASS" if reachable else "FAIL",
+                    "reachable" if reachable else "not reachable",
+                    "Start the configured OpenShell gateway service"
+                    if not reachable
+                    else "",
+                )
+            )
+        else:
+            checks.append(
+                Check(
+                    "OpenShell gateway endpoint",
+                    "configuration",
+                    "FAIL",
+                    "no default endpoint is known for the configured gateway",
+                    "Set OPENSHELL_GATEWAY_ENDPOINT",
+                )
+            )
+        registered = command_runner(
+            ("openshell", "gateway", "info", "--gateway", gateway), 5
+        )
+        checks.append(
+            Check(
+                "OpenShell gateway registration",
+                "local",
+                "PASS" if registered.returncode == 0 else "FAIL",
+                "registered" if registered.returncode == 0 else "not registered",
+                "Run scripts/01-gateway.sh after the endpoint is running"
+                if registered.returncode
+                else "",
+            )
+        )
+        settings = command_runner(
+            ("openshell", "settings", "get", "--global", "--gateway", gateway), 5
+        )
+        provider_v2 = settings.returncode == 0 and bool(
+            re.search(r"providers_v2_enabled\s*=\s*true", settings.stdout)
+        )
+        checks.append(
+            Check(
+                "OpenShell provider v2",
+                "local",
+                "PASS" if provider_v2 else "FAIL",
+                "enabled" if provider_v2 else "not enabled or unreadable",
+                "Run: openshell settings set --global --key providers_v2_enabled --value true --yes"
+                if not provider_v2
+                else "",
+            )
+        )
+    return checks
+
+
+def local_port_checks(
+    values: Mapping[str, str], *, port_available: PortAvailable
+) -> list[Check]:
+    source_port, source_error = integer_value(values, "SOURCE_ETL_API_PORT", 3100)
+    postgres_port, postgres_error = integer_value(
+        values, "SOURCE_ETL_POSTGRES_PORT", 5432
+    )
+    ports = {
+        "Phoenix UI": 6006,
+        "OpenTelemetry gRPC": 4317,
+        "OpenTelemetry HTTP": 4318,
+        "source API": source_port,
+        "source PostgreSQL": postgres_port,
+    }
+    checks: list[Check] = []
+    if source_error:
+        checks.append(Check("source API port", "configuration", "FAIL", source_error))
+        ports.pop("source API")
+    if postgres_error:
+        checks.append(
+            Check("source PostgreSQL port", "configuration", "FAIL", postgres_error)
+        )
+        ports.pop("source PostgreSQL")
+    if values.get("ATIF_EXPORT_MODE", "local") == "relay":
+        relay_endpoint = values.get(
+            "ATIF_RELAY_ENDPOINT", "https://host.openshell.internal:18443"
+        )
+        parsed_relay = urllib.parse.urlsplit(relay_endpoint)
+        try:
+            relay_port = parsed_relay.port or 443
+        except ValueError:
+            relay_port = 0
+        if (
+            parsed_relay.scheme != "https"
+            or not parsed_relay.hostname
+            or not relay_port
+        ):
+            checks.append(
+                Check(
+                    "ATIF relay endpoint",
+                    "configuration",
+                    "FAIL",
+                    "ATIF_RELAY_ENDPOINT must be a valid HTTPS URL",
+                )
+            )
+        else:
+            ports["ATIF relay"] = relay_port
+        if values.get("ATIF_RELAY_BACKEND") == "minio":
+            ports["MinIO API"] = 9000
+            ports["MinIO console"] = 9001
+    for name, port in ports.items():
+        available = port_available(port)
+        checks.append(
+            Check(
+                f"{name} port",
+                "local",
+                "PASS" if available else "WARN",
+                f"host port {port} is available"
+                if available
+                else f"host port {port} is already in use",
+                "Confirm that the existing listener belongs to this recipe before bring-up"
+                if not available
+                else "",
+            )
+        )
+    return checks
+
+
+def optional_component_checks(values: Mapping[str, str]) -> list[Check]:
+    checks: list[Check] = []
+    ca_bundle = Path(
+        values.get("NEMOCLAW_HOST_CA_BUNDLE", "/etc/ssl/certs/ca-certificates.crt")
+    )
+    ca_ready = (
+        ca_bundle.is_absolute()
+        and ca_bundle.is_file()
+        and os.access(ca_bundle, os.R_OK)
+    )
+    checks.append(
+        Check(
+            "host certificate authority (CA) bundle",
+            "local",
+            "PASS" if ca_ready else "FAIL",
+            "readable regular file"
+            if ca_ready
+            else "path is not a readable absolute file",
+            "Set NEMOCLAW_HOST_CA_BUNDLE to the host's readable CA bundle"
+            if not ca_ready
+            else "",
+        )
+    )
+    checks.append(
+        Check(
+            "authenticated GitHub reads",
+            "optional",
+            "PASS" if values.get("GITHUB_TOKEN") else "SKIP",
+            "enabled; access token value redacted"
+            if values.get("GITHUB_TOKEN")
+            else "disabled; anonymous requests remain subject to GitHub limits",
+        )
+    )
+    github_etl = values.get("SOURCE_ETL_GITHUB_ENABLED", "0")
+    github_etl_repository = values.get("SOURCE_ETL_GITHUB_REPO", "NVIDIA/NemoClaw")
+    github_etl_valid = bool(REPOSITORY_RE.fullmatch(github_etl_repository))
+    checks.append(
+        Check(
+            "GitHub source ETL",
+            "optional",
+            "PASS"
+            if github_etl == "1" and github_etl_valid
+            else "SKIP"
+            if github_etl == "0"
+            else "FAIL",
+            f"enabled for {github_etl_repository}"
+            if github_etl == "1" and github_etl_valid
+            else "disabled"
+            if github_etl == "0"
+            else "expected enable flag 0 or 1 and repository owner/name",
+        )
+    )
+    export_mode = values.get("ATIF_EXPORT_MODE", "local")
+    if export_mode == "local":
+        checks.append(
+            Check("ATIF relay export", "optional", "SKIP", "local export selected")
+        )
+    elif export_mode == "relay":
+        backend = values.get("ATIF_RELAY_BACKEND", "")
+        valid = backend in {"s3", "minio", "s3-compatible"}
+        missing: list[str] = []
+        if backend in {"s3", "s3-compatible"} and not values.get("ATIF_RELAY_BUCKET"):
+            missing.append("ATIF_RELAY_BUCKET")
+        if backend == "s3-compatible":
+            for key in (
+                "ATIF_RELAY_S3_ENDPOINT",
+                "ATIF_RELAY_S3_ACCESS_KEY",
+                "ATIF_RELAY_S3_SECRET_KEY",
+            ):
+                if not values.get(key):
+                    missing.append(key)
+        valid = valid and not missing
+        detail = (
+            f"relay enabled with {backend}"
+            if valid
+            else "missing or invalid values: "
+            + ", ".join(missing or ["ATIF_RELAY_BACKEND"])
+        )
+        checks.append(
+            Check(
+                "ATIF relay export",
+                "optional",
+                "PASS" if valid else "FAIL",
+                detail,
+                "Complete the selected relay backend values in .env"
+                if not valid
+                else "",
+            )
+        )
+    else:
+        checks.append(
+            Check(
+                "ATIF relay export",
+                "optional",
+                "FAIL",
+                "ATIF_EXPORT_MODE must be local or relay",
+            )
+        )
+    return checks
+
+
+def external_checks(values: Mapping[str, str], timeout: float) -> list[Check]:
+    checks: list[Check] = []
+    inference_setting = values.get("NEMOCLAW_INFERENCE_PREFLIGHT", "1")
+    inference_key = values.get("OPENAI_API_KEY") or values.get("COMPATIBLE_API_KEY")
+    if inference_setting == "1" and inference_key:
+        endpoint = values.get(
+            "NEMOCLAW_ENDPOINT_URL",
+            values.get("OPENAI_BASE_URL", "https://integrate.api.nvidia.com/v1"),
+        )
+        try:
+            inference_preflight.run_preflight(
+                endpoint,
+                values.get("NEMOCLAW_MODEL", DEFAULTS["NEMOCLAW_MODEL"]),
+                inference_key,
+                timeout,
+            )
+            checks.append(
+                Check(
+                    "inference endpoint and structured tool call",
+                    "external",
+                    "PASS",
+                    "validated by scripts/inference_preflight.py",
+                )
+            )
+        except inference_preflight.PreflightError as error:
+            checks.append(
+                Check(
+                    "inference endpoint and structured tool call",
+                    "external",
+                    "FAIL",
+                    str(error),
+                )
+            )
+    else:
+        checks.append(
+            Check(
+                "inference endpoint and structured tool call",
+                "external",
+                "SKIP",
+                "not configured for an external check",
+            )
+        )
+
+    if all(values.get(key) for key in SLACK_REQUIRED):
+        try:
+            slack_socket_preflight.run_preflight(values["SLACK_APP_TOKEN"], timeout)
+            checks.append(
+                Check(
+                    "Slack Socket Mode",
+                    "external",
+                    "PASS",
+                    "validated by scripts/slack_socket_preflight.py",
+                )
+            )
+        except slack_socket_preflight.SlackPreflightError as error:
+            checks.append(Check("Slack Socket Mode", "external", "FAIL", str(error)))
+    else:
+        checks.append(
+            Check("Slack Socket Mode", "external", "SKIP", "Slack is disabled")
+        )
+
+    if all(values.get(key) for key in OUTLOOK_REQUIRED):
+        checks.append(
+            Check(
+                "Outlook access",
+                "external",
+                "SKIP",
+                "device-code sign-in remains an explicit bring-up step",
+            )
+        )
+    else:
+        checks.append(
+            Check("Outlook access", "external", "SKIP", "Outlook is disabled")
+        )
+    return checks
+
+
+def skipped_external_checks(values: Mapping[str, str]) -> list[Check]:
+    checks = [
+        Check(
+            "inference endpoint and structured tool call",
+            "external",
+            "SKIP",
+            "not contacted; rerun with --external",
+        )
+    ]
+    slack_detail = (
+        "not contacted; rerun with --external"
+        if all(values.get(key) for key in SLACK_REQUIRED)
+        else "Slack is disabled"
+    )
+    checks.append(Check("Slack Socket Mode", "external", "SKIP", slack_detail))
+    outlook_detail = (
+        "device-code sign-in remains an explicit bring-up step"
+        if all(values.get(key) for key in OUTLOOK_REQUIRED)
+        else "Outlook is disabled"
+    )
+    checks.append(Check("Outlook access", "external", "SKIP", outlook_detail))
+    return checks
+
+
+def next_command(checks: Sequence[Check], *, external: bool) -> str:
+    failed = [check for check in checks if check.status == "FAIL"]
+    if any(check.scope == "configuration" for check in failed):
+        return "python3 scripts/configure.py"
+    if failed:
+        if external and all(check.scope == "external" for check in failed):
+            return "python3 scripts/preflight.py --external"
+        return "python3 scripts/preflight.py"
+    if not external:
+        return "python3 scripts/preflight.py --external"
+    return "bash scripts/bring-up.sh"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--env-file", type=Path, default=EXAMPLE_DIR / ".env")
+    parser.add_argument(
+        "--external",
+        action="store_true",
+        help="Contact the configured inference and Slack services with bounded checks",
+    )
+    parser.add_argument("--timeout", type=float, default=10.0)
+    parser.add_argument("--json", action="store_true", help="Print redacted JSON")
+    return parser
+
+
+def run_preflight(
+    env_file: Path,
+    *,
+    environment: Mapping[str, str] | None = None,
+    external: bool = False,
+    timeout: float = 10.0,
+    command_runner: CommandRunner = run_command,
+    port_available: PortAvailable = port_is_available,
+    endpoint_reachable: EndpointReachable = endpoint_is_reachable,
+) -> tuple[dict[str, object], int]:
+    if environment is None:
+        environment = os.environ
+    document = read_env(env_file)
+    values = resolved_values(document, environment)
+    checks = configuration_checks(env_file, values)
+    checks.extend(
+        tool_checks(
+            values,
+            command_runner=command_runner,
+            endpoint_reachable=endpoint_reachable,
+        )
+    )
+    checks.extend(local_port_checks(values, port_available=port_available))
+    checks.extend(optional_component_checks(values))
+    checks.extend(
+        external_checks(values, timeout)
+        if external
+        else skipped_external_checks(values)
+    )
+    checks = [
+        Check(
+            item.name,
+            item.scope,
+            item.status,
+            redact(item.detail, values),
+            redact(item.remediation, values),
+        )
+        for item in checks
+    ]
+    command = next_command(checks, external=external)
+    result: dict[str, object] = {
+        "ok": not any(check.status == "FAIL" for check in checks),
+        "external_checks_requested": external,
+        "resolved": {
+            "sandbox": values.get("SANDBOX_NAME", DEFAULTS["SANDBOX_NAME"]),
+            "gateway": values.get("OPENSHELL_GATEWAY", DEFAULTS["OPENSHELL_GATEWAY"]),
+            "model": values.get("NEMOCLAW_MODEL", DEFAULTS["NEMOCLAW_MODEL"]),
+            "messaging_profiles": list(enabled_profiles(values)),
+            "credential_status": credential_status(values),
+        },
+        "checks": [asdict(check) for check in checks],
+        "next_command": command,
+    }
+    return result, 0 if result["ok"] else 1
+
+
+def print_text(result: Mapping[str, object]) -> None:
+    resolved = result["resolved"]
+    assert isinstance(resolved, dict)
+    print("Resolved configuration (credentials redacted):")
+    print(f"  Sandbox: {resolved['sandbox']}")
+    print(f"  Gateway: {resolved['gateway']}")
+    print(f"  Model: {resolved['model']}")
+    profiles = resolved["messaging_profiles"]
+    assert isinstance(profiles, list)
+    print(f"  Messaging profiles: {', '.join(profiles) or 'none'}")
+    credentials = resolved["credential_status"]
+    assert isinstance(credentials, dict)
+    print("  Credentials (values redacted):")
+    for name, status in credentials.items():
+        print(f"    {name}: {status}")
+    print("\nChecks:")
+    checks = result["checks"]
+    assert isinstance(checks, list)
+    for item in checks:
+        assert isinstance(item, dict)
+        print(
+            f"  [{item['status']}] [{item['scope']}] {item['name']}: {item['detail']}"
+        )
+        if item["remediation"]:
+            print(f"    Remediation: {item['remediation']}")
+    print(f"\nResult: {'PASS' if result['ok'] else 'FAIL'}")
+    print(f"Next command: {result['next_command']}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if not math.isfinite(args.timeout) or args.timeout <= 0 or args.timeout > 60:
+        print(
+            "--timeout must be greater than 0 and at most 60 seconds", file=sys.stderr
+        )
+        return 2
+    try:
+        result, exit_code = run_preflight(
+            args.env_file,
+            external=args.external,
+            timeout=args.timeout,
+        )
+    except ConfigurationError as error:
+        result = {
+            "ok": False,
+            "external_checks_requested": args.external,
+            "resolved": {
+                "sandbox": DEFAULTS["SANDBOX_NAME"],
+                "gateway": DEFAULTS["OPENSHELL_GATEWAY"],
+                "model": DEFAULTS["NEMOCLAW_MODEL"],
+                "messaging_profiles": [],
+                "credential_status": credential_status({}),
+            },
+            "checks": [
+                asdict(Check("configuration file", "configuration", "FAIL", str(error)))
+            ],
+            "next_command": "python3 scripts/configure.py",
+        }
+        exit_code = 2
+    if args.json:
+        print(json.dumps(result, sort_keys=True))
+    else:
+        print_text(result)
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/preflight.py
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/preflight.py
@@ -35,6 +35,7 @@ from lib.configuration import (  # noqa: E402
     SLACK_REQUIRED,
     ConfigurationError,
     enabled_profiles,
+    parse_atif_relay_endpoint,
     profile_errors,
     read_env,
     resolved_values,
@@ -493,22 +494,17 @@ def local_port_checks(
         relay_endpoint = values.get(
             "ATIF_RELAY_ENDPOINT", "https://host.openshell.internal:18443"
         )
-        parsed_relay = urllib.parse.urlsplit(relay_endpoint)
         try:
-            relay_port = parsed_relay.port or 443
-        except ValueError:
-            relay_port = 0
-        if (
-            parsed_relay.scheme != "https"
-            or not parsed_relay.hostname
-            or not relay_port
-        ):
+            _canonical_endpoint, _relay_host, relay_port = parse_atif_relay_endpoint(
+                relay_endpoint
+            )
+        except ConfigurationError as error:
             checks.append(
                 Check(
                     "ATIF relay endpoint",
                     "configuration",
                     "FAIL",
-                    "ATIF_RELAY_ENDPOINT must be a valid HTTPS URL",
+                    str(error),
                 )
             )
         else:

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/tests/test_configuration_tools.py
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/tests/test_configuration_tools.py
@@ -145,6 +145,14 @@ class ConfigurationDocumentTest(TestCase):
             "https://127.0.0.1:17670", values["OPENSHELL_GATEWAY_ENDPOINT"]
         )
 
+    def test_atif_relay_endpoint_matches_lifecycle_origin_contract(self) -> None:
+        self.assertEqual(
+            ("https://host.openshell.internal:8443", "host.openshell.internal", 8443),
+            CONFIGURATION.parse_atif_relay_endpoint(
+                "https://host.openshell.internal:08443/"
+            ),
+        )
+
 
 class GuidedConfigurationTest(TestCase):
     def test_non_interactive_slack_profile_preserves_existing_file(self) -> None:
@@ -556,6 +564,41 @@ class ConsolidatedPreflightTest(TestCase):
         self.assertIn(3200, observed)
         self.assertIn(5544, observed)
         self.assertIn(19443, observed)
+
+    def test_invalid_atif_relay_origins_fail_before_port_check(self) -> None:
+        invalid_endpoints = {
+            "path": "https://host.openshell.internal:18443/unexpected",
+            "query": "https://host.openshell.internal:18443?mode=test",
+            "fragment": "https://host.openshell.internal:18443#relay",
+            "user information": "https://operator:private@host.example:18443",
+            "missing explicit port": "https://host.openshell.internal",
+            "invalid hostname": "https://-invalid.example:18443",
+            "port below range": "https://host.openshell.internal:0",
+            "port above range": "https://host.openshell.internal:65536",
+        }
+
+        for case, endpoint in invalid_endpoints.items():
+            with self.subTest(case=case):
+                values = CONFIGURATION.resolved_values(
+                    CONFIGURATION.parse_env_text(
+                        f"ATIF_EXPORT_MODE=relay\nATIF_RELAY_ENDPOINT={endpoint}\n"
+                    ),
+                    {},
+                )
+                observed: list[int] = []
+
+                checks = PREFLIGHT.local_port_checks(
+                    values,
+                    port_available=lambda port: observed.append(port) or True,
+                )
+
+                failure = next(
+                    item for item in checks if item.name == "ATIF relay endpoint"
+                )
+                self.assertEqual("FAIL", failure.status)
+                self.assertNotIn(endpoint, failure.detail)
+                self.assertNotIn(18443, observed)
+                self.assertNotIn(65536, observed)
 
     def test_missing_configuration_points_to_configurator(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/tests/test_configuration_tools.py
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/scripts/tests/test_configuration_tools.py
@@ -1,0 +1,589 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import patch
+
+SCRIPTS_DIR = Path(__file__).parents[1]
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from lib import configuration as CONFIGURATION  # noqa: E402
+
+
+def load_script(name: str):
+    script = SCRIPTS_DIR / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(f"recipe_{name}", script)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+CONFIGURE = load_script("configure")
+PREFLIGHT = load_script("preflight")
+
+SLACK_ENV = {
+    "COMPATIBLE_API_KEY": "test-inference-secret",
+    "SLACK_BOT_TOKEN": "xoxb-test-bot-secret",
+    "SLACK_APP_TOKEN": "xapp-test-app-secret",
+}
+OUTLOOK_ENV = {
+    "COMPATIBLE_API_KEY": "test-inference-secret",
+    "OUTLOOK_TENANT_ID": "test-tenant",
+    "OUTLOOK_CLIENT_ID": "test-client",
+    "OUTLOOK_TARGET_MAILBOX": "agent@example.test",
+    "OUTLOOK_REPLY_TO": "owner@example.test",
+}
+
+
+class ConfigurationDocumentTest(TestCase):
+    def test_updates_preserve_comments_order_and_unselected_values(self) -> None:
+        original = "# operator note\nUNKNOWN=value\nSLACK_BOT_TOKEN=old\n"
+        document = CONFIGURATION.parse_env_text(original)
+
+        rendered = CONFIGURATION.render_updates(
+            document,
+            {
+                "SLACK_BOT_TOKEN": "xoxb-new value",
+                "SLACK_APP_TOKEN": "xapp-new",
+            },
+        )
+
+        self.assertIn("# operator note\nUNKNOWN=value", rendered)
+        self.assertIn("SLACK_BOT_TOKEN='xoxb-new value'", rendered)
+        self.assertIn("SLACK_APP_TOKEN=xapp-new", rendered)
+        self.assertEqual(
+            "value", CONFIGURATION.parse_env_text(rendered).values["UNKNOWN"]
+        )
+
+    def test_duplicate_assignment_fails_instead_of_guessing(self) -> None:
+        with self.assertRaisesRegex(CONFIGURATION.ConfigurationError, "duplicate"):
+            CONFIGURATION.parse_env_text("SLACK_BOT_TOKEN=one\nSLACK_BOT_TOKEN=two\n")
+
+    def test_invalid_unquoted_space_fails(self) -> None:
+        with self.assertRaisesRegex(CONFIGURATION.ConfigurationError, "shell quoting"):
+            CONFIGURATION.parse_env_text("NEMOCLAW_MODEL=two values\n")
+
+    def test_inline_comments_and_hash_values_are_parsed_without_execution(self) -> None:
+        document = CONFIGURATION.parse_env_text(
+            "FIRST=value # operator note\n"
+            "SECOND=value#suffix\n"
+            "THIRD='value # quoted'\n"
+            "FOURTH=#leading-hash\n"
+        )
+
+        self.assertEqual("value", document.values["FIRST"])
+        self.assertEqual("value#suffix", document.values["SECOND"])
+        self.assertEqual("value # quoted", document.values["THIRD"])
+        self.assertEqual("#leading-hash", document.values["FOURTH"])
+
+    def test_update_keeps_assignment_style_and_inline_comment(self) -> None:
+        original = "  export SANDBOX_NAME=old-name  # operator note\n"
+        document = CONFIGURATION.parse_env_text(original)
+
+        unchanged = CONFIGURATION.render_updates(document, {"SANDBOX_NAME": "old-name"})
+        changed = CONFIGURATION.render_updates(document, {"SANDBOX_NAME": "new-name"})
+
+        self.assertEqual(original, unchanged)
+        self.assertEqual(
+            "  export SANDBOX_NAME=new-name  # operator note\n",
+            changed,
+        )
+
+    def test_executable_shell_syntax_is_rejected_without_running_it(self) -> None:
+        for text in (
+            "VALUE=$(id)\n",
+            "VALUE=`id`\n",
+            "VALUE=${HOME}\n",
+            "VALUE=valid;id\n",
+            "id\n",
+        ):
+            with (
+                self.subTest(text=text),
+                self.assertRaisesRegex(
+                    CONFIGURATION.ConfigurationError,
+                    r"unsupported|not a supported",
+                ),
+            ):
+                CONFIGURATION.parse_env_text(text)
+
+        quoted = CONFIGURATION.parse_env_text("VALUE='${literal};value'\n")
+        self.assertEqual("${literal};value", quoted.values["VALUE"])
+
+    def test_atomic_write_uses_owner_only_permissions(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / ".env"
+            CONFIGURATION.write_env(path, "SLACK_BOT_TOKEN=xoxb-test\n")
+
+            self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o600)
+            self.assertEqual(
+                path.read_text(encoding="utf-8"), "SLACK_BOT_TOKEN=xoxb-test\n"
+            )
+
+    def test_defaults_resolve_without_overwriting_file_values(self) -> None:
+        document = CONFIGURATION.parse_env_text("SANDBOX_NAME=custom-sandbox\n")
+        values = CONFIGURATION.resolved_values(
+            document,
+            {"SANDBOX_NAME": "process-sandbox"},
+        )
+
+        self.assertEqual("custom-sandbox", values["SANDBOX_NAME"])
+        self.assertEqual(CONFIGURATION.DEFAULT_MODEL, values["NEMOCLAW_MODEL"])
+        self.assertEqual(
+            "https://127.0.0.1:17670", values["OPENSHELL_GATEWAY_ENDPOINT"]
+        )
+
+
+class GuidedConfigurationTest(TestCase):
+    def test_non_interactive_slack_profile_preserves_existing_file(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / ".env"
+            path.write_text(
+                "# keep this comment\n"
+                "CUSTOM_SETTING=keep-me\n"
+                "SANDBOX_NAME=existing\n"
+                "NEMOCLAW_INFERENCE_PREFLIGHT=0\n",
+                encoding="utf-8",
+            )
+            path.chmod(0o600)
+            output = io.StringIO()
+            with (
+                patch.dict(os.environ, SLACK_ENV, clear=True),
+                patch("sys.stdout", output),
+            ):
+                exit_code = CONFIGURE.main(
+                    [
+                        "--non-interactive",
+                        "--profile",
+                        "slack",
+                        "--env-file",
+                        str(path),
+                    ]
+                )
+
+            self.assertEqual(0, exit_code)
+            result = CONFIGURATION.read_env(path)
+            self.assertEqual("keep-me", result.values["CUSTOM_SETTING"])
+            self.assertEqual("existing", result.values["SANDBOX_NAME"])
+            self.assertEqual("0", result.values["NEMOCLAW_INFERENCE_PREFLIGHT"])
+            self.assertEqual(
+                SLACK_ENV["SLACK_BOT_TOKEN"], result.values["SLACK_BOT_TOKEN"]
+            )
+            self.assertNotIn(SLACK_ENV["SLACK_BOT_TOKEN"], output.getvalue())
+            self.assertNotIn(SLACK_ENV["SLACK_APP_TOKEN"], output.getvalue())
+            self.assertNotIn(SLACK_ENV["COMPATIBLE_API_KEY"], output.getvalue())
+            self.assertEqual(0o600, stat.S_IMODE(path.stat().st_mode))
+
+    def test_non_interactive_profiles_generate_required_values(self) -> None:
+        for profile, environment, required in (
+            ("slack", SLACK_ENV, CONFIGURATION.SLACK_REQUIRED),
+            ("outlook", OUTLOOK_ENV, CONFIGURATION.OUTLOOK_REQUIRED),
+            (
+                "both",
+                {**SLACK_ENV, **OUTLOOK_ENV},
+                CONFIGURATION.SLACK_REQUIRED + CONFIGURATION.OUTLOOK_REQUIRED,
+            ),
+        ):
+            with (
+                self.subTest(profile=profile),
+                tempfile.TemporaryDirectory() as temp_dir,
+            ):
+                path = Path(temp_dir) / ".env"
+                with (
+                    patch.dict(os.environ, environment, clear=True),
+                    patch("sys.stdout", io.StringIO()),
+                ):
+                    exit_code = CONFIGURE.main(
+                        [
+                            "--non-interactive",
+                            "--profile",
+                            profile,
+                            "--env-file",
+                            str(path),
+                        ]
+                    )
+                values = CONFIGURATION.read_env(path).values
+                self.assertEqual(0, exit_code)
+                self.assertTrue(all(values.get(key) for key in required))
+                self.assertEqual([], CONFIGURATION.profile_errors(values))
+                if profile == "slack":
+                    self.assertNotIn("OUTLOOK_LOGIN_CACHE", values)
+                if profile == "outlook":
+                    self.assertNotIn("NEMOCLAW_SLACK_RICH_BLOCKS", values)
+
+    def test_missing_non_interactive_value_fails_without_writing(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / ".env"
+            stderr = io.StringIO()
+            with (
+                patch.dict(
+                    os.environ,
+                    {
+                        "COMPATIBLE_API_KEY": "test-inference-secret",
+                        "SLACK_BOT_TOKEN": "xoxb-test-bot-secret",
+                    },
+                    clear=True,
+                ),
+                patch("sys.stderr", stderr),
+            ):
+                exit_code = CONFIGURE.main(
+                    [
+                        "--non-interactive",
+                        "--profile",
+                        "slack",
+                        "--env-file",
+                        str(path),
+                    ]
+                )
+
+            self.assertEqual(2, exit_code)
+            self.assertFalse(path.exists())
+            self.assertIn("SLACK_APP_TOKEN", stderr.getvalue())
+            self.assertNotIn("xoxb-test-bot-secret", stderr.getvalue())
+
+    def test_interactive_and_non_interactive_paths_are_equivalent(self) -> None:
+        environment = {**SLACK_ENV, **OUTLOOK_ENV}
+        document = CONFIGURATION.EnvDocument(lines=(), values={}, line_indexes={})
+        input_answers = iter([""] * 8)
+        secret_answers = iter([""] * 3)
+        _, interactive = CONFIGURE.collect_interactive_updates(
+            document,
+            environment,
+            profile="both",
+            replacements={},
+            input_fn=lambda _prompt: next(input_answers),
+            secret_fn=lambda _prompt: next(secret_answers),
+        )
+        non_interactive = CONFIGURE.collect_non_interactive_updates(
+            document,
+            environment,
+            profile="both",
+            replacements={},
+            replace=False,
+        )
+
+        self.assertEqual(non_interactive, interactive)
+        self.assertEqual(
+            "https://127.0.0.1:17670",
+            interactive["OPENSHELL_GATEWAY_ENDPOINT"],
+        )
+
+    def test_gateway_change_proposes_the_matching_endpoint(self) -> None:
+        document = CONFIGURATION.parse_env_text("OPENSHELL_GATEWAY=openshell\n")
+        input_answers = iter(["", "snap-docker", "", ""])
+        secret_answers = iter([""] * 3)
+
+        _, updates = CONFIGURE.collect_interactive_updates(
+            document,
+            SLACK_ENV,
+            profile="slack",
+            replacements={},
+            input_fn=lambda _prompt: next(input_answers),
+            secret_fn=lambda _prompt: next(secret_answers),
+        )
+
+        self.assertEqual("snap-docker", updates["OPENSHELL_GATEWAY"])
+        self.assertEqual(
+            "http://127.0.0.1:17670",
+            updates["OPENSHELL_GATEWAY_ENDPOINT"],
+        )
+
+    def test_replace_discards_unselected_advanced_values_only_when_requested(
+        self,
+    ) -> None:
+        document = CONFIGURATION.parse_env_text("ADVANCED_SETTING=old\n")
+        updates = CONFIGURE.collect_non_interactive_updates(
+            document,
+            SLACK_ENV,
+            profile="slack",
+            replacements={},
+            replace=True,
+        )
+        rendered = CONFIGURATION.render_updates(document, updates, replace=True)
+
+        self.assertNotIn("ADVANCED_SETTING", rendered)
+        self.assertIn("SLACK_BOT_TOKEN", rendered)
+
+
+def successful_runner(
+    command: tuple[str, ...] | list[str], _timeout: float
+) -> subprocess.CompletedProcess[str]:
+    args = list(command)
+    stdout = ""
+    if args == ["openshell", "--version"]:
+        stdout = "openshell 0.0.85\n"
+    elif args == [
+        "openshell",
+        "settings",
+        "get",
+        "--global",
+        "--gateway",
+        "openshell",
+    ]:
+        stdout = "providers_v2_enabled = true\n"
+    return subprocess.CompletedProcess(args, 0, stdout, "")
+
+
+class ConsolidatedPreflightTest(TestCase):
+    def make_env(self, directory: str, values: dict[str, str] | None = None) -> Path:
+        path = Path(directory) / ".env"
+        ca_bundle = Path(directory) / "ca-certificates.crt"
+        ca_bundle.write_text("test CA bundle\n", encoding="utf-8")
+        settings = {
+            **SLACK_ENV,
+            "NEMOCLAW_HOST_CA_BUNDLE": str(ca_bundle),
+            **(values or {}),
+        }
+        path.write_text(
+            "\n".join(f"{key}={value}" for key, value in settings.items()) + "\n",
+            encoding="utf-8",
+        )
+        path.chmod(0o600)
+        return path
+
+    def test_local_preflight_is_read_only_and_skips_external_services(self) -> None:
+        commands: list[tuple[str, ...]] = []
+
+        def runner(command, timeout):
+            commands.append(tuple(command))
+            return successful_runner(command, timeout)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = self.make_env(temp_dir)
+            with (
+                patch.object(PREFLIGHT.shutil, "which", return_value="/test/tool"),
+                patch.object(
+                    PREFLIGHT.inference_preflight, "run_preflight"
+                ) as inference,
+                patch.object(
+                    PREFLIGHT.slack_socket_preflight, "run_preflight"
+                ) as slack,
+            ):
+                result, exit_code = PREFLIGHT.run_preflight(
+                    path,
+                    environment={},
+                    command_runner=runner,
+                    port_available=lambda _port: True,
+                    endpoint_reachable=lambda _endpoint, _timeout: True,
+                )
+
+        self.assertEqual(0, exit_code)
+        self.assertTrue(result["ok"])
+        inference.assert_not_called()
+        slack.assert_not_called()
+        self.assertEqual(
+            {
+                ("docker", "info"),
+                ("docker", "compose", "version"),
+                ("openshell", "--version"),
+                ("openshell", "gateway", "info", "--gateway", "openshell"),
+                (
+                    "openshell",
+                    "settings",
+                    "get",
+                    "--global",
+                    "--gateway",
+                    "openshell",
+                ),
+            },
+            set(commands),
+        )
+        self.assertEqual(
+            "python3 scripts/preflight.py --external", result["next_command"]
+        )
+
+    def test_external_preflight_reuses_specialized_validators(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = self.make_env(temp_dir)
+            with (
+                patch.object(PREFLIGHT.shutil, "which", return_value="/test/tool"),
+                patch.object(
+                    PREFLIGHT.inference_preflight, "run_preflight"
+                ) as inference,
+                patch.object(
+                    PREFLIGHT.slack_socket_preflight, "run_preflight"
+                ) as slack,
+            ):
+                result, exit_code = PREFLIGHT.run_preflight(
+                    path,
+                    environment={},
+                    external=True,
+                    command_runner=successful_runner,
+                    port_available=lambda _port: True,
+                    endpoint_reachable=lambda _endpoint, _timeout: True,
+                )
+
+        self.assertEqual(0, exit_code)
+        inference.assert_called_once()
+        slack.assert_called_once_with(SLACK_ENV["SLACK_APP_TOKEN"], 10.0)
+        self.assertEqual("bash scripts/bring-up.sh", result["next_command"])
+        serialized = json.dumps(result)
+        self.assertNotIn(SLACK_ENV["SLACK_BOT_TOKEN"], serialized)
+        self.assertNotIn(SLACK_ENV["SLACK_APP_TOKEN"], serialized)
+        self.assertNotIn(SLACK_ENV["COMPATIBLE_API_KEY"], serialized)
+
+    def test_failed_external_check_recommends_the_external_preflight(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = self.make_env(temp_dir)
+            with (
+                patch.object(PREFLIGHT.shutil, "which", return_value="/test/tool"),
+                patch.object(
+                    PREFLIGHT.inference_preflight,
+                    "run_preflight",
+                    side_effect=PREFLIGHT.inference_preflight.PreflightError(
+                        "provider-availability", "test failure", 6
+                    ),
+                ),
+                patch.object(PREFLIGHT.slack_socket_preflight, "run_preflight"),
+            ):
+                result, exit_code = PREFLIGHT.run_preflight(
+                    path,
+                    environment={},
+                    external=True,
+                    command_runner=successful_runner,
+                    port_available=lambda _port: True,
+                    endpoint_reachable=lambda _endpoint, _timeout: True,
+                )
+
+        self.assertEqual(1, exit_code)
+        self.assertEqual(
+            "python3 scripts/preflight.py --external", result["next_command"]
+        )
+
+    def test_non_finite_timeout_is_rejected_before_checks(self) -> None:
+        stderr = io.StringIO()
+        with patch("sys.stderr", stderr):
+            exit_code = PREFLIGHT.main(["--timeout", "nan"])
+
+        self.assertEqual(2, exit_code)
+        self.assertIn("at most 60 seconds", stderr.getvalue())
+
+    def test_invalid_configuration_reports_actionable_names_without_secrets(
+        self,
+    ) -> None:
+        secret = "xoxb-private-test-value"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = self.make_env(
+                temp_dir,
+                {
+                    "SLACK_BOT_TOKEN": secret,
+                    "SLACK_APP_TOKEN": "wrong-token-type",
+                    "NEMOCLAW_SLACK_RICH_BLOCKS": "yes",
+                    "OUTLOOK_TENANT_ID": "partial",
+                    "GITHUB_READONLY_REPO": "invalid",
+                },
+            )
+            values = CONFIGURATION.resolved_values(CONFIGURATION.read_env(path), {})
+            checks = PREFLIGHT.configuration_checks(path, values)
+
+        failures = "\n".join(
+            f"{item.name}: {item.detail}" for item in checks if item.status == "FAIL"
+        )
+        self.assertIn("partial Outlook configuration", failures)
+        self.assertIn("Slack token formats", failures)
+        self.assertIn("Slack rich blocks", failures)
+        self.assertIn("GitHub read-only repository", failures)
+        self.assertNotIn(secret, failures)
+
+    def test_missing_tools_and_gateway_are_reported_before_bring_up(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = self.make_env(temp_dir)
+            with patch.object(PREFLIGHT.shutil, "which", return_value=None):
+                result, exit_code = PREFLIGHT.run_preflight(
+                    path,
+                    environment={},
+                    command_runner=successful_runner,
+                    port_available=lambda _port: True,
+                    endpoint_reachable=lambda _endpoint, _timeout: False,
+                )
+
+        self.assertEqual(1, exit_code)
+        self.assertFalse(result["ok"])
+        self.assertEqual("python3 scripts/preflight.py", result["next_command"])
+        failed_names = {
+            item["name"] for item in result["checks"] if item["status"] == "FAIL"
+        }
+        self.assertIn("docker command", failed_names)
+        self.assertIn("openshell command", failed_names)
+
+    def test_occupied_recipe_port_is_disclosed_as_warning(self) -> None:
+        values = CONFIGURATION.resolved_values(
+            CONFIGURATION.parse_env_text(
+                "COMPATIBLE_API_KEY=test\n"
+                "SLACK_BOT_TOKEN=xoxb-test\n"
+                "SLACK_APP_TOKEN=xapp-test\n"
+            ),
+            {},
+        )
+        checks = PREFLIGHT.local_port_checks(
+            values,
+            port_available=lambda port: port != 6006,
+        )
+
+        phoenix = next(item for item in checks if item.name == "Phoenix UI port")
+        self.assertEqual("WARN", phoenix.status)
+        self.assertIn("already in use", phoenix.detail)
+
+    def test_custom_host_service_ports_are_checked(self) -> None:
+        values = CONFIGURATION.resolved_values(
+            CONFIGURATION.parse_env_text(
+                "SOURCE_ETL_API_PORT=3200\n"
+                "SOURCE_ETL_POSTGRES_PORT=5544\n"
+                "ATIF_EXPORT_MODE=relay\n"
+                "ATIF_RELAY_ENDPOINT=https://host.openshell.internal:19443\n"
+            ),
+            {},
+        )
+        observed: list[int] = []
+
+        PREFLIGHT.local_port_checks(
+            values,
+            port_available=lambda port: observed.append(port) or True,
+        )
+
+        self.assertIn(3200, observed)
+        self.assertIn(5544, observed)
+        self.assertIn(19443, observed)
+
+    def test_missing_configuration_points_to_configurator(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            missing = Path(temp_dir) / ".env"
+            with patch.object(PREFLIGHT.shutil, "which", return_value=None):
+                result, exit_code = PREFLIGHT.run_preflight(
+                    missing,
+                    environment=SLACK_ENV,
+                    command_runner=successful_runner,
+                    port_available=lambda _port: True,
+                    endpoint_reachable=lambda _endpoint, _timeout: False,
+                )
+
+        self.assertEqual(1, exit_code)
+        self.assertEqual("python3 scripts/configure.py", result["next_command"])
+
+    def test_world_readable_configuration_fails_with_exact_fix(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = self.make_env(temp_dir)
+            path.chmod(0o644)
+            values = CONFIGURATION.resolved_values(CONFIGURATION.read_env(path), {})
+            check = PREFLIGHT.configuration_checks(path, values)[0]
+
+        self.assertEqual("FAIL", check.status)
+        self.assertIn("chmod 600", check.remediation)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Related Issue

Closes #68

## Description

This change adds an example-owned guided setup path for the developer community chief-of-staff recipe:

- `scripts/configure.py` creates a minimal Slack, Outlook, or combined configuration through interactive prompts or a deterministic non-interactive mode.
- Existing `.env` values, assignment style, inline comments, advanced settings, and unselected profiles remain unchanged unless the user supplies a replacement value or uses `--replace`.
- Secret inputs use hidden prompts, never use command arguments, and remain redacted from summaries and diagnostics. The parser rejects command lines, shell operators, and shell expansions without executing the file.
- `scripts/preflight.py` performs read-only configuration, tool, Docker, OpenShell, gateway, port, and optional-component checks. External inference and Slack checks run only with `--external` and reuse the existing specialized validators.
- Preflight validates `ATIF_RELAY_ENDPOINT` against the lifecycle scripts' HTTPS-origin contract before checking its port. It rejects paths, queries, fragments, user information, missing ports, invalid hostnames, and ports outside `1..65535` without echoing the configured value.
- The README, `.env.example`, and new guided-setup document describe profile inputs, preservation and replacement behavior, local and external boundaries, redacted JSON, exit codes, and next commands.

No third-party runtime dependency, generic NemoClaw onboarding behavior, gateway provisioning primitive, or external application registration is added.

## Verification

- [x] `python3 scripts/check_license_headers.py --check` — all 375 checked files passed.
- [x] `python3 scripts/check_label_taxonomy.py --check` — 64 labels passed; governance metadata is unchanged.
- [x] `git diff --check origin/main...HEAD` — passed.
- [x] Relevant example setup or syntax checks
  - `python -m pytest -q examples/recipes/nvidia/developer-community-chief-of-staff/scripts/tests examples/recipes/nvidia/developer-community-chief-of-staff/agents/hermes/tests` — 140 tests and 22 subtests passed in an isolated Python 3.14 environment.
  - `ruff check --select E4,E7,E9,F,I,UP` and `ruff format --check` on the four added Python files — passed.
  - `bash examples/recipes/nvidia/developer-community-chief-of-staff/scripts/tests/test-enterprise-ca-staging.sh` — passed.
  - `bash examples/recipes/nvidia/developer-community-chief-of-staff/scripts/tests/test-snapshot-safety.sh` — passed.
  - A non-interactive Slack configuration with placeholder values wrote a mode-`0600` file; the local JSON preflight made no external checks and did not contain any placeholder secret value.

Not completed:

- `python3 scripts/preflight.py --external` was not run against live inference or Slack services because no live credentials are required for this pull request. Unit tests verify delegation to both existing validators, bounded timeout propagation, failure routing, and redaction.
- Full `bring-up.sh` and sandbox creation were not run because this change targets the pre-deployment path and the local development host is not the documented Ubuntu deployment host.
- The unchanged `test-host-ca-bundle.sh` currently exits before its assertions because it searches the unchanged Dockerfile for `apt-get update -qq`, while that Dockerfile uses `apt-get update`. The same failure is present before this branch; this pull request does not modify either file.

## Documentation Writer Review

- [x] Documentation writer review completed for the final changes
- Result: `docs-updated`
- Evidence or justification: Updated `examples/recipes/nvidia/developer-community-chief-of-staff/README.md` and `.env.example`; added `docs/guided-setup.md`; reviewed all added CLI messages and help text.
- Reviewer: Codex documentation review
- [x] Changed user-facing text follows the
  [writing guide](https://github.com/NVIDIA/nemoclaw-community/blob/main/WRITING.md)
  and
  [controlled-word list](https://github.com/NVIDIA/nemoclaw-community/blob/main/.agents/skills/_shared/controlled-words.md).
- [x] A public contributor can understand the changed text without internal
  company context.
- [ ] I reviewed any agent-generated text before submission.

## Release And Compliance

- [x] No secrets or credentials are included, including API keys, access tokens,
  passwords, local `.env` files, private certificates, or token caches.
- [x] No nonpublic project names, environment names, hostnames, URLs, ticket
  identifiers, workspace paths, logs, screenshots, or configuration values are
  included.
- [x] Third-party dependency changes are reflected in `THIRD-PARTY-NOTICES`.
  No third-party dependency changed.
- [x] Public content uses sanitized examples and placeholders instead of private
  values.
- [x] I added my DCO sign-off declaration to this pull request description.

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>
