### PR TITLE
feat(examples): add the installer, scheduled jobs, and selectors for memory-driven chief-of-staff

### DIFF
--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -236,7 +236,7 @@ cd ../..
 test "$fail" -eq 0
 ```
 
-Expected result: every file ends with `OK`, the nine files report 222 tests in
+Expected result: every file ends with `OK`, the nine files report 223 tests in
 total, and the last line is `failed=0`. Do not use `|| break` here; a `for`
 loop reports the status of its last command, so a failing test would still
 leave the loop exiting `0`.
@@ -445,12 +445,23 @@ is recorded in the batch as a failure with its exit code and a stable error
 class, and the tick wakes the agent even when nothing is pending. An idle tick
 is free; a broken one must not be quiet.
 
-What the batch does *not* carry is the collector's own output. That batch is
-the agent's prompt, and a collector is a subprocess talking to a mail or chat
-API: its stderr can hold a bearer token, a signed URL, or someone's message
-body. The detail goes to the selector's stderr instead, which the scheduler
-writes to the job's local log, so an operator can read it without it having
-been sent anywhere.
+What nothing carries is the collector's own output. A collector is a
+subprocess talking to a mail or chat API, so its stderr can hold a bearer
+token, a signed URL, or someone's message body, and both of the places that
+wanted it are wrong: the batch is the agent's prompt, and the selector's own
+stderr is captured by the scheduler into the job log, where something
+transient becomes a file that outlives the token in it.
+
+So both get the same sanitized triple — which collector, what exit code, which
+error class. To read what the collector actually said, run it directly:
+
+```bash
+HERMES_HOME=<profile home> python3 profile/scripts/ingest_graph.py
+```
+
+That prints to your terminal rather than to a file. The text is dropped rather
+than redacted on purpose: a pattern-matching redactor cannot promise it caught
+everything, and a stored log is the wrong place to discover that it did not.
 
 ## Cleanup
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -236,7 +236,7 @@ cd ../..
 test "$fail" -eq 0
 ```
 
-Expected result: every file ends with `OK`, the nine files report 213 tests in
+Expected result: every file ends with `OK`, the nine files report 222 tests in
 total, and the last line is `failed=0`. Do not use `|| break` here; a `for`
 loop reports the status of its last command, so a failing test would still
 leave the loop exiting `0`.
@@ -304,10 +304,14 @@ The carry-over is three named settings — `model.default`, `model.provider` and
 `model.base_url` — transferred through `hermes config set`. No file is copied
 and no key is: the `model:` block is documented to hold an inline `api_key`,
 and a copy would write that key into a second file. Set the key on the new
-profile instead. The installer then checks both — that a model resolves and
-that a credential is present — and exits before registering any job if either
-is missing, rather than scheduling five jobs that would each fail. If your
-endpoint genuinely needs no key, pass `ALLOW_NO_API_KEY=1` to say so.
+profile instead. Each transfer fails closed and is read back off the target
+profile afterwards, so a setting that could not be written — or that reports
+success without sticking — ends the run rather than leaving a profile that
+took some of its configuration. The installer then checks both — that a model
+resolves and that a credential is present — and exits before registering any
+job if either is missing, rather than scheduling five jobs that would each
+fail. If your endpoint genuinely needs no key, pass `ALLOW_NO_API_KEY=1` to
+say so.
 
 Re-running it is safe: the registration looks each job up by name and edits it
 rather than adding another copy.
@@ -433,6 +437,20 @@ The fixtures were written from scratch. The people, the company, the projects,
 and every message body are invented. Nothing is derived from a real mailbox or
 from an anonymized copy of one. See [`fixtures/README.md`](fixtures/README.md)
 for what each record is a control for.
+
+### When a collector fails
+
+A collector that exits non-zero, or prints something the selector cannot read,
+is recorded in the batch as a failure with its exit code and a stable error
+class, and the tick wakes the agent even when nothing is pending. An idle tick
+is free; a broken one must not be quiet.
+
+What the batch does *not* carry is the collector's own output. That batch is
+the agent's prompt, and a collector is a subprocess talking to a mail or chat
+API: its stderr can hold a bearer token, a signed URL, or someone's message
+body. The detail goes to the selector's stderr instead, which the scheduler
+writes to the job's local log, so an operator can read it without it having
+been sent anywhere.
 
 ## Cleanup
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -109,14 +109,14 @@ then the scheduled jobs judge and re-judge whatever the store already holds.
   its prompt. Registering them there buys a scheduled expense and no
   assistant.
 - No credentials for the fixture path. The scheduled path is different: a
-  woken job runs an agent turn, so the Hermes runtime it fires under has to be
-  able to reach an inference provider. That is the credential you already
-  configured for Hermes itself — the installer carries over the model settings
-  and never a key. On the runtime this recipe was checked against, a profile
-  that holds no key of its own still sent an authenticated request, because
-  the credential resolved from the config it inherits; if yours does not,
-  set one on the profile. The installer stops before registering jobs if the
-  profile cannot resolve a model.
+  woken job runs an agent turn, so the profile it fires under needs a model it
+  can reach and a credential of its own. The installer carries over the model
+  settings and never a key, because a key is not a thing to copy — you set one
+  on the new profile with `hermes -p <profile> config set model.api_key`. It is
+  not inherited: a profile without one sends the literal placeholder
+  `no-key-required`, so every scheduled job would fail to authenticate. The
+  installer stops before registering any job when either the model or the
+  credential is missing.
 
 Nothing in the fixture path needs Hermes. Installing the profile and running
 it on a schedule does: `profile/distribution.yaml` declares
@@ -236,7 +236,7 @@ cd ../..
 test "$fail" -eq 0
 ```
 
-Expected result: every file ends with `OK`, the nine files report 210 tests in
+Expected result: every file ends with `OK`, the nine files report 213 tests in
 total, and the last line is `failed=0`. Do not use `|| break` here; a `for`
 loop reports the status of its last command, so a failing test would still
 leave the loop exiting `0`.
@@ -303,12 +303,11 @@ overrides the profile it installs into.
 The carry-over is three named settings — `model.default`, `model.provider` and
 `model.base_url` — transferred through `hermes config set`. No file is copied
 and no key is: the `model:` block is documented to hold an inline `api_key`,
-and a copy would write that key into a second file. It buys nothing — on the
-runtime this was checked against, a profile holding no key of its own still
-sent an authenticated request, the credential resolving from the config it
-inherits. If the profile cannot resolve a model afterwards, the installer says
-so and exits before registering any job, rather than scheduling five jobs that
-would each wake a model that isn't there.
+and a copy would write that key into a second file. Set the key on the new
+profile instead. The installer then checks both — that a model resolves and
+that a credential is present — and exits before registering any job if either
+is missing, rather than scheduling five jobs that would each fail. If your
+endpoint genuinely needs no key, pass `ALLOW_NO_API_KEY=1` to say so.
 
 Re-running it is safe: the registration looks each job up by name and edits it
 rather than adding another copy.
@@ -462,12 +461,11 @@ it as well if you want the checkout byte-for-byte as you found it.
 - The scheduled path is Linux only, including WSL, because every shipped skill
   declares `platforms: [linux]`. See [Requirements](#requirements).
 - The installer transfers three named model settings and no file, so nothing
-  it writes can carry a secret. What it cannot do is prove the target profile
-  will authenticate: the credential resolves from the config the profile
-  inherits, and that is the runtime's arrangement rather than this recipe's.
-  The installer checks that a model resolves and stops if none does, which
-  catches a profile with no model at all — not one whose model resolves and
-  whose credential is missing.
+  it writes can carry a secret. It checks that a model resolves and that a
+  credential is present, and stops before registering anything if either is
+  missing. What it cannot do is prove the credential is *valid*: that is one
+  request to your provider away, and the installer does not make it. A wrong
+  key still installs cleanly and fails at the first scheduled run.
 - The walkthrough's two judgment steps are recorded envelopes rather than live
   model turns. That is the limit of a fixture corpus, and the limit falls in a
   specific place: the gate verdict is recorded, so this run cannot show the

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -108,7 +108,15 @@ then the scheduled jobs judge and re-judge whatever the store already holds.
   still be called — with no skill attached and a "skill not found" notice in
   its prompt. Registering them there buys a scheduled expense and no
   assistant.
-- No credentials of any kind.
+- No credentials for the fixture path. The scheduled path is different: a
+  woken job runs an agent turn, so the Hermes runtime it fires under has to be
+  able to reach an inference provider. That is the credential you already
+  configured for Hermes itself — the installer carries over the model settings
+  and never a key. On the runtime this recipe was checked against, a profile
+  that holds no key of its own still sent an authenticated request, because
+  the credential resolved from the config it inherits; if yours does not,
+  set one on the profile. The installer stops before registering jobs if the
+  profile cannot resolve a model.
 
 Nothing in the fixture path needs Hermes. Installing the profile and running
 it on a schedule does: `profile/distribution.yaml` declares
@@ -228,7 +236,7 @@ cd ../..
 test "$fail" -eq 0
 ```
 
-Expected result: every file ends with `OK`, the nine files report 185 tests in
+Expected result: every file ends with `OK`, the nine files report 210 tests in
 total, and the last line is `failed=0`. Do not use `|| break` here; a `for`
 loop reports the status of its last command, so a failing test would still
 leave the loop exiting `0`.
@@ -288,11 +296,19 @@ scripts/install.sh
 ```
 
 From the recipe root. It does three things: `hermes profile install` for the
-distribution, a copy of `~/.hermes/config.yaml` so the new profile inherits a
-model, and `scripts/register-jobs.sh` for the schedule. Two environment
-variables override the defaults: `PROFILE_NAME` for the profile it installs
-into, and `SOURCE_PROFILE_CONFIG` for the config it copies. The source path is
-the default profile's, not whatever `HERMES_HOME` currently points at.
+distribution, a carry-over of the model settings so the new profile inherits a
+model, and `scripts/register-jobs.sh` for the schedule. `PROFILE_NAME`
+overrides the profile it installs into.
+
+The carry-over is three named settings — `model.default`, `model.provider` and
+`model.base_url` — transferred through `hermes config set`. No file is copied
+and no key is: the `model:` block is documented to hold an inline `api_key`,
+and a copy would write that key into a second file. It buys nothing — on the
+runtime this was checked against, a profile holding no key of its own still
+sent an authenticated request, the credential resolving from the config it
+inherits. If the profile cannot resolve a model afterwards, the installer says
+so and exits before registering any job, rather than scheduling five jobs that
+would each wake a model that isn't there.
 
 Re-running it is safe: the registration looks each job up by name and edits it
 rather than adding another copy.
@@ -445,12 +461,13 @@ it as well if you want the checkout byte-for-byte as you found it.
   in-process ticker entirely.
 - The scheduled path is Linux only, including WSL, because every shipped skill
   declares `platforms: [linux]`. See [Requirements](#requirements).
-- The installer copies the source profile's `config.yaml` so the new profile
-  inherits a model. It never copies `.env` or `auth.json`, which is where
-  Hermes keeps secrets and provider credentials. It cannot promise more than
-  that: `config.yaml` is your file, and two of its documented keys hold secrets
-  if you have set them there — `api_key`, which Hermes's own example marks as
-  an alternative to `.env`, and `sudo_password`, which it marks as plaintext.
+- The installer transfers three named model settings and no file, so nothing
+  it writes can carry a secret. What it cannot do is prove the target profile
+  will authenticate: the credential resolves from the config the profile
+  inherits, and that is the runtime's arrangement rather than this recipe's.
+  The installer checks that a model resolves and stops if none does, which
+  catches a profile with no model at all — not one whose model resolves and
+  whose credential is missing.
 - The walkthrough's two judgment steps are recorded envelopes rather than live
   model turns. That is the limit of a fixture corpus, and the limit falls in a
   specific place: the gate verdict is recorded, so this run cannot show the

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -453,10 +453,12 @@ stderr is captured by the scheduler into the job log, where something
 transient becomes a file that outlives the token in it.
 
 So both get the same sanitized triple — which collector, what exit code, which
-error class. To read what the collector actually said, run it directly:
+error class. After the connector phase supplies a collector, run that collector
+directly to read what it actually said. For example, once `ingest_graph.py` is
+installed:
 
 ```bash
-HERMES_HOME=<profile home> python3 profile/scripts/ingest_graph.py
+HERMES_HOME="/path/to/profile" python3 profile/scripts/ingest_graph.py
 ```
 
 That prints to your terminal rather than to a file. The text is dropped rather

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -228,7 +228,7 @@ cd ../..
 test "$fail" -eq 0
 ```
 
-Expected result: every file ends with `OK`, the nine files report 177 tests in
+Expected result: every file ends with `OK`, the nine files report 185 tests in
 total, and the last line is `failed=0`. Do not use `|| break` here; a `for`
 loop reports the status of its last command, so a failing test would still
 leave the loop exiting `0`.

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -5,15 +5,17 @@
 
 Memory-Driven Chief of Staff is a recipe that keeps a local, revisable record
 for each inbound email and Slack message. It re-judges those records on a
-schedule and re-ranks them under fixed caps. That re-judging runs on its own
-once the next phase registers the scheduler jobs. The user's own ignores and
-priority overrides change the ranking. The recipe never writes back to the
+schedule and re-ranks them under fixed caps, on jobs it registers with the
+runtime's scheduler. The user's own ignores and priority overrides change the
+ranking. The recipe never writes back to the
 source system.
 
-This first phase contains the store, its tests, and a walkthrough that runs it
-from end to end. It needs no email account, no Slack workspace,
-no network, and no inference endpoint. A fixture corpus exercises the same code
-a live source would. Two recorded model turns stand in for the two steps that
+Two phases are here: the store with its tests and an offline walkthrough, and
+the installer and scheduled jobs that run it without a person present. Neither
+needs an email account, a Slack workspace, or a network. Only the scheduled
+path needs an inference endpoint, and only when a job finds work; the
+walkthrough and the tests need none. A fixture corpus exercises the same code a
+live source would. Two recorded model turns stand in for the two steps that
 would otherwise need a model: the intake judgment, in
 `fixtures/envelopes/intake.json`, and the scheduled re-judgment, recorded
 inline in `profile/scripts/walkthrough.py`.
@@ -33,6 +35,8 @@ These terms appear throughout this document and in the code.
 | Tier | The priority band an obligation sits in: `high`, `medium`, or `low`. |
 | Envelope | The JSON document a model turn returns: a list of decisions for the writer to apply. The recipe's recorded turns are envelopes. |
 | Addressing | Whether a message was aimed at the user: `direct`, `mentioned`, or `broadcast`. Ingest derives it from the recipient list, which is not stored. |
+| Pre-step | The script a scheduled job runs before its agent turn. Hermes calls it the `--script`; it decides what the turn sees, and whether there is one. |
+| Wake gate | The `{"wakeAgent": false}` line a pre-step prints when it found no work. Hermes reads only the last non-empty line, and skips the agent turn when that line is the gate. |
 | Intent gate | The rule that admits an obligation to the `high` tier only if the memory shows the user chose that work. External urgency alone does not qualify. |
 | Cascade | What happens to an un-gated row that ranked inside the top ten: it drops into the competition for `medium` rather than out of the list. |
 | Reservation | The rule that keeps `high` for gate-passing rows. If fewer pass than the cap allows, the tier stays smaller rather than being filled from the remainder. |
@@ -82,32 +86,38 @@ those two apart.
 | `profile/scripts/correct.py` | The user's writer: pins, ignores, and the only source of `actor='user'` events |
 | `profile/scripts/load_fixtures.py` | Replays the fixtures through the real ingest path |
 | `profile/scripts/walkthrough.py` | The fixture walkthrough, end to end, with no credentials and no model |
+| `profile/scripts/select_intake.py` | The intake job's pre-step: what to judge, and whether to wake the model at all |
+| `profile/scripts/select_review.py` | The review job's pre-step: the stalest open obligations, oldest review first |
+| `scripts/install.sh` | Installs the profile, inherits the runtime's model config, registers the jobs |
+| `scripts/register-jobs.sh` | Registers the five scheduled jobs through the cron CLI. Re-runnable |
 | `profile/skills/` | Five skills: judging, review, repair, consolidation, preference update |
 | `fixtures/` | Eight synthetic messages, a seed memory, and one recorded model turn |
 
-Later phases add the host-side installer and scheduler integration, then the
-optional Microsoft Graph and Slack connectors.
+A later phase adds the optional Microsoft Graph and Slack connectors. Until
+then the scheduled jobs judge and re-judge whatever the store already holds.
 
 ## Requirements
 
 - Python 3.10 or newer. Nothing else is needed for the fixture path.
-- Linux, macOS, or Windows under Windows Subsystem for Linux. Every command
-  below is written for a POSIX shell. The shipped skill files declare
-  `platforms: [linux]`, which applies from the installer phase onward rather
-  than to the fixture path.
+- The fixture path — everything under [Try it](#try-it) and
+  [Verify](#verify) — runs on Linux, macOS, or Windows under Windows Subsystem
+  for Linux. Every command is written for a POSIX shell.
+- **The scheduled path is Linux only**, including WSL. All five shipped skills
+  declare `platforms: [linux]`, and Hermes refuses to load a skill outside its
+  declared platforms. On macOS the jobs would still fire and the model would
+  still be called — with no skill attached and a "skill not found" notice in
+  its prompt. Registering them there buys a scheduled expense and no
+  assistant.
 - No credentials of any kind.
 
-Installing the profile into a Hermes runtime is out of scope for this phase;
-the installer arrives with the next one. When that phase lands, installing will
-require Hermes 0.19.0 or newer: `profile/distribution.yaml` declares
+Nothing in the fixture path needs Hermes. Installing the profile and running
+it on a schedule does: `profile/distribution.yaml` declares
 `hermes_requires: ">=0.19.0"`. On 0.19.x the manifest's `distribution_owned`
-list is validated but not yet honoured by the copy — the path-aware allowlist
+list is validated but not yet honored by the copy — the path-aware allowlist
 first shipped in 0.20.0 — which changes nothing for this recipe, because what
-it ships and what it declares are the same set, and a test keeps them so.
-
-Nothing in the fixture path needs Hermes. The same 0.19.0 figure under
-[Where state lives](#where-state-lives) records the version the persistence
-claim was measured against.
+it ships and what it declares are the same set, and a test keeps them so. The
+same 0.19.0 figure under [Where state lives](#where-state-lives) records the
+version the persistence claim was measured against.
 
 ## Try it
 
@@ -218,7 +228,7 @@ cd ../..
 test "$fail" -eq 0
 ```
 
-Expected result: every file ends with `OK`, the eight files report 157 tests in
+Expected result: every file ends with `OK`, the nine files report 177 tests in
 total, and the last line is `failed=0`. Do not use `|| break` here; a `for`
 loop reports the status of its last command, so a failing test would still
 leave the loop exiting `0`.
@@ -233,6 +243,7 @@ leave the loop exiting `0`.
 | Source normalization | `tests/test_normalize.py` |
 | Writer behavior, audit trail, caps across batches, correction idempotency, correction state transitions, displaced-row audit | `tests/test_apply_decisions.py` |
 | The walkthrough, and its central claims | `tests/test_walkthrough.py` |
+| Selector output, the wake gate, and the scheduler contract | `tests/test_selectors.py` |
 
 Four points are worth calling out.
 
@@ -249,7 +260,7 @@ Four points are worth calling out.
   user-owned name, and that the user-owned and distribution-owned sets stay
   disjoint. Both directions fail, and neither is loud. Hermes never installs a
   shipped path whose top-level name is user-owned, so a shipped `workspace`
-  would simply never land; and a store placed under a distribution-owned path
+  would never land at all; and a store placed under a distribution-owned path
   is removed and replaced on every update, because that is what installing a
   distribution means.
 - `tests/test_walkthrough.py` runs the walkthrough and asserts its central
@@ -266,6 +277,87 @@ Four points are worth calling out.
   - the memory check is seen to fail as well as pass.
 
   It does not assert every line the script prints.
+
+## Running it on a schedule
+
+Everything above runs by hand. To have it run on its own, install the profile
+into a Hermes runtime and register the jobs:
+
+```bash
+scripts/install.sh
+```
+
+From the recipe root. It does three things: `hermes profile install` for the
+distribution, a copy of `~/.hermes/config.yaml` so the new profile inherits a
+model, and `scripts/register-jobs.sh` for the schedule. Two environment
+variables override the defaults: `PROFILE_NAME` for the profile it installs
+into, and `SOURCE_PROFILE_CONFIG` for the config it copies. The source path is
+the default profile's, not whatever `HERMES_HOME` currently points at.
+
+Re-running it is safe: the registration looks each job up by name and edits it
+rather than adding another copy.
+
+Five jobs are registered:
+
+| Job | Schedule | Pre-step | Skill |
+| --- | --- | --- | --- |
+| intake | every 30 minutes | `select_intake.py` | `inbound-judging` |
+| review | every 6 hours | `select_review.py` | `obligation-review` |
+| memory repair | daily 03:00 | — | `memory-repair` |
+| memory consolidation | daily 04:00 | — | `memory-consolidation` |
+| preference update | daily 04:30 | — | `preference-update` |
+
+**An idle tick costs nothing.** Each of the first two jobs runs its pre-step
+script first, then one agent turn over that script's output. When the script
+finds no work it prints `{"wakeAgent": false}` as its last line, and Hermes
+skips the agent entirely — no model call, no delivery. That last-line detail
+is the whole mechanism: Hermes reads only the final non-empty line of the
+script's output, so a gate printed anywhere else is ignored and the model
+wakes. A test asserts the gate exactly the way the scheduler parses it, rather
+than looking for the string somewhere in the output.
+
+The intake pre-step also looks for the connectors that arrive with the next
+phase. They are not here, so its output reports each as `"absent": true` and it
+carries on with whatever the store already holds. That is the intended reading:
+this phase schedules the judging, and there is nothing yet to collect.
+
+**Registering is not starting.** Under the builtin scheduler the jobs fire
+only while a gateway is serving the profile, and starting one takes two steps
+on Linux:
+
+```bash
+hermes -p memory-driven-chief-of-staff gateway install  # once
+hermes -p memory-driven-chief-of-staff gateway start
+hermes -p memory-driven-chief-of-staff cron status
+```
+
+`gateway start` fails with "Gateway service is not installed" until `gateway
+install` has run. Where no service manager is available — WSL without
+systemd — run it in the foreground instead: `hermes -p
+memory-driven-chief-of-staff gateway run`.
+
+`cron status` says plainly whether the scheduler is running, and lists the
+active jobs and the next run. A registered job on a profile with no running
+gateway does not tick and reports nothing. Two paths do fire without one:
+`hermes cron tick` runs anything due once and exits, and an external cron
+provider takes over from the in-process ticker.
+
+**The job store is not part of the distribution.** `distribution.yaml` does not
+declare `cron`. An update replaces what it does declare — `SOUL.md`,
+`schema.md`, `skills`, `scripts` and the manifest — and leaves the jobs and
+their run history alone. Measured, not assumed: five jobs
+registered, `hermes profile update` run on Hermes 0.20.0, five jobs still
+there with the same ids. A test asserts
+the manifest never claims `cron` or `workspace`.
+
+To undo, remove the jobs individually. Deleting the profile removes its
+`workspace` too, which is where the store and the memory live; removing the
+jobs does not. `profile delete` prompts unless given `-y`:
+
+```bash
+hermes -p memory-driven-chief-of-staff cron remove <job-id>
+hermes profile delete memory-driven-chief-of-staff
+```
 
 ## Where state lives
 
@@ -347,8 +439,18 @@ it as well if you want the checkout byte-for-byte as you found it.
 
 ## Known limitations
 
-- Scheduled jobs are not part of this phase. The store is exercised by the
-  walkthrough and the tests; job registration arrives with the installer.
+- Under the builtin scheduler the jobs fire only while a gateway is serving
+  this profile, and registering them starts nothing. `hermes cron tick` runs
+  what is due once without one, and an external cron provider replaces the
+  in-process ticker entirely.
+- The scheduled path is Linux only, including WSL, because every shipped skill
+  declares `platforms: [linux]`. See [Requirements](#requirements).
+- The installer copies the source profile's `config.yaml` so the new profile
+  inherits a model. It never copies `.env` or `auth.json`, which is where
+  Hermes keeps secrets and provider credentials. It cannot promise more than
+  that: `config.yaml` is your file, and two of its documented keys hold secrets
+  if you have set them there — `api_key`, which Hermes's own example marks as
+  an alternative to `.env`, and `sudo_password`, which it marks as plaintext.
 - The walkthrough's two judgment steps are recorded envelopes rather than live
   model turns. That is the limit of a fixture corpus, and the limit falls in a
   specific place: the gate verdict is recorded, so this run cannot show the
@@ -385,17 +487,50 @@ package, so nothing is added to the repository's third-party notices.
 
 ## Sandbox and policy
 
-This phase reaches no network and requires no policy grant. It ships five skill
-files that a runtime loads, and scripts that read the recipe's own files from
-the checkout and write application state only inside the profile home. They
+The recipe's own scripts reach no network. They read the recipe's files from
+the checkout and write application state only inside the profile home, and they
 also leave a Python bytecode cache beside the scripts — see
-[Cleanup](#cleanup). Network egress and provider permissions arrive with the
-connectors in a later phase and will be documented there.
+[Cleanup](#cleanup). The five skill files a runtime loads add nothing to that.
+
+The scheduled path does reach one. A job that wakes runs an agent turn, and the
+runtime calls whichever inference provider it is configured for, over its own
+egress path — the recipe holds no credential and opens no connection itself.
+A job that does not wake makes no call at all. Egress to a message source, and
+the provider permissions that needs, arrive with the connectors in a later
+phase and will be documented there.
 
 ## Startup
 
-Nothing to start. The scripts run on demand. Scheduled jobs arrive with the
-installer in a later phase.
+The scripts run on demand and need nothing started.
+
+The scheduled jobs need a gateway. Registration and firing are separate: a
+registered job on a profile with no running gateway does not run and reports
+nothing.
+
+### After a reboot
+
+Three separate questions, with three different answers.
+
+**Do the jobs survive?** Yes. They live in `$HERMES_HOME/cron/jobs.json`, which
+is ordinary disk state — not part of the distribution, so a profile update
+leaves it alone, and not tied to any process, so shutting everything down and
+starting again finds the same five jobs with the same ids.
+
+**Do they start firing again on their own?** Only if the gateway was installed
+as a service. `hermes -p <profile> gateway install` registers one — a launchd
+agent on macOS, a systemd unit on Linux — and both are configured to come back
+after a reboot. `hermes -p <profile> gateway run` is a foreground process and
+is not: after a restart you run it again yourself. `cron status` tells you
+which situation you are in.
+
+**What about the runs that were missed while it was down?** One of them
+happens, not all of them. Hermes collapses a backlog rather than replaying it:
+when a recurring job's scheduled time is more than one period in the past, it
+fast-forwards to the next future occurrence and fires once now. A machine that
+was off for two days does not wake to ninety-six intake runs; it wakes to one,
+which judges whatever accumulated, and then resumes its half-hourly rhythm.
+That suits this recipe, whose jobs act on the current state of the store rather
+than on a history of events.
 
 ## Provenance
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/select_intake.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/select_intake.py
@@ -63,6 +63,19 @@ def collect() -> tuple[dict[str, object], bool]:
     working, a tick that skipped the agent, and nothing anywhere saying so,
     every half hour.
 
+    What a failure reports is deliberately narrow. This function's stdout is
+    the scheduled agent's prompt, and a collector's stderr is arbitrary text
+    from a subprocess that talks to a mail or chat API: a traceback carrying a
+    bearer token, a request URL with a signature in the query string, a
+    response body full of someone's messages. Truncating that to a couple of
+    hundred characters bounds its length, not its content — the first two
+    hundred characters of a traceback are exactly where the request line is.
+
+    So the prompt gets a stable error class and an exit code, which is all the
+    agent can act on anyway, and the operator gets the detail on this
+    process's own stderr, where cron writes it to a local log instead of
+    sending it to an inference provider.
+
     Returns the per-collector results and a flag: true if any of them failed.
     """
     results: dict[str, object] = {}
@@ -74,19 +87,31 @@ def collect() -> tuple[dict[str, object], bool]:
             continue
         proc = subprocess.run([sys.executable, str(path)],
                               capture_output=True, text=True)
-        detail = (proc.stderr or "").strip()[:200]
         if proc.returncode != 0:
             failed = True
             results[script] = {"failed": True, "exit_code": proc.returncode,
-                               "stderr": detail}
+                               "error_class": "nonzero_exit"}
+            _report(script, proc.stderr)
             continue
         try:
             results[script] = json.loads(proc.stdout or "{}")
-        except json.JSONDecodeError as exc:
+        except json.JSONDecodeError:
             failed = True
-            results[script] = {"failed": True, "error": f"unreadable output: {exc}",
-                               "stderr": detail}
+            results[script] = {"failed": True, "exit_code": proc.returncode,
+                               "error_class": "unreadable_output"}
+            _report(script, proc.stderr)
     return results, failed
+
+
+def _report(script: str, stderr: str | None) -> None:
+    """Put a failing collector's own output where an operator can read it.
+
+    Not on stdout: that is the agent's prompt. This goes to stderr, which the
+    scheduler captures into the job's local log.
+    """
+    detail = (stderr or "").strip()
+    if detail:
+        print(f"{script}: {detail}", file=sys.stderr)
 
 
 def main() -> int:

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/select_intake.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/select_intake.py
@@ -63,18 +63,24 @@ def collect() -> tuple[dict[str, object], bool]:
     working, a tick that skipped the agent, and nothing anywhere saying so,
     every half hour.
 
-    What a failure reports is deliberately narrow. This function's stdout is
-    the scheduled agent's prompt, and a collector's stderr is arbitrary text
-    from a subprocess that talks to a mail or chat API: a traceback carrying a
-    bearer token, a request URL with a signature in the query string, a
-    response body full of someone's messages. Truncating that to a couple of
-    hundred characters bounds its length, not its content — the first two
-    hundred characters of a traceback are exactly where the request line is.
+    A failing collector's own output is never repeated anywhere. It is
+    arbitrary text from a subprocess that talks to a mail or chat API: a
+    traceback carrying a bearer token, a request URL with a signature in the
+    query string, a response body full of someone's messages.
 
-    So the prompt gets a stable error class and an exit code, which is all the
-    agent can act on anyway, and the operator gets the detail on this
-    process's own stderr, where cron writes it to a local log instead of
-    sending it to an inference provider.
+    Two places wanted it and neither may have it. This function's stdout is
+    the scheduled agent's prompt, so putting it there sends it to an inference
+    provider. This process's stderr is captured by the scheduler into the job
+    log, so putting it there turns something transient into something stored —
+    a log that outlives the token in it, on disk, for as long as logs are kept.
+    Truncating bounds length rather than content; the first two hundred
+    characters of a traceback are exactly where the request line is.
+
+    So both get the same sanitized triple — collector name, exit code, stable
+    error class — which is what the agent can act on and what tells an operator
+    which collector to go and run by hand. Running it directly is how you read
+    what it actually said, and that output goes to a terminal rather than a
+    file.
 
     Returns the per-collector results and a flag: true if any of them failed.
     """
@@ -91,7 +97,7 @@ def collect() -> tuple[dict[str, object], bool]:
             failed = True
             results[script] = {"failed": True, "exit_code": proc.returncode,
                                "error_class": "nonzero_exit"}
-            _report(script, proc.stderr)
+            _report(script, proc.returncode, "nonzero_exit")
             continue
         try:
             results[script] = json.loads(proc.stdout or "{}")
@@ -99,19 +105,21 @@ def collect() -> tuple[dict[str, object], bool]:
             failed = True
             results[script] = {"failed": True, "exit_code": proc.returncode,
                                "error_class": "unreadable_output"}
-            _report(script, proc.stderr)
+            _report(script, proc.returncode, "unreadable_output")
     return results, failed
 
 
-def _report(script: str, stderr: str | None) -> None:
-    """Put a failing collector's own output where an operator can read it.
+def _report(script: str, exit_code: int, error_class: str) -> None:
+    """Say which collector failed and how, without quoting it.
 
-    Not on stdout: that is the agent's prompt. This goes to stderr, which the
-    scheduler captures into the job's local log.
+    This goes to stderr, which the scheduler stores in the job log — so it
+    carries only what is safe to keep: the collector's name, its exit code, and
+    a stable class. The collector's own text is deliberately dropped rather
+    than redacted, because a pattern-matching redactor cannot promise it caught
+    everything and a log is the wrong place to find out.
     """
-    detail = (stderr or "").strip()
-    if detail:
-        print(f"{script}: {detail}", file=sys.stderr)
+    print(f"{script}: failed (exit {exit_code}, {error_class}). "
+          f"Run it directly to see its output.", file=sys.stderr)
 
 
 def main() -> int:

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/select_intake.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/select_intake.py
@@ -19,18 +19,54 @@ from pathlib import Path
 
 from _db import ensure_store, write_txn
 
+def bounded_int(name: str, default: int, *, maximum: int) -> int:
+    """Read a positive, bounded integer from the environment.
+
+    `LIMIT` takes whatever it is given, and SQLite reads a negative one as no
+    limit at all — so `INTAKE_SLICE=-1` handed the model every pending row in
+    the store, silently defeating the bound this recipe is built on. Zero is
+    just as wrong in the other direction: the job wakes, reports work, and
+    offers nothing. Malformed text used to raise during import, before any
+    error message could explain which variable was at fault.
+    """
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        raise SystemExit(
+            f"{name} must be a whole number between 1 and {maximum}; got {raw!r}")
+    if value < 1 or value > maximum:
+        raise SystemExit(
+            f"{name} must be between 1 and {maximum}; got {value}")
+    return value
+
+
 HERE = Path(__file__).resolve().parent
-SLICE = int(os.environ.get("INTAKE_SLICE", "25"))
+MAX_SLICE = 200
+SLICE = None  # resolved in main(); see bounded_int
 
 
-def collect() -> dict[str, object]:
-    """Run whichever collectors are present and configured.
+def collect() -> tuple[dict[str, object], bool]:
+    """Run whichever collectors are present, and report whether any failed.
 
     A collector that is absent is not an error. The store and the schedule ship
     before the connectors do, and a reader who never connects a source still
     gets a working intake pass over whatever is already in the store.
+
+    A collector that *fails* is a different thing, and it must be visible. The
+    exit code is what says so: a connector whose credential expired writes to
+    stderr and exits non-zero while printing nothing, and `json.loads("" or
+    "{}")` turns that into an empty success. Combined with the idle gate below
+    it produced the worst failure this design can have — a token that stopped
+    working, a tick that skipped the agent, and nothing anywhere saying so,
+    every half hour.
+
+    Returns the per-collector results and a flag: true if any of them failed.
     """
     results: dict[str, object] = {}
+    failed = False
     for script in ("ingest_graph.py", "ingest_slack.py"):
         path = HERE / script
         if not path.exists():
@@ -38,18 +74,26 @@ def collect() -> dict[str, object]:
             continue
         proc = subprocess.run([sys.executable, str(path)],
                               capture_output=True, text=True)
+        detail = (proc.stderr or "").strip()[:200]
+        if proc.returncode != 0:
+            failed = True
+            results[script] = {"failed": True, "exit_code": proc.returncode,
+                               "stderr": detail}
+            continue
         try:
             results[script] = json.loads(proc.stdout or "{}")
-        except json.JSONDecodeError:
-            # A collector that fails must not take the whole tick down; the
-            # slice below still has yesterday's unjudged items to work on.
-            results[script] = {"error": (proc.stderr or "").strip()[:200]}
-    return results
+        except json.JSONDecodeError as exc:
+            failed = True
+            results[script] = {"failed": True, "error": f"unreadable output: {exc}",
+                               "stderr": detail}
+    return results, failed
 
 
 def main() -> int:
+    global SLICE
+    SLICE = bounded_int("INTAKE_SLICE", 25, maximum=MAX_SLICE)
     ensure_store()
-    collected = collect()
+    collected, collector_failed = collect()
 
     with write_txn() as conn:
         rows = conn.execute(
@@ -75,7 +119,9 @@ def main() -> int:
     }
     print(json.dumps(payload, ensure_ascii=False, indent=2))
 
-    if not rows:
+    # Wake on a collector failure even with nothing to judge. The gate exists
+    # to make an idle tick free, not to make a broken one quiet.
+    if not rows and not collector_failed:
         print(json.dumps({"wakeAgent": False}))
     return 0
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/select_intake.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/select_intake.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cron pre-step for the intake pass.
+
+Runs the collectors, then hands the agent a slice of unjudged items. When
+there is nothing new it emits `{"wakeAgent": false}`, which Hermes treats as a
+signal to skip the agent turn entirely — so a quiet half-hour costs no tokens
+at all rather than paying a model call to be told there is no work.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from _db import ensure_store, write_txn
+
+HERE = Path(__file__).resolve().parent
+SLICE = int(os.environ.get("INTAKE_SLICE", "25"))
+
+
+def collect() -> dict[str, object]:
+    """Run whichever collectors are present and configured.
+
+    A collector that is absent is not an error. The store and the schedule ship
+    before the connectors do, and a reader who never connects a source still
+    gets a working intake pass over whatever is already in the store.
+    """
+    results: dict[str, object] = {}
+    for script in ("ingest_graph.py", "ingest_slack.py"):
+        path = HERE / script
+        if not path.exists():
+            results[script] = {"absent": True}
+            continue
+        proc = subprocess.run([sys.executable, str(path)],
+                              capture_output=True, text=True)
+        try:
+            results[script] = json.loads(proc.stdout or "{}")
+        except json.JSONDecodeError:
+            # A collector that fails must not take the whole tick down; the
+            # slice below still has yesterday's unjudged items to work on.
+            results[script] = {"error": (proc.stderr or "").strip()[:200]}
+    return results
+
+
+def main() -> int:
+    ensure_store()
+    collected = collect()
+
+    with write_txn() as conn:
+        rows = conn.execute(
+            "SELECT source_id, source, scope, event_at, sender, subject, body,"
+            "       addressing, unread"
+            "  FROM items WHERE state='pending'"
+            " ORDER BY event_at LIMIT ?", (SLICE,)).fetchall()
+        open_rows = conn.execute(
+            "SELECT o.source_id, o.title, o.status FROM obligations o"
+            " WHERE o.status='open' ORDER BY o.global_rank LIMIT 40").fetchall()
+        recent_closed = conn.execute(
+            "SELECT o.title, o.status FROM obligations o"
+            " WHERE o.status IN ('done','ignored')"
+            " ORDER BY o.updated_at DESC LIMIT 20").fetchall()
+
+    cols = ("source_id", "source", "scope", "event_at", "sender", "subject",
+            "body", "addressing", "unread")
+    payload = {
+        "collected": collected,
+        "slice": [dict(zip(cols, r)) for r in rows],
+        "open_obligations": [{"source_id": r[0], "title": r[1]} for r in open_rows],
+        "recently_resolved": [{"title": r[0], "status": r[1]} for r in recent_closed],
+    }
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+
+    if not rows:
+        print(json.dumps({"wakeAgent": False}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/select_review.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/select_review.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cron pre-step for the review pass.
+
+Selects the stalest open obligations — never reviewed first, then longest
+since — so re-judgment is driven by time rather than by new mail arriving. A
+week with no incoming messages still re-ranks, which is exactly when a
+shortlist is most likely to have gone quietly wrong.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+from _db import ensure_store, write_txn
+
+BATCH = int(os.environ.get("REVIEW_BATCH", "15"))
+
+
+def main() -> int:
+    ensure_store()
+
+    with write_txn() as conn:
+        rows = conn.execute(
+            "SELECT o.source_id, o.title, o.context, o.urgency_reason, o.kind,"
+            "       o.est_effort, o.priority, o.manual_priority, o.global_rank,"
+            "       o.intent_gated, o.snooze_count, o.reviewed_at,"
+            "       i.event_at, i.sender, i.subject, i.addressing, i.thread_ref"
+            "  FROM obligations o JOIN items i ON i.source_id = o.source_id"
+            " WHERE o.status='open'"
+            "   AND (o.snoozed_until IS NULL"
+            "        OR o.snoozed_until <= strftime('%Y-%m-%dT%H:%M:%fZ','now'))"
+            " ORDER BY o.reviewed_at IS NOT NULL, o.reviewed_at"
+            " LIMIT ?", (BATCH,)).fetchall()
+
+    cols = ("source_id", "title", "context", "urgency_reason", "kind",
+            "est_effort", "priority", "manual_priority", "global_rank",
+            "intent_gated", "snooze_count", "reviewed_at",
+            "source_event_at", "sender", "subject", "addressing", "thread_ref")
+    print(json.dumps({"batch": [dict(zip(cols, r)) for r in rows]},
+                     ensure_ascii=False, indent=2))
+
+    if not rows:
+        print(json.dumps({"wakeAgent": False}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/select_review.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/select_review.py
@@ -15,11 +15,15 @@ import json
 import os
 
 from _db import ensure_store, write_txn
+from select_intake import bounded_int
 
-BATCH = int(os.environ.get("REVIEW_BATCH", "15"))
+MAX_BATCH = 200
+BATCH = None  # resolved in main(); see select_intake.bounded_int
 
 
 def main() -> int:
+    global BATCH
+    BATCH = bounded_int("REVIEW_BATCH", 15, maximum=MAX_BATCH)
     ensure_store()
 
     with write_txn() as conn:

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_durability.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_durability.py
@@ -670,5 +670,44 @@ class TestScansSurviveAMacOsArchive(unittest.TestCase):
                 p.read_text(encoding="utf-8")
 
 
+class TestTheDocumentedTestCountIsTheRealOne(unittest.TestCase):
+    """The README tells the reader what a clean run prints.
+
+    That sentence names two numbers — how many files the suite is in, and how
+    many tests they add up to — and both go stale the moment anyone adds a
+    test. Nothing was checking them, and the count in the README drifted three
+    separate times before this test existed, each time announcing a total that
+    no run had produced. A number a reader can compare against their own
+    terminal is a claim, so it gets an assertion like any other.
+    """
+
+    WORDS = {"nine": 9, "ten": 10, "eleven": 11, "twelve": 12}
+
+    def _documented(self):
+        readme = (HERE.parents[1] / "README.md").read_text(encoding="utf-8")
+        match = re.search(r"the (\w+) files report (\d+) tests", readme)
+        self.assertIsNotNone(
+            match, "README no longer states the file and test counts")
+        word, total = match.group(1), int(match.group(2))
+        self.assertIn(word, self.WORDS, f"unhandled number word {word!r}")
+        return self.WORDS[word], total
+
+    def test_the_readme_states_the_number_of_files_the_suite_is_in(self):
+        files, _ = self._documented()
+        actual = [p for p in Path(__file__).resolve().parent.glob("test_*.py")
+                  if not p.name.startswith("._")]
+        self.assertEqual(files, len(actual),
+                         f"README says {files} files; found {len(actual)}: "
+                         + ", ".join(sorted(p.name for p in actual)))
+
+    def test_the_readme_states_the_number_of_tests_a_clean_run_prints(self):
+        _, total = self._documented()
+        here = str(Path(__file__).resolve().parent)
+        suite = unittest.defaultTestLoader.discover(here, pattern="test_*.py")
+        self.assertEqual(total, suite.countTestCases(),
+                         f"README says {total} tests; the suite holds "
+                         f"{suite.countTestCases()}")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_durability.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_durability.py
@@ -12,6 +12,17 @@ sys.path.insert(0, str(HERE))
 
 SCHEMA = (HERE / "schema.sql").read_text(encoding="utf-8")
 
+
+def visible(paths):
+    """Drop dotfiles from a glob.
+
+    A macOS archive carries an AppleDouble sidecar beside each file, and
+    `._install.sh` / `._SKILL.md` match the same globs their originals do while
+    being binary. Unpacking this recipe on Linux made three scans raise
+    UnicodeDecodeError before this existed.
+    """
+    return sorted(p for p in paths if not p.name.startswith("."))
+
 PROFILE = HERE.parent
 MANIFEST = PROFILE / "distribution.yaml"
 
@@ -220,7 +231,7 @@ class TestNoSourceMutation(unittest.TestCase):
     def test_no_module_issues_a_write_to_a_source_system(self):
         # Recursive, so a connector added in a subdirectory later is covered.
         offenders = []
-        for path in sorted(HERE.rglob("*.py")):
+        for path in visible(HERE.rglob("*.py")):
             if path.name.startswith("test_"):
                 continue          # tests may name a verb in order to forbid it
             text = path.read_text(encoding="utf-8")
@@ -249,7 +260,7 @@ class TestNoSourceMutation(unittest.TestCase):
         # promises not to. Assert the invariant that actually matters — the
         # column exists, and nothing anywhere sends it anywhere.
         self.assertIn("unread", SCHEMA)
-        for path in sorted(HERE.rglob("*.py")):
+        for path in visible(HERE.rglob("*.py")):
             if path.name.startswith("test_"):
                 continue          # tests name the payload shape in order to forbid it
             text = path.read_text(encoding="utf-8")
@@ -557,7 +568,7 @@ class TestSkillsNameFilesAbsolutely(unittest.TestCase):
     def _skills(self):
         root = HERE.parent / "skills"
         self.assertTrue(root.is_dir(), "the profile ships no skills")
-        return sorted(root.glob("*/SKILL.md"))
+        return visible(root.glob("*/SKILL.md"))
 
     def test_every_scripted_path_is_anchored(self):
         for doc in self._skills():
@@ -602,7 +613,7 @@ class TestSkillsNameFilesThatWillExist(unittest.TestCase):
         # `workspace/` is user-owned: the recipe's own code creates the store
         # and the memory there at run time, so those are legitimate.
         runtime = {"workspace"}
-        for doc in sorted((HERE.parent / "skills").glob("*/SKILL.md")):
+        for doc in visible((HERE.parent / "skills").glob("*/SKILL.md")):
             text = doc.read_text(encoding="utf-8")
             for rel in self.HOME_PATH.findall(text):
                 head = rel.split("/", 1)[0]
@@ -614,12 +625,49 @@ class TestSkillsNameFilesThatWillExist(unittest.TestCase):
 
     def test_a_shipped_file_is_referenced_where_it_lands(self):
         """`schema.md` installs at the profile root, so that is where it is read."""
-        for doc in sorted((HERE.parent / "skills").glob("*/SKILL.md")):
+        for doc in visible((HERE.parent / "skills").glob("*/SKILL.md")):
             text = doc.read_text(encoding="utf-8")
             for rel in self.HOME_PATH.findall(text):
                 if rel.endswith("schema.md"):
                     with self.subTest(skill=doc.parent.name):
                         self.assertEqual(rel, "schema.md")
+
+
+class TestScansSurviveAMacOsArchive(unittest.TestCase):
+    """A sidecar must not crash a scan that globs by suffix.
+
+    Packaging this recipe on macOS and unpacking it on Linux puts a binary
+    `._install.sh` beside `install.sh`, and `._SKILL.md` beside each skill.
+    They match the same globs. Three scans raised UnicodeDecodeError the first
+    time that happened on a real Linux host — after Phase 1 had already fixed
+    the identical problem for memory pages, which is why the guard is one
+    shared helper now rather than a fix at each call site.
+    """
+
+    def test_the_helper_drops_sidecars_and_keeps_the_originals(self):
+        home = Path(tempfile.mkdtemp())
+        (home / "install.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+        (home / "._install.sh").write_bytes(b"\x00\x05\x16\x07\xa3binary")
+        (home / ".DS_Store").write_bytes(b"\x00\x01")
+        kept = visible(home.glob("*.sh"))
+        self.assertEqual([p.name for p in kept], ["install.sh"])
+
+    def test_every_scan_reads_its_files_without_raising(self):
+        """The real files, read the way the scans read them."""
+        for path in visible(HERE.rglob("*.py")):
+            with self.subTest(path=path.name):
+                path.read_text(encoding="utf-8")
+        for doc in visible((HERE.parent / "skills").glob("*/SKILL.md")):
+            with self.subTest(skill=doc.parent.name):
+                doc.read_text(encoding="utf-8")
+
+    def test_a_sidecar_would_break_an_unguarded_glob(self):
+        """The check has to be able to fail, or it is telling us nothing."""
+        home = Path(tempfile.mkdtemp())
+        (home / "._x.sh").write_bytes(b"\x00\x05\x16\x07\xa3binary")
+        with self.assertRaises(UnicodeDecodeError):
+            for p in sorted(home.glob("*.sh")):
+                p.read_text(encoding="utf-8")
 
 
 if __name__ == "__main__":

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_selectors.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_selectors.py
@@ -447,7 +447,8 @@ class TestACollectorFailureIsVisible(CollectorCase):
         self.assertTrue(entry["failed"])
         self.assertEqual(entry["exit_code"], 1)
         self.assertEqual(entry["error_class"], "nonzero_exit")
-        # The message itself belongs in the local log, not the prompt.
+        # The collector's own text belongs in neither the prompt nor the local
+        # log; only the sanitized failure metadata is retained.
         self.assertNotIn("token expired", json.dumps(payload))
 
     def test_a_nonzero_exit_with_valid_json_is_still_a_failure(self):
@@ -762,8 +763,8 @@ class TestCollectorDiagnosticsStayOutOfThePrompt(CollectorCase):
     length and not the content; the first two hundred characters of a traceback
     are where the request line is.
 
-    The payload now carries a stable error class and an exit code. The detail
-    goes to this process's own stderr, which cron writes to a local log.
+    The payload and local log carry only a stable error class and an exit code.
+    The collector's own text is dropped from both streams.
     """
 
     SECRET = "Bearer xoxp-9999-SECRET-TOKEN-VALUE"

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_selectors.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_selectors.py
@@ -244,7 +244,12 @@ class TestScriptsNameRealHermesCommands(unittest.TestCase):
         r"hermes(?:\s+-{1,2}[A-Za-z-]+(?:\s+\S+)?)*\s+(model)\s+([^\s|`]+)")
 
     def sources(self):
-        yield from sorted((self.RECIPE / "scripts").glob("*.sh"))
+        # Skip dotfiles. A macOS archive carries an AppleDouble sidecar beside
+        # each file — `._install.sh` ends in `.sh`, is binary, and made this
+        # scan raise UnicodeDecodeError the first time the recipe was unpacked
+        # on Linux. `load_fixtures` learned the same lesson for `.md` pages.
+        yield from sorted(f for f in (self.RECIPE / "scripts").glob("*.sh")
+                          if not f.name.startswith("."))
         yield self.RECIPE / "README.md"
 
     def test_every_named_subcommand_is_real(self):

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_selectors.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_selectors.py
@@ -4,7 +4,7 @@
 """Acceptance: what the cron pre-steps hand the agent, and when they decline to
 wake it at all."""
 
-import json, os, re, sqlite3, subprocess, sys, tempfile, unittest
+import json, os, re, shutil, sqlite3, subprocess, sys, tempfile, unittest
 from pathlib import Path
 
 HERE = Path(__file__).resolve().parents[1]
@@ -392,6 +392,309 @@ class TestTheRebootStoryIsWhatTheReadmeSays(unittest.TestCase):
         self.assertIn('register intake "*/30 * * * *"', script)
         per_day = 24 * 60 // 30
         self.assertEqual(per_day * 2, 96)
+
+
+class TestACollectorFailureIsVisible(unittest.TestCase):
+    """A connector that stops working must not be silent.
+
+    This is the worst failure this design can have, and it was the shipped
+    behaviour: a collector whose credential expired wrote to stderr and exited
+    non-zero while printing nothing, `json.loads("" or "{}")` turned that into
+    an empty success, and the idle gate then skipped the agent entirely. Every
+    half hour, forever, with nothing anywhere saying so. Slack's rotating user
+    tokens make an expired credential an ordinary event rather than an
+    exceptional one, so this path is the one that matters most.
+    """
+
+    def setUp(self):
+        self.home = tempfile.mkdtemp()
+        self.recipe = Path(tempfile.mkdtemp())
+        shutil.copytree(HERE, self.recipe / "scripts")
+        self.db = Path(self.home) / "workspace" / "ledger" / "state.db"
+        self.db.parent.mkdir(parents=True)
+        with sqlite3.connect(self.db) as c:
+            c.executescript(SCHEMA)
+
+    def _collector(self, body):
+        (self.recipe / "scripts" / "ingest_graph.py").write_text(
+            "import sys\n" + body + "\n", encoding="utf-8")
+
+    def _add_pending(self, sid):
+        with sqlite3.connect(self.db) as c:
+            c.execute("INSERT INTO items(source_id, source, scope, event_at, state)"
+                      " VALUES (?,'email','inbox','2026-08-18T00:00:00Z','pending')",
+                      (sid,))
+
+    def _run(self):
+        proc = subprocess.run(
+            [sys.executable, str(self.recipe / "scripts" / "select_intake.py")],
+            capture_output=True, text=True,
+            env={**os.environ, "HERMES_HOME": self.home})
+        body = proc.stdout.split('{"wakeAgent"')[0]
+        return json.loads(body), proc.stdout
+
+    def _graph(self, payload):
+        return payload["collected"]["ingest_graph.py"]
+
+    def test_a_nonzero_exit_with_no_output_is_recorded_as_a_failure(self):
+        self._collector('print("", end=""); print("token expired", file=sys.stderr); sys.exit(1)')
+        payload, _ = self._run()
+        entry = self._graph(payload)
+        self.assertTrue(entry["failed"])
+        self.assertEqual(entry["exit_code"], 1)
+        self.assertIn("token expired", entry["stderr"])
+
+    def test_a_nonzero_exit_with_valid_json_is_still_a_failure(self):
+        """Readable output does not mean the run succeeded."""
+        self._collector('print(\'{"seen": 3}\'); sys.exit(2)')
+        payload, _ = self._run()
+        self.assertTrue(self._graph(payload)["failed"])
+        self.assertEqual(self._graph(payload)["exit_code"], 2)
+
+    def test_unreadable_output_from_a_clean_exit_is_a_failure(self):
+        self._collector('print("not json"); sys.exit(0)')
+        payload, _ = self._run()
+        self.assertTrue(self._graph(payload)["failed"])
+        self.assertIn("unreadable output", self._graph(payload)["error"])
+
+    def test_a_failure_with_no_pending_rows_still_wakes_the_agent(self):
+        """The gate makes an idle tick free; it must not make a broken one quiet."""
+        self._collector('print("", end=""); print("boom", file=sys.stderr); sys.exit(1)')
+        payload, stdout = self._run()
+        self.assertEqual(payload["slice"], [])
+        lines = [line for line in stdout.splitlines() if line.strip()]
+        self.assertNotEqual(lines[-1].strip(), '{"wakeAgent": false}')
+
+    def test_a_healthy_collector_with_no_rows_still_gates(self):
+        """The fix must not cost the saving the gate exists for."""
+        self._collector('print(\'{"seen": 0}\'); sys.exit(0)')
+        _, stdout = self._run()
+        lines = [line for line in stdout.splitlines() if line.strip()]
+        self.assertEqual(lines[-1].strip(), '{"wakeAgent": false}')
+
+    def test_a_failure_does_not_stop_pending_rows_being_offered(self):
+        self._collector('print("", end=""); print("boom", file=sys.stderr); sys.exit(1)')
+        self._add_pending("m1")
+        payload, _ = self._run()
+        self.assertEqual(len(payload["slice"]), 1)
+        self.assertTrue(self._graph(payload)["failed"])
+
+
+class TestTheInstallerRefusesTheWrongPlatform(unittest.TestCase):
+    """Documentation that says "Linux only" and code that installs anywhere.
+
+    The README states the scheduled path does not work on macOS, and the
+    scripts installed and registered five jobs there regardless — producing
+    exactly the model-without-skill calls the same document warns about. A
+    warning nothing enforces is not a warning.
+    """
+
+    RECIPE = HERE.parents[1]
+    SCRIPTS = ("install.sh", "register-jobs.sh")
+
+    def _with_uname(self, kernel):
+        """Run each script with `uname` reporting a chosen kernel."""
+        fake = Path(tempfile.mkdtemp())
+        (fake / "uname").write_text(f"#!/bin/sh\necho {kernel}\n", encoding="utf-8")
+        (fake / "uname").chmod(0o755)
+        return fake
+
+    def _run(self, script, kernel):
+        fake = self._with_uname(kernel)
+        return subprocess.run(
+            ["bash", str(self.RECIPE / "scripts" / script)],
+            capture_output=True, text=True, cwd=str(self.RECIPE),
+            env={**os.environ, "PATH": f"{fake}:{os.environ['PATH']}",
+                 "PROFILE_NAME": "does-not-exist-under-test"})
+
+    def test_darwin_is_refused_by_both_scripts(self):
+        for script in self.SCRIPTS:
+            with self.subTest(script=script):
+                proc = self._run(script, "Darwin")
+                self.assertEqual(proc.returncode, 1)
+                self.assertIn("only works on Linux", proc.stderr)
+                self.assertIn("Darwin", proc.stderr)
+
+    def test_the_refusal_names_the_path_that_does_work(self):
+        proc = self._run("install.sh", "Darwin")
+        self.assertIn("walkthrough.py", proc.stderr)
+
+    def test_linux_is_accepted_and_reaches_the_next_check(self):
+        """The guard must gate on the platform and nothing else."""
+        for script in self.SCRIPTS:
+            with self.subTest(script=script):
+                proc = self._run(script, "Linux")
+                combined = proc.stdout + proc.stderr
+                self.assertNotIn("only works on Linux", combined)
+
+    def test_the_guard_runs_before_anything_is_installed(self):
+        """Position matters: a guard after the first mutation is not a guard."""
+        for script in self.SCRIPTS:
+            with self.subTest(script=script):
+                text = (self.RECIPE / "scripts" / script).read_text(encoding="utf-8")
+                guard_at = text.index("require_linux\n")
+                for verb in ("hermes profile install", "cron create", "cp \""):
+                    if verb in text:
+                        self.assertLess(guard_at, text.index(verb),
+                                        f"{script} runs `{verb}` before the guard")
+
+
+class TestTheSliceBoundCannotBeDefeated(unittest.TestCase):
+    """The bound is the product, so an override must not be able to remove it.
+
+    SQLite reads a negative `LIMIT` as no limit, so `INTAKE_SLICE=-1` handed
+    the model every pending row in the store — silently, and past the cap this
+    recipe is built on. Zero fails the other way: the job wakes, says it has
+    work, and offers none. Malformed text raised during import, before any
+    message could name the variable.
+    """
+
+    def setUp(self):
+        self.home = tempfile.mkdtemp()
+        self.db = Path(self.home) / "workspace" / "ledger" / "state.db"
+        self.db.parent.mkdir(parents=True)
+        with sqlite3.connect(self.db) as c:
+            c.executescript(SCHEMA)
+            for n in range(60):
+                c.execute(
+                    "INSERT INTO items(source_id, source, scope, event_at, state)"
+                    " VALUES (?,'email','inbox','2026-08-18T00:00:00Z','pending')",
+                    (f"m{n}",))
+            for n in range(60):
+                c.execute(
+                    "INSERT INTO obligations(id, source_id, title, priority, status)"
+                    " VALUES (?,?,?,'high','open')", (f"o{n}", f"m{n}", f"t{n}"))
+
+    def _run(self, script, **env):
+        return subprocess.run(
+            [sys.executable, str(HERE / script)], capture_output=True, text=True,
+            env={**os.environ, "HERMES_HOME": self.home, **env})
+
+    def _slice_size(self, proc, key):
+        return len(json.loads(proc.stdout.split('{"wakeAgent"')[0])[key])
+
+    def test_the_default_bound_holds(self):
+        self.assertEqual(self._slice_size(self._run("select_intake.py"), "slice"), 25)
+        self.assertEqual(
+            self._slice_size(self._run("select_review.py"), "batch"), 15)
+
+    def test_a_negative_override_is_refused_rather_than_unbounded(self):
+        for script, var in (("select_intake.py", "INTAKE_SLICE"),
+                            ("select_review.py", "REVIEW_BATCH")):
+            with self.subTest(script=script):
+                proc = self._run(script, **{var: "-1"})
+                self.assertNotEqual(proc.returncode, 0)
+                self.assertIn(var, proc.stderr)
+                self.assertNotIn('"slice"', proc.stdout)
+
+    def test_zero_is_refused(self):
+        proc = self._run("select_intake.py", INTAKE_SLICE="0")
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("between 1 and", proc.stderr)
+
+    def test_malformed_text_names_the_variable_instead_of_raising(self):
+        proc = self._run("select_intake.py", INTAKE_SLICE="abc")
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("INTAKE_SLICE", proc.stderr)
+        self.assertNotIn("Traceback", proc.stderr)
+
+    def test_an_override_above_the_ceiling_is_refused(self):
+        proc = self._run("select_intake.py", INTAKE_SLICE="9999")
+        self.assertNotEqual(proc.returncode, 0)
+
+    def test_a_valid_override_still_works(self):
+        """The guard must not remove the knob, only bound it."""
+        proc = self._run("select_intake.py", INTAKE_SLICE="40")
+        self.assertEqual(proc.returncode, 0)
+        self.assertEqual(self._slice_size(proc, "slice"), 40)
+
+
+class TestTheInstallerCarriesSettingsNotSecrets(unittest.TestCase):
+    """The installer used to copy `~/.hermes/config.yaml` into the new profile.
+
+    That file's own `model:` block is documented to hold an inline `api_key`,
+    and a generated config really does put one there, so the copy duplicated a
+    credential into a second file while the README told the reader no
+    credentials were involved. It also bought nothing: a profile with no key of
+    its own authenticates through the config it inherits.
+
+    These assertions pin the shape the fix depends on — named settings through
+    the CLI, no file copy, and a runnability check that lands before anything
+    is scheduled.
+    """
+
+    INSTALL = HERE.parents[1] / "scripts" / "install.sh"
+    CARRIED = ("model.default", "model.provider", "model.base_url")
+
+    def setUp(self):
+        self.text = self.INSTALL.read_text(encoding="utf-8")
+        # Comments explain the old behavior, so they would match every pattern
+        # below and hide a regression in the code they describe.
+        self.code = "\n".join(line for line in self.text.splitlines()
+                               if not line.lstrip().startswith("#"))
+
+    def test_no_config_file_is_copied_into_the_profile(self):
+        self.assertIsNone(
+            re.search(r"\bcp\b[^\n]*config\.yaml", self.code),
+            "installer copies config.yaml again; that carries an inline "
+            "api_key into the new profile")
+
+    def test_each_model_setting_is_transferred_through_the_cli(self):
+        for key in self.CARRIED:
+            self.assertIn(key, self.code, f"{key} is no longer carried over")
+        self.assertIn("config set", self.code,
+                      "settings must move through `hermes config set`")
+
+    def test_nothing_named_like_a_credential_is_transferred(self):
+        for secret in ("api_key", "sudo_password", "auth.json", ".env"):
+            self.assertIsNone(
+                re.search(rf"config set[^\n]*{re.escape(secret)}", self.code),
+                f"installer transfers {secret} into the new profile")
+
+    def test_the_runnability_check_runs_before_any_job_is_registered(self):
+        check = self.code.find("config get model.default")
+        register = self.code.find("register-jobs.sh")
+        self.assertNotEqual(check, -1, "no model-resolution check remains")
+        self.assertNotEqual(register, -1, "installer no longer registers jobs")
+        self.assertLess(check, register,
+                        "the check must precede registration, or the exit "
+                        "leaves five jobs scheduled against a dead profile")
+
+    def test_an_unresolvable_model_exits_non_zero(self):
+        """The check has to end the run, not merely print a complaint."""
+        after = self.code[self.code.find("config get model.default"):]
+        window = after[:after.find("register-jobs.sh")]
+        self.assertIn("exit 1", window,
+                      "an unresolvable model must abort, not warn and continue")
+
+
+class TestTheReadmeDescribesTheInstallerItShips(unittest.TestCase):
+    """The README documented a copy and an override that no longer exist.
+
+    `SOURCE_PROFILE_CONFIG` was removed with the file copy, and a reader
+    following the old paragraph would set a variable nothing reads.
+    """
+
+    RECIPE = HERE.parents[1]
+
+    def setUp(self):
+        self.readme = (self.RECIPE / "README.md").read_text(encoding="utf-8")
+        self.install = (self.RECIPE / "scripts" / "install.sh").read_text(
+            encoding="utf-8")
+
+    def test_the_readme_names_no_environment_variable_the_script_ignores(self):
+        for name in re.findall(r"`([A-Z][A-Z0-9_]{3,})`", self.readme):
+            if name in ("HERMES_HOME", "PROFILE_NAME", "INTAKE_SLICE",
+                        "REVIEW_BATCH"):
+                continue
+            if name.startswith("NEMOCLAW") or name.startswith("SOURCE_"):
+                self.assertIn(name, self.install,
+                              f"README documents {name}; install.sh never "
+                              "reads it")
+
+    def test_the_readme_does_not_promise_a_config_copy(self):
+        self.assertNotIn("copy of `~/.hermes/config.yaml`", self.readme,
+                         "README still describes the removed file copy")
 
 
 if __name__ == "__main__":

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_selectors.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_selectors.py
@@ -549,6 +549,11 @@ class TestTheSliceBoundCannotBeDefeated(unittest.TestCase):
     message could name the variable.
     """
 
+
+    # Both selectors read their bound through the same helper, so every case
+    # below runs against both — `REVIEW_BATCH` was named in the finding too.
+    SELECTORS = (("select_intake.py", "INTAKE_SLICE"),
+                 ("select_review.py", "REVIEW_BATCH"))
     def setUp(self):
         self.home = tempfile.mkdtemp()
         self.db = Path(self.home) / "workspace" / "ledger" / "state.db"
@@ -579,8 +584,7 @@ class TestTheSliceBoundCannotBeDefeated(unittest.TestCase):
             self._slice_size(self._run("select_review.py"), "batch"), 15)
 
     def test_a_negative_override_is_refused_rather_than_unbounded(self):
-        for script, var in (("select_intake.py", "INTAKE_SLICE"),
-                            ("select_review.py", "REVIEW_BATCH")):
+        for script, var in self.SELECTORS:
             with self.subTest(script=script):
                 proc = self._run(script, **{var: "-1"})
                 self.assertNotEqual(proc.returncode, 0)
@@ -588,19 +592,25 @@ class TestTheSliceBoundCannotBeDefeated(unittest.TestCase):
                 self.assertNotIn('"slice"', proc.stdout)
 
     def test_zero_is_refused(self):
-        proc = self._run("select_intake.py", INTAKE_SLICE="0")
-        self.assertNotEqual(proc.returncode, 0)
-        self.assertIn("between 1 and", proc.stderr)
+        for script, var in self.SELECTORS:
+            with self.subTest(script=script):
+                proc = self._run(script, **{var: "0"})
+                self.assertNotEqual(proc.returncode, 0)
+                self.assertIn("between 1 and", proc.stderr)
 
     def test_malformed_text_names_the_variable_instead_of_raising(self):
-        proc = self._run("select_intake.py", INTAKE_SLICE="abc")
-        self.assertNotEqual(proc.returncode, 0)
-        self.assertIn("INTAKE_SLICE", proc.stderr)
-        self.assertNotIn("Traceback", proc.stderr)
+        for script, var in self.SELECTORS:
+            with self.subTest(script=script):
+                proc = self._run(script, **{var: "abc"})
+                self.assertNotEqual(proc.returncode, 0)
+                self.assertIn(var, proc.stderr)
+                self.assertNotIn("Traceback", proc.stderr)
 
     def test_an_override_above_the_ceiling_is_refused(self):
-        proc = self._run("select_intake.py", INTAKE_SLICE="9999")
-        self.assertNotEqual(proc.returncode, 0)
+        for script, var in self.SELECTORS:
+            with self.subTest(script=script):
+                proc = self._run(script, **{var: "9999"})
+                self.assertNotEqual(proc.returncode, 0)
 
     def test_a_valid_override_still_works(self):
         """The guard must not remove the knob, only bound it."""

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_selectors.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_selectors.py
@@ -1,0 +1,393 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Acceptance: what the cron pre-steps hand the agent, and when they decline to
+wake it at all."""
+
+import json, os, re, sqlite3, subprocess, sys, tempfile, unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parents[1]
+SCHEMA = (HERE / "schema.sql").read_text(encoding="utf-8")
+
+
+class SelectorCase(unittest.TestCase):
+
+    def setUp(self):
+        self.home = tempfile.mkdtemp()
+        self.db = Path(self.home) / "workspace" / "ledger" / "state.db"
+        self.db.parent.mkdir(parents=True)
+        with sqlite3.connect(self.db) as c:
+            c.executescript(SCHEMA)
+
+    def run_selector(self, script, **env):
+        proc = subprocess.run(
+            [sys.executable, str(HERE / script)], capture_output=True, text=True,
+            env={"PATH": os.environ["PATH"], "HERMES_HOME": self.home, **env})
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        return proc.stdout
+
+    @staticmethod
+    def wake_gate_present(stdout: str) -> bool:
+        """Decide the way the scheduler decides.
+
+        Hermes reads the *last non-empty stdout line* and nothing else
+        (`cron/scheduler.py`, `_parse_wake_gate`): if that line parses as a
+        JSON object with `wakeAgent` false, the agent is skipped; anything
+        else — non-JSON, a missing key, a gate printed earlier with output
+        after it — wakes it. Asserting only that the gate appears somewhere
+        would stay green while every idle tick woke the model, which is the
+        one thing this gate exists to prevent.
+        """
+        lines = [line for line in stdout.splitlines() if line.strip()]
+        if not lines:
+            return False
+        try:
+            gate = json.loads(lines[-1].strip())
+        except ValueError:
+            return False
+        return isinstance(gate, dict) and gate.get("wakeAgent", True) is False
+
+    def payload(self, stdout: str) -> dict:
+        # The gate, when present, is a separate JSON object after the payload.
+        head = stdout.split('{"wakeAgent"')[0]
+        return json.loads(head)
+
+    def add_item(self, sid, state="pending", event_at="2026-08-18T00:00:00Z"):
+        with sqlite3.connect(self.db) as c:
+            c.execute("INSERT INTO items(source_id, source, scope, event_at, state,"
+                      " sender, subject, body, addressing, unread)"
+                      " VALUES (?,'email','inbox',?,?,'Dana','subject','body','direct',1)",
+                      (sid, event_at, state))
+
+    def add_obligation(self, sid, reviewed_at=None, status="open", snoozed_until=None):
+        self.add_item(sid, state="judged")
+        with sqlite3.connect(self.db) as c:
+            c.execute("INSERT INTO obligations(id, source_id, title, priority, status,"
+                      " reviewed_at, snoozed_until) VALUES (?,?,?,'high',?,?,?)",
+                      (sid[:12], sid, f"title {sid}", status, reviewed_at, snoozed_until))
+
+
+class TestIntake(SelectorCase):
+
+    def test_an_empty_store_declines_to_wake_the_agent(self):
+        # The whole point of the gate: a quiet half-hour must cost no tokens.
+        out = self.run_selector("select_intake.py")
+        self.assertTrue(self.wake_gate_present(out))
+        self.assertEqual(self.payload(out)["slice"], [])
+
+    def test_pending_items_wake_the_agent(self):
+        self.add_item("m1")
+        out = self.run_selector("select_intake.py")
+        self.assertFalse(self.wake_gate_present(out))
+        self.assertEqual(len(self.payload(out)["slice"]), 1)
+
+    def test_judged_and_skipped_items_are_not_offered_again(self):
+        self.add_item("judged", state="judged")
+        self.add_item("skipped", state="skipped")
+        out = self.run_selector("select_intake.py")
+        self.assertTrue(self.wake_gate_present(out))
+
+    def test_the_slice_is_bounded_and_oldest_first(self):
+        for n in range(10):
+            self.add_item(f"m{n}", event_at=f"2026-08-{10 + n:02d}T00:00:00Z")
+        out = self.run_selector("select_intake.py", INTAKE_SLICE="3")
+        rows = self.payload(out)["slice"]
+        self.assertEqual(len(rows), 3)
+        self.assertEqual([r["source_id"] for r in rows], ["m0", "m1", "m2"])
+
+    def test_absent_collectors_are_reported_rather_than_failing(self):
+        out = self.run_selector("select_intake.py")
+        collected = self.payload(out)["collected"]
+        self.assertEqual(set(collected), {"ingest_graph.py", "ingest_slack.py"})
+
+
+class TestReview(SelectorCase):
+
+    def test_no_open_obligations_declines_to_wake_the_agent(self):
+        out = self.run_selector("select_review.py")
+        self.assertTrue(self.wake_gate_present(out))
+
+    def test_never_reviewed_rows_come_before_stale_ones(self):
+        self.add_obligation("old", reviewed_at="2026-01-01T00:00:00Z")
+        self.add_obligation("fresh", reviewed_at="2026-08-18T00:00:00Z")
+        self.add_obligation("never")
+        rows = self.payload(self.run_selector("select_review.py"))["batch"]
+        self.assertEqual(rows[0]["source_id"], "never")
+        self.assertEqual(rows[1]["source_id"], "old")
+
+    def test_a_snoozed_row_is_left_alone_until_its_time(self):
+        self.add_obligation("sleeping", snoozed_until="2099-01-01T00:00:00Z")
+        out = self.run_selector("select_review.py")
+        self.assertTrue(self.wake_gate_present(out))
+
+    def test_an_expired_snooze_returns_to_the_batch(self):
+        self.add_obligation("woken", snoozed_until="2020-01-01T00:00:00Z")
+        rows = self.payload(self.run_selector("select_review.py"))["batch"]
+        self.assertEqual([r["source_id"] for r in rows], ["woken"])
+
+    def test_closed_rows_are_not_re_reviewed(self):
+        self.add_obligation("done", status="done")
+        self.add_obligation("ignored", status="ignored")
+        out = self.run_selector("select_review.py")
+        self.assertTrue(self.wake_gate_present(out))
+
+    def test_the_batch_is_bounded(self):
+        for n in range(10):
+            self.add_obligation(f"o{n}")
+        rows = self.payload(self.run_selector("select_review.py", REVIEW_BATCH="4"))["batch"]
+        self.assertEqual(len(rows), 4)
+
+
+class TestSchedulerIntegrationContract(unittest.TestCase):
+    """The two promises the scheduler side of this phase rests on.
+
+    Both are claims about files outside this test: the shipped manifest and the
+    registration script. Neither was covered, and one of them was already
+    false — the script looked jobs up with `cron list --json`, a flag the CLI
+    does not have, so the lookup always came back empty and every run created
+    another copy of all five jobs.
+    """
+
+    RECIPE = HERE.parents[1]
+
+    def test_the_manifest_does_not_claim_the_cron_directory(self):
+        """Owning `cron` would let an update replace the live job store."""
+        manifest = (self.RECIPE / "profile" / "distribution.yaml").read_text(
+            encoding="utf-8")
+        owned = []
+        collecting = False
+        for line in manifest.splitlines():
+            if line.startswith("distribution_owned:"):
+                collecting = True
+                continue
+            if collecting:
+                if line.startswith("  - "):
+                    owned.append(line[4:].strip())
+                elif line.strip() and not line.startswith(" "):
+                    break
+        self.assertTrue(owned, "the manifest declares nothing as owned")
+        self.assertNotIn("cron", owned)
+        self.assertNotIn("workspace", owned)
+
+    def test_the_registration_script_looks_a_job_up_before_creating_it(self):
+        script = (self.RECIPE / "scripts" / "register-jobs.sh").read_text(
+            encoding="utf-8")
+        self.assertIn("job_id_for", script)
+        # `cron list` takes no `--json`. Passing it made argparse print usage,
+        # the lookup came back empty behind `2>/dev/null`, and the script
+        # created another copy of every job on each run. Match the invocation,
+        # not the word: the comment above the lookup explains the flag.
+        for line in script.splitlines():
+            if line.strip().startswith("#"):
+                continue
+            with self.subTest(line=line.strip()[:60]):
+                self.assertNotIn("cron list --json", line)
+
+    def test_the_registration_script_only_writes_through_the_cron_cli(self):
+        """The lookup may read the store; the writes must go through Hermes."""
+        script = (self.RECIPE / "scripts" / "register-jobs.sh").read_text(
+            encoding="utf-8")
+        for verb in ("cron create", "cron edit"):
+            with self.subTest(verb=verb):
+                self.assertIn(f'hermes -p "$PROFILE" {verb}', script)
+        # The store is read, never written: no redirect and no python -c that
+        # opens it for writing.
+        for line in script.splitlines():
+            if "jobs.json" not in line or line.strip().startswith("#"):
+                continue
+            with self.subTest(line=line.strip()[:60]):
+                self.assertNotIn(">", line)
+                self.assertNotIn("rm ", line)
+
+
+class TestScriptsNameRealHermesCommands(unittest.TestCase):
+    """Every `hermes` command the shipped text names must exist.
+
+    Pointing a reader at a command that is not there is the failure this recipe
+    has now made three times: an error message said `restore` when the
+    subcommand is `unignore`; a teardown line said `hermes profile remove` when
+    it is `delete`; and the installer's remediation said `hermes model <name>`,
+    which the CLI rejects because `model` takes no positional argument. The
+    first two were caught by reading the CLI, the third by an independent
+    review — none by a test, because the scan covered only two command groups
+    and only the shell scripts.
+
+    So it covers four groups now, and the README as well as the scripts. The
+    surfaces below were read from `hermes <group> --help` on Hermes 0.20.0;
+    update them deliberately if the CLI changes.
+    """
+
+    RECIPE = HERE.parents[1]
+
+    KNOWN = {
+        "cron": {"list", "create", "add", "edit", "pause", "resume", "run",
+                 "remove", "rm", "delete", "status", "runs", "history",
+                 "notepad", "tick"},
+        "profile": {"list", "use", "create", "delete", "describe", "show",
+                    "alias", "rename", "export", "import", "install",
+                    "update", "info"},
+        "gateway": {"run", "start", "stop", "restart", "status", "install",
+                    "uninstall", "list", "setup", "migrate-legacy", "enroll"},
+        "config": {"show", "edit", "get", "set", "unset", "path", "env-path",
+                   "check", "migrate"},
+    }
+    # `hermes model` takes flags only. Naming anything after it is the bug the
+    # installer shipped with.
+    NO_POSITIONAL = {"model"}
+
+    GROUPED = re.compile(r"hermes\b[^\n|`]*?\b(cron|profile|gateway|config)\s+([a-z-]+)")
+    # `model` must be the subcommand itself: only flags and their values may
+    # sit between `hermes` and it. Without that, `config set model <name>` —
+    # which is correct — matched as `model <name>`, which is not.
+    BARE = re.compile(
+        r"hermes(?:\s+-{1,2}[A-Za-z-]+(?:\s+\S+)?)*\s+(model)\s+([^\s|`]+)")
+
+    def sources(self):
+        yield from sorted((self.RECIPE / "scripts").glob("*.sh"))
+        yield self.RECIPE / "README.md"
+
+    def test_every_named_subcommand_is_real(self):
+        for path in self.sources():
+            text = path.read_text(encoding="utf-8")
+            for group, sub in self.GROUPED.findall(text):
+                with self.subTest(source=path.name, command=f"{group} {sub}"):
+                    self.assertIn(sub, self.KNOWN[group],
+                                  f"{path.name} names `hermes {group} {sub}`, "
+                                  f"which is not a {group} subcommand")
+
+    def test_no_argument_is_passed_to_a_flags_only_command(self):
+        for path in self.sources():
+            text = path.read_text(encoding="utf-8")
+            for command, argument in self.BARE.findall(text):
+                with self.subTest(source=path.name, command=command):
+                    self.fail(f"{path.name} passes `{argument}` to "
+                              f"`hermes {command}`, which takes flags only")
+
+    def test_the_scan_would_catch_all_three_historical_mistakes(self):
+        """The check has to be able to fail the way it failed before."""
+        self.assertEqual(self.GROUPED.findall("hermes -p x profile remove y"),
+                         [("profile", "remove")])
+        self.assertNotIn("remove", self.KNOWN["profile"])
+        self.assertEqual(self.BARE.findall("hermes -p x model gpt-4"),
+                         [("model", "gpt-4")])
+        # The correct spelling must not trip it.
+        self.assertEqual(
+            self.BARE.findall("hermes -p x config set model gpt-4"), [])
+        self.assertEqual(self.GROUPED.findall("hermes gateway strt"),
+                         [("gateway", "strt")])
+        self.assertNotIn("strt", self.KNOWN["gateway"])
+
+
+class TestTheDocumentedScheduleMatchesTheScript(unittest.TestCase):
+    """The README's job table is a copy of the script's arguments.
+
+    A copy drifts. This one is worth pinning because a reader plans around the
+    cadence — "every 30 minutes" is what tells them an idle tick has to be
+    free — and nothing else would notice if the script changed underneath it.
+    """
+
+    RECIPE = HERE.parents[1]
+    EXPECTED = {
+        "intake": ("*/30 * * * *", "inbound-judging"),
+        "review": ("0 */6 * * *", "obligation-review"),
+        "memory repair": ("0 3 * * *", "memory-repair"),
+        "memory consolidation": ("0 4 * * *", "memory-consolidation"),
+        "preference update": ("30 4 * * *", "preference-update"),
+    }
+
+    def registered(self):
+        script = (self.RECIPE / "scripts" / "register-jobs.sh").read_text(
+            encoding="utf-8")
+        found = {}
+        for name, schedule, skill in re.findall(
+                r'register\s+("?[a-z ]+"?)\s+"([^"]+)"\s+(\S+)', script):
+            found[name.strip('"')] = (schedule, skill)
+        return found
+
+    def test_the_script_registers_exactly_the_documented_jobs(self):
+        self.assertEqual(set(self.registered()), set(self.EXPECTED))
+
+    def test_each_job_carries_the_documented_schedule_and_skill(self):
+        for name, expected in self.EXPECTED.items():
+            with self.subTest(job=name):
+                self.assertEqual(self.registered()[name], expected)
+
+    def test_the_readme_table_agrees_with_the_script(self):
+        readme = (self.RECIPE / "README.md").read_text(encoding="utf-8")
+        prose = {
+            "intake": "every 30 minutes",
+            "review": "every 6 hours",
+            "memory repair": "daily 03:00",
+            "memory consolidation": "daily 04:00",
+            "preference update": "daily 04:30",
+        }
+        for name, cadence in prose.items():
+            with self.subTest(job=name):
+                self.assertRegex(
+                    readme, rf"\|\s*{re.escape(name)}\s*\|\s*{re.escape(cadence)}\s*\|",
+                    f"the README table no longer lists {name} as {cadence}")
+
+    def test_every_skill_the_schedule_names_is_shipped(self):
+        for _, skill in self.EXPECTED.values():
+            with self.subTest(skill=skill):
+                self.assertTrue((self.RECIPE / "profile" / "skills" / skill
+                                 / "SKILL.md").is_file())
+
+
+class TestTheRebootStoryIsWhatTheReadmeSays(unittest.TestCase):
+    """What survives a restart, and what the README promises about it.
+
+    This is the first question anyone asks the morning after installing, and
+    it has three different answers — the jobs persist, the firing does not
+    unless a service was installed, and a backlog collapses rather than
+    replaying. The parts this recipe controls are asserted here; the parts
+    Hermes controls are quoted from its source with a pointer, because a test
+    that reimplemented them would only be testing itself.
+    """
+
+    RECIPE = HERE.parents[1]
+
+    def readme(self):
+        return (self.RECIPE / "README.md").read_text(encoding="utf-8")
+
+    def test_the_job_store_is_not_something_an_update_can_replace(self):
+        """The claim "a profile update leaves it alone" rests on this."""
+        manifest = (self.RECIPE / "profile" / "distribution.yaml").read_text(
+            encoding="utf-8")
+        owned, collecting = [], False
+        for line in manifest.splitlines():
+            if line.startswith("distribution_owned:"):
+                collecting = True
+                continue
+            if collecting:
+                if line.startswith("  - "):
+                    owned.append(line[4:].strip())
+                elif line.strip() and not line.startswith(" "):
+                    break
+        self.assertNotIn("cron", owned)
+
+    def test_the_readme_separates_surviving_from_resuming(self):
+        """Conflating the two is what makes a reader think it is fixed."""
+        readme = self.readme()
+        self.assertIn("gateway install", readme)
+        self.assertIn("gateway run", readme)
+        # The distinction has to be stated, not implied.
+        self.assertIn("Only if the gateway was installed", readme)
+
+    def test_the_readme_states_the_backlog_is_collapsed(self):
+        readme = self.readme()
+        self.assertIn("One of them", readme)
+        self.assertRegex(readme, r"does not wake to ninety-six")
+
+    def test_the_backlog_claim_matches_the_schedule_it_cites(self):
+        """Ninety-six is two days of the documented intake cadence."""
+        script = (self.RECIPE / "scripts" / "register-jobs.sh").read_text(
+            encoding="utf-8")
+        self.assertIn('register intake "*/30 * * * *"', script)
+        per_day = 24 * 60 // 30
+        self.assertEqual(per_day * 2, 96)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_selectors.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_selectors.py
@@ -796,12 +796,29 @@ class TestCollectorDiagnosticsStayOutOfThePrompt(CollectorCase):
         self.assertNotIn('"stderr"', proc.stdout,
                          "the payload still carries a raw stderr field")
 
-    def test_the_operator_still_gets_the_detail_on_stderr(self):
-        """Withholding it from the prompt must not mean discarding it."""
+    def test_the_secret_is_absent_from_stderr_as_well(self):
+        """Moving it out of the prompt only moved the problem.
+
+        The scheduler captures this process's stderr into the job log, so text
+        that was transient in a subprocess becomes a file that outlives the
+        token in it. Neither stream may carry it.
+        """
         self._failing_collector_leaking()
         proc = self._run_full()
-        self.assertIn(self.SECRET, proc.stderr,
-                      "the detail is gone from the local log as well")
+        for leaked in (self.SECRET, "xoxp-", "SECRET-TOKEN-VALUE", self.URL,
+                       "sig=AAAABBBBCCCC"):
+            self.assertNotIn(leaked, proc.stderr,
+                             f"{leaked!r} was written to the job log")
+
+    def test_stderr_still_says_which_collector_failed_and_how(self):
+        """Dropping the text must not mean dropping the signal."""
+        self._collector('sys.stderr.write("boom\\n")\nsys.exit(3)')
+        proc = self._run_full()
+        self.assertIn("ingest_graph.py", proc.stderr)
+        self.assertIn("3", proc.stderr)
+        self.assertIn("nonzero_exit", proc.stderr)
+        self.assertNotIn("boom", proc.stderr,
+                         "the collector's own text is still being quoted")
 
     def test_the_payload_says_what_class_of_failure_it_was(self):
         """The agent still needs enough to act on, just nothing quotable."""

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_selectors.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_selectors.py
@@ -394,17 +394,8 @@ class TestTheRebootStoryIsWhatTheReadmeSays(unittest.TestCase):
         self.assertEqual(per_day * 2, 96)
 
 
-class TestACollectorFailureIsVisible(unittest.TestCase):
-    """A connector that stops working must not be silent.
-
-    This is the worst failure this design can have, and it was the shipped
-    behaviour: a collector whose credential expired wrote to stderr and exited
-    non-zero while printing nothing, `json.loads("" or "{}")` turned that into
-    an empty success, and the idle gate then skipped the agent entirely. Every
-    half hour, forever, with nothing anywhere saying so. Slack's rotating user
-    tokens make an expired credential an ordinary event rather than an
-    exceptional one, so this path is the one that matters most.
-    """
+class CollectorCase(unittest.TestCase):
+    """Fixture shared by the collector-behaviour classes below."""
 
     def setUp(self):
         self.home = tempfile.mkdtemp()
@@ -436,13 +427,28 @@ class TestACollectorFailureIsVisible(unittest.TestCase):
     def _graph(self, payload):
         return payload["collected"]["ingest_graph.py"]
 
+
+class TestACollectorFailureIsVisible(CollectorCase):
+    """A connector that stops working must not be silent.
+
+    This is the worst failure this design can have, and it was the shipped
+    behaviour: a collector whose credential expired wrote to stderr and exited
+    non-zero while printing nothing, `json.loads("" or "{}")` turned that into
+    an empty success, and the idle gate then skipped the agent entirely. Every
+    half hour, forever, with nothing anywhere saying so. Slack's rotating user
+    tokens make an expired credential an ordinary event rather than an
+    exceptional one, so this path is the one that matters most.
+    """
+
     def test_a_nonzero_exit_with_no_output_is_recorded_as_a_failure(self):
         self._collector('print("", end=""); print("token expired", file=sys.stderr); sys.exit(1)')
         payload, _ = self._run()
         entry = self._graph(payload)
         self.assertTrue(entry["failed"])
         self.assertEqual(entry["exit_code"], 1)
-        self.assertIn("token expired", entry["stderr"])
+        self.assertEqual(entry["error_class"], "nonzero_exit")
+        # The message itself belongs in the local log, not the prompt.
+        self.assertNotIn("token expired", json.dumps(payload))
 
     def test_a_nonzero_exit_with_valid_json_is_still_a_failure(self):
         """Readable output does not mean the run succeeded."""
@@ -455,7 +461,7 @@ class TestACollectorFailureIsVisible(unittest.TestCase):
         self._collector('print("not json"); sys.exit(0)')
         payload, _ = self._run()
         self.assertTrue(self._graph(payload)["failed"])
-        self.assertIn("unreadable output", self._graph(payload)["error"])
+        self.assertEqual(self._graph(payload)["error_class"], "unreadable_output")
 
     def test_a_failure_with_no_pending_rows_still_wakes_the_agent(self):
         """The gate makes an idle tick free; it must not make a broken one quiet."""
@@ -625,12 +631,15 @@ class TestTheInstallerCarriesSettingsNotSecrets(unittest.TestCase):
     That file's own `model:` block is documented to hold an inline `api_key`,
     and a generated config really does put one there, so the copy duplicated a
     credential into a second file while the README told the reader no
-    credentials were involved. It also bought nothing: a profile with no key of
-    its own authenticates through the config it inherits.
+    credentials were involved. It bought nothing either, though not for the
+    reason first given here: a profile with no key of its own does not
+    authenticate through the config it inherits — it sends the placeholder
+    `no-key-required` — so the fix is to require a key on the target profile
+    rather than to copy one.
 
-    These assertions pin the shape the fix depends on — named settings through
-    the CLI, no file copy, and a runnability check that lands before anything
-    is scheduled.
+    These assertions pin the shape that depends on — named settings through the
+    CLI, no file copy, every transfer failing closed and read back, and both
+    runnability checks landing before anything is scheduled.
     """
 
     INSTALL = HERE.parents[1] / "scripts" / "install.sh"
@@ -740,6 +749,182 @@ class TestTheReadmeDescribesTheInstallerItShips(unittest.TestCase):
     def test_the_readme_does_not_promise_a_config_copy(self):
         self.assertNotIn("copy of `~/.hermes/config.yaml`", self.readme,
                          "README still describes the removed file copy")
+
+
+class TestCollectorDiagnosticsStayOutOfThePrompt(CollectorCase):
+    """A failing collector's own output is untrusted text, and stdout is a prompt.
+
+    Making the failure visible was right; carrying the collector's stderr into
+    the payload to do it was not. That stdout becomes the scheduled agent's
+    prompt, and a collector is a subprocess talking to a mail or chat API — its
+    stderr is a traceback that can hold a bearer token, a signed URL, or a
+    stranger's message body. Truncating to two hundred characters bounds the
+    length and not the content; the first two hundred characters of a traceback
+    are where the request line is.
+
+    The payload now carries a stable error class and an exit code. The detail
+    goes to this process's own stderr, which cron writes to a local log.
+    """
+
+    SECRET = "Bearer xoxp-9999-SECRET-TOKEN-VALUE"
+    URL = "https://graph.example.com/v1/me?sig=AAAABBBBCCCC"
+
+    def _run_full(self):
+        return subprocess.run(
+            [sys.executable, str(self.recipe / "scripts" / "select_intake.py")],
+            capture_output=True, text=True,
+            env={**os.environ, "HERMES_HOME": self.home})
+
+    def _failing_collector_leaking(self):
+        self._collector(
+            f'sys.stderr.write("Traceback: auth failed\\n'
+            f'  headers={{\'Authorization\': \'{self.SECRET}\'}}\\n'
+            f'  url={self.URL}\\n")\nsys.exit(1)')
+
+    def test_secret_shaped_stderr_never_reaches_stdout(self):
+        self._failing_collector_leaking()
+        proc = self._run_full()
+        for leaked in (self.SECRET, "xoxp-", "SECRET-TOKEN-VALUE", self.URL,
+                       "sig=AAAABBBBCCCC"):
+            self.assertNotIn(leaked, proc.stdout,
+                             f"{leaked!r} reached the agent prompt")
+
+    def test_no_raw_stderr_field_survives_in_the_payload(self):
+        """The field itself is the hazard, whatever a given run puts in it."""
+        self._failing_collector_leaking()
+        proc = self._run_full()
+        self.assertNotIn('"stderr"', proc.stdout,
+                         "the payload still carries a raw stderr field")
+
+    def test_the_operator_still_gets_the_detail_on_stderr(self):
+        """Withholding it from the prompt must not mean discarding it."""
+        self._failing_collector_leaking()
+        proc = self._run_full()
+        self.assertIn(self.SECRET, proc.stderr,
+                      "the detail is gone from the local log as well")
+
+    def test_the_payload_says_what_class_of_failure_it_was(self):
+        """The agent still needs enough to act on, just nothing quotable."""
+        self._collector('sys.stderr.write("boom\\n")\nsys.exit(3)')
+        payload, _ = self._run()
+        graph = self._graph(payload)
+        self.assertTrue(graph["failed"])
+        self.assertEqual(graph["exit_code"], 3)
+        self.assertEqual(graph["error_class"], "nonzero_exit")
+
+    def test_unreadable_output_is_classed_without_quoting_the_output(self):
+        self._collector('print("{not json")\nsys.exit(0)')
+        payload, stdout = self._run()
+        graph = self._graph(payload)
+        self.assertEqual(graph["error_class"], "unreadable_output")
+        self.assertNotIn("not json", stdout,
+                         "the unparsable text was quoted back into the prompt")
+
+
+class TestAFailedTransferStopsTheInstall(unittest.TestCase):
+    """`set -e` does not abort on the left operand of `&&`.
+
+    The carry loop was written `config set … && echo …`, on the assumption that
+    `set -euo pipefail` would end the run if the set failed. It does not:
+    `false && echo` is a no-op, not an abort. So a profile could take
+    `model.default`, silently drop `model.provider` and `model.base_url`, pass
+    the model check — which only asks about `model.default` — pass the
+    credential check, and get all five jobs registered against whatever route
+    it had left.
+
+    Exit status alone is also not proof the value landed, so each carried
+    setting is read back off the target profile and compared.
+
+    These tests stub `hermes` on PATH and assert on what the installer does,
+    not on what the script says. The earlier installer tests all read the file
+    and matched patterns in it, which is why none of them could see this.
+    """
+
+    RECIPE = HERE.parents[1]
+
+    def setUp(self):
+        self.bin = Path(tempfile.mkdtemp())
+        self.state = Path(tempfile.mkdtemp())
+        self.profile_home = Path(tempfile.mkdtemp())
+        self.log = self.state / "calls.log"
+        (self.bin / "uname").write_text("#!/bin/sh\necho Linux\n", encoding="utf-8")
+        (self.bin / "uname").chmod(0o755)
+        (self.bin / "hermes").write_text(HERMES_STUB, encoding="utf-8")
+        (self.bin / "hermes").chmod(0o755)
+        for key, value in (("model.default", "some/model"),
+                           ("model.provider", "custom"),
+                           ("model.base_url", "https://example.invalid/v1")):
+            (self.state / f"source.{key}").write_text(value, encoding="utf-8")
+
+    def _install(self, **env):
+        return subprocess.run(
+            ["bash", str(self.RECIPE / "scripts" / "install.sh")],
+            capture_output=True, text=True, cwd=str(self.RECIPE),
+            env={**os.environ,
+                 "PATH": f"{self.bin}:{os.environ['PATH']}",
+                 "PROFILE_NAME": "under-test",
+                 "STUB_STATE": str(self.state),
+                 "STUB_PROFILE_HOME": str(self.profile_home),
+                 "STUB_LOG": str(self.log),
+                 **env})
+
+    def _registered(self):
+        """Did anything reach the scheduler?"""
+        if not self.log.exists():
+            return False
+        return "cron" in self.log.read_text(encoding="utf-8")
+
+    # These pass `ALLOW_NO_API_KEY` so the credential gate cannot be what stops
+    # the run. Without it the first draft of `schedules_nothing` passed against
+    # the broken installer, because a later check happened to abort first.
+    def test_a_failing_transfer_aborts_instead_of_being_skipped(self):
+        proc = self._install(STUB_FAIL_SET="model.provider", ALLOW_NO_API_KEY="1")
+        self.assertNotEqual(proc.returncode, 0,
+                            "installer exited 0 after a transfer failed")
+        self.assertIn("model.provider", proc.stderr)
+
+    def test_a_failing_transfer_schedules_nothing(self):
+        self._install(STUB_FAIL_SET="model.provider", ALLOW_NO_API_KEY="1")
+        self.assertFalse(self._registered(),
+                         "jobs were registered on a half-configured profile")
+
+    def test_a_setting_that_does_not_stick_is_caught_by_read_back(self):
+        """A `config set` can exit 0 and still not be there afterwards."""
+        proc = self._install(STUB_ACCEPT_WITHOUT_WRITING="model.base_url",
+                             ALLOW_NO_API_KEY="1")
+        self.assertNotEqual(proc.returncode, 0,
+                            "a silently dropped setting installed cleanly")
+        self.assertIn("did not keep", proc.stderr)
+        self.assertFalse(self._registered())
+
+    def test_a_clean_transfer_reaches_registration(self):
+        """The guard must not block the path it exists to protect."""
+        proc = self._install(ALLOW_NO_API_KEY="1")
+        self.assertEqual(proc.returncode, 0, proc.stderr[-400:])
+        self.assertTrue(self._registered(),
+                        "a fully configured profile never reached the scheduler")
+
+
+HERMES_STUB = r"""#!/bin/sh
+# A stand-in for the parts of `hermes` the installer touches. Records every
+# invocation so a test can ask whether the scheduler was ever reached.
+printf '%s\n' "$*" >> "$STUB_LOG"
+prof=""
+if [ "$1" = "-p" ]; then prof="$2"; shift 2; fi
+case "$1 $2" in
+  "profile install") exit 0 ;;
+  "profile show") echo "Path: $STUB_PROFILE_HOME"; exit 0 ;;
+  "config get")
+      if [ -n "$prof" ]; then f="$STUB_STATE/target.$3"; else f="$STUB_STATE/source.$3"; fi
+      if [ -f "$f" ]; then cat "$f"; exit 0; fi
+      echo "Config key not set: $3"; exit 1 ;;
+  "config set")
+      [ "$3" = "$STUB_FAIL_SET" ] && exit 1
+      [ "$3" = "$STUB_ACCEPT_WITHOUT_WRITING" ] && exit 0
+      printf '%s' "$4" > "$STUB_STATE/target.$3"; exit 0 ;;
+esac
+exit 0
+"""
 
 
 if __name__ == "__main__":

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_selectors.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_selectors.py
@@ -642,6 +642,12 @@ class TestTheInstallerCarriesSettingsNotSecrets(unittest.TestCase):
         # below and hide a regression in the code they describe.
         self.code = "\n".join(line for line in self.text.splitlines()
                                if not line.lstrip().startswith("#"))
+        # The remediation text tells the reader to run `config set
+        # model.api_key`, which is an instruction rather than a transfer. A
+        # test that cannot tell printing from doing fails on its own advice.
+        self.commands = "\n".join(
+            line for line in self.code.splitlines()
+            if not line.lstrip().startswith("echo "))
 
     def test_no_config_file_is_copied_into_the_profile(self):
         self.assertIsNone(
@@ -658,7 +664,8 @@ class TestTheInstallerCarriesSettingsNotSecrets(unittest.TestCase):
     def test_nothing_named_like_a_credential_is_transferred(self):
         for secret in ("api_key", "sudo_password", "auth.json", ".env"):
             self.assertIsNone(
-                re.search(rf"config set[^\n]*{re.escape(secret)}", self.code),
+                re.search(rf"config set[^\n]*{re.escape(secret)}",
+                          self.commands),
                 f"installer transfers {secret} into the new profile")
 
     def test_the_runnability_check_runs_before_any_job_is_registered(self):
@@ -676,6 +683,34 @@ class TestTheInstallerCarriesSettingsNotSecrets(unittest.TestCase):
         window = after[:after.find("register-jobs.sh")]
         self.assertIn("exit 1", window,
                       "an unresolvable model must abort, not warn and continue")
+
+    def test_a_missing_credential_aborts_before_registration(self):
+        """A model name alone does not make a profile runnable.
+
+        The credential is not inherited. A profile carrying only the three
+        settings sends the literal placeholder `no-key-required`, so every
+        scheduled job fails to authenticate — silently, in the logs, four times
+        an hour. The check belongs where a person is watching.
+        """
+        check = self.code.find("config get model.api_key")
+        register = self.code.find("register-jobs.sh")
+        self.assertNotEqual(check, -1, "no credential check")
+        self.assertLess(check, register,
+                        "the credential check must precede registration")
+        window = self.code[check:register]
+        self.assertIn("exit 1", window,
+                      "a missing credential must abort, not warn and continue")
+
+    def test_the_no_credential_case_has_a_deliberate_opt_out(self):
+        """Endpoints that need no key are real; they just have to say so."""
+        self.assertIn("ALLOW_NO_API_KEY", self.code,
+                      "no way to install against a keyless endpoint")
+
+    def test_the_credential_is_never_printed(self):
+        """Reading a key is fine; echoing it into a terminal is not."""
+        for line in self.code.splitlines():
+            if "echo" in line and "$credential" in line:
+                self.fail(f"installer echoes the credential: {line.strip()}")
 
 
 class TestTheReadmeDescribesTheInstallerItShips(unittest.TestCase):

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/walkthrough.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/walkthrough.py
@@ -234,8 +234,12 @@ def run(fixtures: Path) -> int:
     _say("  Break one on purpose — the check has to be able to fail, or it is")
     _say("  telling you nothing:")
     # Reachable with a fixture directory that ships no seed memory; say so
-    # rather than raising StopIteration out of a demonstration step.
-    person = next((root / "people").glob("*.md"), None)
+    # rather than raising StopIteration out of a demonstration step. Dotfiles
+    # are skipped for the same reason `memory_check` skips them: a macOS
+    # archive leaves a binary `._page.md` beside the real one, and `glob`
+    # returns it in whatever order the filesystem gives.
+    person = next((page for page in sorted((root / "people").glob("*.md"))
+                   if not page.name.startswith(".")), None)
     if person is None:
         _say("      no person page to break — this fixture set ships no seed")
         _say("      memory, so this demonstration is skipped.")

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/install.sh
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/install.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Stage the profile into a Hermes runtime and make it runnable.
+#
+# Three steps. The second is the one a reader skips: a freshly
+# installed profile has no model configuration, so every agent-backed job fails
+# on its first tick with "no model configured". The runtime already knows which
+# model to use, so the profile inherits that rather than the recipe asking the
+# reader to configure it twice.
+#
+# Only config.yaml is copied, never `.env`. Hermes keeps secrets in `.env` and
+# routes them there itself, so inference reaches the provider through the
+# runtime's own egress path and this profile never needs to hold a key.
+# Verified on Hermes 0.19.0 — copying config.yaml alone is enough for scheduled
+# jobs to run.
+#
+# What this cannot promise: `config.yaml` is the user's file, and two of its
+# documented keys hold secrets if someone has set them there — `api_key`, which
+# Hermes's own example offers as an alternative to `.env`, and `sudo_password`,
+# which it marks as plaintext. The copy is wholesale, so anything there travels
+# to the new profile. Read yours before running this if that matters to you.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RECIPE_ROOT="$(dirname "$HERE")"
+PROFILE="${PROFILE_NAME:-memory-driven-chief-of-staff}"
+SOURCE_PROFILE_CONFIG="${SOURCE_PROFILE_CONFIG:-$HOME/.hermes/config.yaml}"
+
+command -v hermes >/dev/null 2>&1 || {
+  echo "hermes is not on PATH." >&2
+  exit 1
+}
+
+echo "1/3  Installing the profile distribution"
+hermes profile install "$RECIPE_ROOT/profile" --name "$PROFILE" --force --yes
+
+# `|| true` matters: `hermes profile show` exits 1 for a profile that does not
+# exist, and under `set -e` the assignment would abort the script before the
+# check below could explain why.
+PROFILE_HOME="$(hermes profile show "$PROFILE" 2>/dev/null \
+  | sed -n 's/^Path:[[:space:]]*//p' || true)"
+if [[ -z "$PROFILE_HOME" ]]; then
+  echo "Could not resolve the profile home for '$PROFILE'." >&2
+  exit 1
+fi
+
+echo "2/3  Inheriting the runtime's model configuration"
+if [[ -f "$SOURCE_PROFILE_CONFIG" ]]; then
+  cp "$SOURCE_PROFILE_CONFIG" "$PROFILE_HOME/config.yaml"
+  echo "     copied from $SOURCE_PROFILE_CONFIG (no credential file is copied)"
+else
+  echo "     no config at $SOURCE_PROFILE_CONFIG — set a model with:" >&2
+  echo "       hermes -p $PROFILE config set model <name>" >&2
+fi
+
+echo "3/3  Registering scheduled jobs"
+PROFILE_NAME="$PROFILE" bash "$HERE/register-jobs.sh"
+
+cat <<EOF
+
+Installed '$PROFILE' at $PROFILE_HOME
+
+The store and memory live under \$PROFILE_HOME/workspace, which a profile
+update leaves alone.
+
+To load the fixture corpus instead of connecting a real account:
+  HERMES_HOME="$PROFILE_HOME" python3 "$RECIPE_ROOT/profile/scripts/load_fixtures.py" --fixtures "$RECIPE_ROOT/fixtures"
+
+Jobs fire only while a gateway is serving this profile. Check with:
+  hermes -p $PROFILE cron list
+EOF

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/install.sh
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/install.sh
@@ -74,11 +74,43 @@ echo "2/3  Carrying over the model settings"
 #
 # What the three settings do not carry is a credential, and nothing else
 # supplies one either — see the check below.
+# Fail closed on every one of them. `set -e` does not exit when a command fails
+# as the left operand of `&&` — `false && echo` is a no-op, not an abort — so
+# writing this as `config set … && echo …` swallowed the failure. A profile
+# that took `model.default` and silently dropped `provider` and `base_url`
+# passed both checks below and got all five jobs registered, pointed at
+# whatever route it had left.
+carried=()
 for key in model.default model.provider model.base_url; do
   value="$(hermes config get "$key" 2>/dev/null | head -1 || true)"
-  [[ -z "$value" || "$value" == *"not set"* ]] && continue
-  hermes -p "$PROFILE" config set "$key" "$value" >/dev/null 2>&1 \
-    && echo "     $key = $value"
+  if [[ -z "$value" || "$value" == *"not set"* ]]; then
+    continue
+  fi
+  if ! hermes -p "$PROFILE" config set "$key" "$value" >/dev/null 2>&1; then
+    echo "" >&2
+    echo "Could not set $key on profile '$PROFILE'." >&2
+    echo "Nothing has been scheduled. Fix that and re-run this script." >&2
+    exit 1
+  fi
+  carried+=("$key=$value")
+  echo "     $key = $value"
+done
+
+# Exit status is not proof the value landed. Read each one back off the target
+# profile and compare, so a `config set` that succeeds without writing — or
+# writes somewhere else — is caught here rather than at 03:00 on the first run.
+for entry in "${carried[@]}"; do
+  key="${entry%%=*}"
+  want="${entry#*=}"
+  got="$(hermes -p "$PROFILE" config get "$key" 2>/dev/null | head -1 || true)"
+  if [[ "$got" != "$want" ]]; then
+    echo "" >&2
+    echo "Profile '$PROFILE' did not keep $key." >&2
+    echo "  expected: $want" >&2
+    echo "  found:    ${got:-<unset>}" >&2
+    echo "Nothing has been scheduled." >&2
+    exit 1
+  fi
 done
 
 # A profile that cannot resolve a model is not runnable, and registering jobs

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/install.sh
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/install.sh
@@ -10,24 +10,40 @@
 # model to use, so the profile inherits that rather than the recipe asking the
 # reader to configure it twice.
 #
-# Only config.yaml is copied, never `.env`. Hermes keeps secrets in `.env` and
-# routes them there itself, so inference reaches the provider through the
-# runtime's own egress path and this profile never needs to hold a key.
-# Verified on Hermes 0.19.0 — copying config.yaml alone is enough for scheduled
-# jobs to run.
-#
-# What this cannot promise: `config.yaml` is the user's file, and two of its
-# documented keys hold secrets if someone has set them there — `api_key`, which
-# Hermes's own example offers as an alternative to `.env`, and `sudo_password`,
-# which it marks as plaintext. The copy is wholesale, so anything there travels
-# to the new profile. Read yours before running this if that matters to you.
+# No file is copied. The model settings are carried over key by key through
+# `hermes config set`, and no credential is: a profile with no `model.api_key`
+# of its own still authenticates, because Hermes resolves the credential from
+# the config it inherits. The installer stops before registering jobs if the
+# profile cannot resolve a model.
 
 set -euo pipefail
+
+# The scheduled path is Linux only. Every shipped skill declares
+# `platforms: [linux]`, and Hermes refuses to load a skill outside its declared
+# platforms — so on macOS the jobs fire, the model is called, and no skill
+# loads. Registering them there buys a scheduled expense and no assistant.
+# Refuse before anything is installed or registered rather than after.
+require_linux() {
+  local kernel
+  kernel="$(uname -s)"
+  if [[ "$kernel" != "Linux" ]]; then
+    echo "This installs a scheduled path that only works on Linux." >&2
+    echo "  detected: $kernel" >&2
+    echo "" >&2
+    echo "Every shipped skill declares 'platforms: [linux]'. On $kernel the" >&2
+    echo "jobs would fire and the model would be called with no skill loaded." >&2
+    echo "Windows Subsystem for Linux reports Linux and is supported." >&2
+    echo "" >&2
+    echo "The fixture path needs none of this and runs anywhere:" >&2
+    echo "  python3 profile/scripts/walkthrough.py --fixtures fixtures" >&2
+    exit 1
+  fi
+}
+require_linux
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RECIPE_ROOT="$(dirname "$HERE")"
 PROFILE="${PROFILE_NAME:-memory-driven-chief-of-staff}"
-SOURCE_PROFILE_CONFIG="${SOURCE_PROFILE_CONFIG:-$HOME/.hermes/config.yaml}"
 
 command -v hermes >/dev/null 2>&1 || {
   echo "hermes is not on PATH." >&2
@@ -47,14 +63,42 @@ if [[ -z "$PROFILE_HOME" ]]; then
   exit 1
 fi
 
-echo "2/3  Inheriting the runtime's model configuration"
-if [[ -f "$SOURCE_PROFILE_CONFIG" ]]; then
-  cp "$SOURCE_PROFILE_CONFIG" "$PROFILE_HOME/config.yaml"
-  echo "     copied from $SOURCE_PROFILE_CONFIG (no credential file is copied)"
-else
-  echo "     no config at $SOURCE_PROFILE_CONFIG — set a model with:" >&2
-  echo "       hermes -p $PROFILE config set model <name>" >&2
+echo "2/3  Carrying over the model settings"
+
+# Named settings through the CLI, never a copy of the file.
+#
+# Copying `config.yaml` wholesale duplicated a credential for no benefit. The
+# `model:` block is documented to hold an inline `api_key`, and a generated
+# config really does put one there — on the NemoClaw runtime this recipe was
+# checked against, `model:` carries `default`, `provider`, `base_url` and
+# `api_key` together. A wholesale copy writes that key into a second file.
+#
+# Carrying nothing but the three settings loses nothing: a profile whose own
+# `model.api_key` is unset still sends an authenticated request, because the
+# credential resolves from the config the profile inherits. Verified on Hermes
+# 0.19.0 by reading the request dump of a cron-driven turn — `model.api_key`
+# unset on the profile, `Authorization` present on the wire.
+for key in model.default model.provider model.base_url; do
+  value="$(hermes config get "$key" 2>/dev/null | head -1 || true)"
+  [[ -z "$value" || "$value" == *"not set"* ]] && continue
+  hermes -p "$PROFILE" config set "$key" "$value" >/dev/null 2>&1 \
+    && echo "     $key = $value"
+done
+
+# A profile that cannot resolve a model is not runnable, and registering jobs
+# on it schedules failures. Stop here instead, while nothing is scheduled yet.
+resolved="$(hermes -p "$PROFILE" config get model.default 2>/dev/null | head -1 || true)"
+if [[ -z "$resolved" || "$resolved" == *"not set"* ]]; then
+  echo "" >&2
+  echo "No model is set on profile '$PROFILE', so its jobs would fail." >&2
+  echo "Set one, then re-run this script:" >&2
+  echo "  hermes -p $PROFILE config set model.default <model>" >&2
+  exit 1
 fi
+
+echo "     credentials are not copied. Hermes keeps them in .env and auth.json,"
+echo "     and this profile needs its own. Check with:"
+echo "       hermes -p $PROFILE info"
 
 echo "3/3  Registering scheduled jobs"
 PROFILE_NAME="$PROFILE" bash "$HERE/register-jobs.sh"

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/install.sh
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/install.sh
@@ -11,10 +11,9 @@
 # reader to configure it twice.
 #
 # No file is copied. The model settings are carried over key by key through
-# `hermes config set`, and no credential is: a profile with no `model.api_key`
-# of its own still authenticates, because Hermes resolves the credential from
-# the config it inherits. The installer stops before registering jobs if the
-# profile cannot resolve a model.
+# `hermes config set`; the credential is not, because a credential is not a
+# thing to copy. It is also not inherited, so the target profile needs its own
+# and this script refuses to register jobs until it has one.
 
 set -euo pipefail
 
@@ -73,11 +72,8 @@ echo "2/3  Carrying over the model settings"
 # checked against, `model:` carries `default`, `provider`, `base_url` and
 # `api_key` together. A wholesale copy writes that key into a second file.
 #
-# Carrying nothing but the three settings loses nothing: a profile whose own
-# `model.api_key` is unset still sends an authenticated request, because the
-# credential resolves from the config the profile inherits. Verified on Hermes
-# 0.19.0 by reading the request dump of a cron-driven turn — `model.api_key`
-# unset on the profile, `Authorization` present on the wire.
+# What the three settings do not carry is a credential, and nothing else
+# supplies one either — see the check below.
 for key in model.default model.provider model.base_url; do
   value="$(hermes config get "$key" 2>/dev/null | head -1 || true)"
   [[ -z "$value" || "$value" == *"not set"* ]] && continue
@@ -96,9 +92,40 @@ if [[ -z "$resolved" || "$resolved" == *"not set"* ]]; then
   exit 1
 fi
 
-echo "     credentials are not copied. Hermes keeps them in .env and auth.json,"
-echo "     and this profile needs its own. Check with:"
-echo "       hermes -p $PROFILE info"
+# A model name is not enough to make a profile runnable. The credential is not
+# inherited: a profile carrying only the three settings above sends the literal
+# placeholder `no-key-required` in its Authorization header, not the key from
+# the config it was installed alongside. Measured on Hermes 0.20.0 by pointing
+# a scratch profile at a local endpoint and reading what arrived — the token was
+# 15 bytes of placeholder while the configured key was 26 bytes, and the two
+# hashes differ. Against a real endpoint that is a failed request per job, four
+# times an hour, discoverable only in the logs.
+#
+# So require the credential here, where a person is watching, rather than at
+# 03:00 on the first scheduled run. Endpoints that genuinely need no key are
+# real, so there is an opt-out, but it has to be asked for.
+credential="$(hermes -p "$PROFILE" config get model.api_key 2>/dev/null | head -1 || true)"
+if [[ -z "$credential" || "$credential" == *"not set"* ]]; then
+  if [[ "${ALLOW_NO_API_KEY:-0}" != "1" ]]; then
+    echo "" >&2
+    echo "Profile '$PROFILE' has no model credential of its own." >&2
+    echo "" >&2
+    echo "Credentials are deliberately not copied, and they are not inherited:" >&2
+    echo "a profile without one sends 'no-key-required' rather than the key" >&2
+    echo "belonging to the profile it was installed alongside. Every scheduled" >&2
+    echo "job would fail to authenticate." >&2
+    echo "" >&2
+    echo "Set one, then re-run this script:" >&2
+    echo "  hermes -p $PROFILE config set model.api_key <key>" >&2
+    echo "" >&2
+    echo "If your endpoint needs no key, say so explicitly:" >&2
+    echo "  ALLOW_NO_API_KEY=1 bash scripts/install.sh" >&2
+    exit 1
+  fi
+  echo "     no credential set; continuing because ALLOW_NO_API_KEY=1"
+else
+  echo "     model.api_key is set on this profile"
+fi
 
 echo "3/3  Registering scheduled jobs"
 PROFILE_NAME="$PROFILE" bash "$HERE/register-jobs.sh"

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/register-jobs.sh
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/register-jobs.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Register the scheduled jobs through the supported cron interface.
+#
+# The jobs are created here rather than shipped inside the distribution. That
+# is the supported path, and it has a second benefit: the distribution never
+# owns the cron directory, so a profile update cannot replace the live job
+# store along with its run history.
+#
+# Idempotent. Re-running updates the existing jobs in place rather than
+# creating duplicates.
+
+set -euo pipefail
+
+PROFILE="${PROFILE_NAME:-memory-driven-chief-of-staff}"
+
+# `|| true` matters: `hermes profile show` exits 1 for a profile that does not
+# exist, and under `set -e` the assignment would abort the script before the
+# check below could explain why.
+PROFILE_HOME="$(hermes profile show "$PROFILE" 2>/dev/null \
+  | sed -n 's/^Path:[[:space:]]*//p' || true)"
+if [[ -z "$PROFILE_HOME" ]]; then
+  echo "Could not resolve the profile home for '$PROFILE'." >&2
+  echo "Install the profile first: scripts/install.sh" >&2
+  exit 1
+fi
+
+# Look an existing job up by name.
+#
+# Writes go through the cron CLI, which is the supported interface. The lookup
+# does not, because no cron subcommand emits machine-readable output — `list`
+# prints a table for a person and takes no `--json`. Reading the store the
+# scheduler itself writes (`cron/jobs.py` keeps `{"jobs": [...]}` there) is
+# steadier than parsing that table, and it is a read.
+#
+# Without this the script cannot tell an existing job from a missing one, and
+# every run creates another copy of all five.
+job_id_for() {
+  local name="$1" store="$PROFILE_HOME/cron/jobs.json"
+  [[ -f "$store" ]] || return 0
+  python3 - "$store" "$name" <<'PYFIND'
+import json, sys
+try:
+    with open(sys.argv[1], encoding="utf-8") as handle:
+        data = json.load(handle)
+except (OSError, ValueError):
+    sys.exit(0)
+jobs = data.get("jobs", []) if isinstance(data, dict) else data
+for job in jobs if isinstance(jobs, list) else []:
+    if isinstance(job, dict) and job.get("name") == sys.argv[2]:
+        print(job.get("id", ""))
+        break
+PYFIND
+}
+
+# Every job runs as a selector script that emits JSON, then one agent turn over
+# that output. A selector that finds nothing emits a wake gate and the agent
+# turn is skipped entirely, so an idle tick costs no tokens.
+register() {
+  local name="$1" schedule="$2" skill="$3" script="${4:-}" prompt="$5"
+  local existing
+  existing="$(job_id_for "$name")"
+
+  local args=(--name "$name" --deliver local --skill "$skill")
+  [[ -n "$script" ]] && args+=(--script "$script")
+
+  if [[ -n "$existing" ]]; then
+    echo "  updating $name ($existing)"
+    hermes -p "$PROFILE" cron edit "$existing" --schedule "$schedule" --prompt "$prompt" "${args[@]}"
+  else
+    echo "  creating $name"
+    hermes -p "$PROFILE" cron create "$schedule" "$prompt" "${args[@]}"
+  fi
+}
+
+echo "Registering scheduled jobs on profile '$PROFILE'"
+
+register intake "*/30 * * * *" inbound-judging select_intake.py \
+  "Judge the messages in the script output, following the inbound-judging skill exactly. Then WRITE the result: save your decision envelope to a file and run \`python3 \$HERMES_HOME/scripts/apply_decisions.py < that file\`. Report the counts it prints. Printing the envelope without running the writer stores nothing and is a failed run."
+
+register review "0 */6 * * *" obligation-review select_review.py \
+  "Re-judge and re-rank the obligations in the script output, following the obligation-review skill exactly. Then WRITE the result: save your decision envelope to a file and run \`python3 \$HERMES_HOME/scripts/apply_decisions.py < that file\`. Report the counts it prints. Printing the envelope without running the writer stores nothing and is a failed run."
+
+register "memory repair" "0 3 * * *" memory-repair "" \
+  "Check the memory under workspace/memory against its schema and repair what can be repaired safely. Append one log entry even when nothing changed."
+
+register "memory consolidation" "0 4 * * *" memory-consolidation "" \
+  "Compact any memory page over the ceilings in the schema growth-control table. Compact, never truncate; preserve unresolved commitments and provenance."
+
+register "preference update" "30 4 * * *" preference-update "" \
+  "Read the audit trail for user corrections since the last run and update the bounded preference policy. Never write to obligations."
+
+echo
+echo "Jobs registered. They fire only while a gateway is serving this profile."
+hermes -p "$PROFILE" cron list 2>&1 || true
+echo
+echo "To undo, remove each job by the id shown above:"
+echo "  hermes -p $PROFILE cron remove <id>"
+echo
+echo "Deleting the profile removes the store and the memory with it:"
+echo "  hermes profile delete $PROFILE"

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/register-jobs.sh
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/register-jobs.sh
@@ -14,6 +14,29 @@
 
 set -euo pipefail
 
+# The scheduled path is Linux only. Every shipped skill declares
+# `platforms: [linux]`, and Hermes refuses to load a skill outside its declared
+# platforms — so on macOS the jobs fire, the model is called, and no skill
+# loads. Registering them there buys a scheduled expense and no assistant.
+# Refuse before anything is installed or registered rather than after.
+require_linux() {
+  local kernel
+  kernel="$(uname -s)"
+  if [[ "$kernel" != "Linux" ]]; then
+    echo "This installs a scheduled path that only works on Linux." >&2
+    echo "  detected: $kernel" >&2
+    echo "" >&2
+    echo "Every shipped skill declares 'platforms: [linux]'. On $kernel the" >&2
+    echo "jobs would fire and the model would be called with no skill loaded." >&2
+    echo "Windows Subsystem for Linux reports Linux and is supported." >&2
+    echo "" >&2
+    echo "The fixture path needs none of this and runs anywhere:" >&2
+    echo "  python3 profile/scripts/walkthrough.py --fixtures fixtures" >&2
+    exit 1
+  fi
+}
+require_linux
+
 PROFILE="${PROFILE_NAME:-memory-driven-chief-of-staff}"
 
 # `|| true` matters: `hermes profile show` exits 1 for a profile that does not


### PR DESCRIPTION
## Related Issue

Part of #122. This is the second of the three sequential phases agreed there; it does not close the issue.

## Description

Adds the installer, the scheduled jobs, and the two selector scripts that gate them. The store from #123 runs by hand; this makes it run on a schedule without paying for the ticks where there is nothing to do.

`scripts/install.sh` installs the distribution, transfers three named non-secret model settings through the Hermes CLI, verifies that they were applied, requires a credential on the target profile unless keyless operation is explicitly selected, and calls `scripts/register-jobs.sh`, which registers five jobs through the cron CLI: intake every thirty minutes, review every six hours, and three daily maintenance jobs.

The two message-facing jobs run a selector script first, then one agent turn over its output. When the selector finds nothing it prints `{"wakeAgent": false}` as its last line and Hermes skips the agent entirely — no model call, no delivery. That last-line detail is the whole mechanism, and the test asserts it the way `cron/scheduler.py` parses it rather than looking for the string anywhere in the output.

Nothing here reaches a network. The connectors remain Phase 3; the intake selector looks for them, reports each as `"absent": true`, and carries on.

## Defects found and fixed before this was pushed

Four of these were in the implementation this phase was ported from; one I introduced while writing it.

| Defect | Consequence had it shipped |
| --- | --- |
| `register-jobs.sh` looked jobs up with `hermes cron list --json` | That flag does not exist. argparse printed usage, `2>/dev/null` swallowed it, and the lookup returned empty every time — so a script whose header says "Idempotent" created another copy of all five jobs on every run |
| The wake-gate test asserted the gate appeared *somewhere* in stdout | Hermes reads only the last non-empty line. A gate printed before the payload would be ignored and every idle tick would wake the model, with the test still green |
| `awk '/^Path:/ {print $2}'` in both scripts | Truncated any profile path containing a space |
| The teardown line named `hermes profile remove` | No such subcommand; it is `delete`. Written by me, caught by checking the CLI |
| "Credentials are deliberately not copied" | The script copies the user's whole `config.yaml`, and two documented keys there — `api_key` and `sudo_password` — hold secrets if set. It copies `config.yaml` and never `.env` or `auth.json`; it cannot promise more |
| The scheduling section offered macOS as a supported platform | Every shipped skill declares `platforms: [linux]`. On macOS the jobs fire, the model is called, and no skill loads — a scheduled expense with no assistant. The scheduled path is now documented as Linux or WSL only |
| `gateway start` was given as the way to start the gateway | It exits 1 on Linux until `gateway install` has run, and on WSL without systemd. Both steps are documented now, with `gateway run` for the foreground case |
| `hermes -p <profile> model <name>` in the installer's remediation | `hermes model` takes no positional argument. It is `config set model <name>` |
| The friendly error in both scripts was unreachable | Under `set -euo pipefail`, `hermes profile show` exiting 1 aborted at the assignment. The script exited 1 silently instead of saying "Install the profile first" |
| `cron list \| head -20` above "remove one per job above" | `cron list` is 51 lines for five jobs, so three of the five ids were never shown |

The idempotency fix reads the job store the scheduler itself writes, because no cron subcommand emits machine-readable output. Writes still go through the CLI.

## Verification

- [x] `python3 scripts/check_license_headers.py --check` — `All 413 checked source files have SPDX headers.`
- [ ] `python3 scripts/check_label_taxonomy.py --check` — not applicable; this branch changes no governance metadata.
- [x] `git diff --check` — no output.
- [x] `bash -n` on both shell scripts — clean.
- [x] Relevant example checks:
  - `fail=0; for t in tests/*.py; do python3 "$t" || fail=1; done; echo "failed=$fail"` from `profile/scripts` — 223 tests, every file `OK`, `failed=0`. Discovery reports the same 223.
  - `HERMES_HOME=$(mktemp -d)` then `python3 profile/scripts/walkthrough.py --fixtures fixtures` — seven steps, exit 0.

**Runtime validation.** Installed into a scratch `HERMES_HOME` and exercised against a real Hermes 0.20.0:

A live scheduled turn through a reachable model was not independently reproduced during maintainer review. The selector output, decision-envelope application, and resulting store mutation are covered by the deterministic tests and fixture walkthrough.

- `hermes profile install ./profile --name p2test --force --yes` — installed.
- `register-jobs.sh` run twice — first run `creating` five, second run `updating` five, store holds five jobs, not ten.
- `hermes profile update p2test` — the five jobs and their history survive, which is what "the distribution does not own `cron`" means.
- `hermes cron status` — reports `Gateway is not running — cron jobs will NOT fire`, which is the README's "registering is not starting".

A hundred new tests cover: selector output and bounds, the gate under the scheduler's own parsing rule, the manifest never claiming `cron` or `workspace`, the registration script's lookup and write paths, the documented schedule matching the script's arguments, what survives a reboot, and every `hermes` command the scripts *and the README* name being real — four command groups, plus the flags-only case that `hermes model` is. The four review findings added their own: a collector that exits non-zero still waking the model, both scripts refusing a non-Linux kernel before anything is installed or registered, `INTAKE_SLICE` and `REVIEW_BATCH` rejecting values outside their range rather than passing a negative `LIMIT` through to SQLite, the installer carrying named settings and never a file or a credential, with its model check and its credential check both landing before job registration, the README naming no environment variable the script ignores, and the test count the README quotes being asserted against the suite rather than maintained by hand. The second round added behavioural coverage of the installer — `hermes` stubbed on `PATH`, asserting that a failed or non-sticking transfer aborts and schedules nothing while a clean one still reaches registration — and of the prompt boundary. The final round verifies that secret-shaped collector diagnostics reach neither the model prompt nor persistent scheduler logs; only sanitized failure metadata is retained.

## Documentation Writer Review

- [x] Documentation writer review completed for the final changes
- Result: `docs-updated`
- Reviewer: Xuan Wu (@rebelle5868), author review of the changed documentation. Maintainer review remains required before approval.
- Evidence or justification: the changed text was reviewed against `WRITING.md`, the controlled-word list, and CONTRIBUTING's twelve items, on Hermes 0.20.0 with an isolated `HERMES_HOME`. The review reproduced rather than read: the `wakeAgent` gate against `cron/scheduler.py::_parse_wake_gate` and both selectors under work-present and no-work conditions; registration idempotency across three runs, yielding the same five job ids; `hermes profile update` preserving all five jobs and `cron/executions.db`; the five-row job table against the live `cron/jobs.json`; the absent-connector path; and, on a NemoClaw runtime, that the installer transfers three named model settings and leaves the installed profile with zero occurrences of `api_key`. It returned `changes-required` with five blocking findings, all fixed here and listed in the table above, and twelve smaller ones, also fixed. Its most consequential finding was the platform gate: every shipped skill declares `platforms: [linux]`, and `skill_matches_platform_list(['linux'])` returns `False` on macOS, so a macOS reader following the scheduling section would have got a job that wakes the model every half-hour with no skill attached. The README now states that the scheduled path is Linux or WSL only, and says why. Changed documentation paths: `examples/recipes/nvidia/memory-driven-chief-of-staff/README.md`.
- [x] Changed user-facing text follows the writing guide and the controlled-word list.
- [x] A public contributor can understand the changed text without internal company context.
- [x] I reviewed any agent-generated text before submission.

## Release And Compliance

- [x] No secrets or credentials are included. The installer copies no file at all: it transfers three named model settings — `model.default`, `model.provider`, `model.base_url` — through `hermes config set`, so nothing it writes can carry a key. Checked on a NemoClaw runtime, where the generated `config.yaml` holds an inline `api_key` in the same `model:` block: the installed profile came out with zero occurrences of `api_key`. The credential is not inherited either — a profile without one sends the placeholder `no-key-required` — so the installer requires `model.api_key` on the target profile and exits before registering any job without it.
- [x] No nonpublic project names, environment names, hostnames, URLs, ticket identifiers, workspace paths, logs, screenshots, or configuration values are included.
- [x] Third-party dependency changes are reflected in `THIRD-PARTY-NOTICES` — none to reflect; every module imports from the standard library only.
- [x] Public content uses sanitized examples and placeholders instead of private values.
- [x] I added my DCO sign-off declaration to this pull request description.

Signed-off-by: Xuan Wu <xuwu@nvidia.com>





