### PR TITLE
docs: add README table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,17 @@
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue)](LICENSE)
 [![Security Policy](https://img.shields.io/badge/Security-Report%20a%20Vulnerability-red)](SECURITY.md)
 
+## Table of Contents
+
+- [Reference Examples](#reference-examples)
+- [Getting Started](#getting-started)
+- [Requirements](#requirements)
+- [Contributing](#contributing)
+- [Security](#security)
+- [Support](#support)
+- [Governance And Maintainers](#governance-and-maintainers)
+- [License](#license)
+
 NemoClaw Community is a collection of examples that showcase NemoClaw blueprints for constrained, inspectable agent workflows.
 
 NemoClaw is the blueprint layer for composing three things into a repeatable agent system:


### PR DESCRIPTION
## Related Issue

Not linked.

## Description

Add a table of contents as the first section of the root README so readers can navigate directly to the repository overview sections.

## Verification

- [x] `python3 scripts/check_license_headers.py --check` — passed (408 files)
- [x] `python3 scripts/check_label_taxonomy.py --check` — passed (64 labels)
- [x] `git diff --check origin/main...HEAD` — passed
- [x] Relevant example setup or syntax checks — not applicable; this is a root README-only change

## Documentation Writer Review

- [x] Documentation writer review completed for the final changes
- Result: `docs-updated`
- Evidence or justification: `README.md` contains the new table of contents and eight section links.
- Reviewer: Apurv Kumaria
- [x] Changed user-facing text follows the [writing guide](https://github.com/NVIDIA/nemoclaw-community/blob/main/WRITING.md) and [controlled-word list](https://github.com/NVIDIA/nemoclaw-community/blob/main/.agents/skills/_shared/controlled-words.md).
- [x] A public contributor can understand the changed text without internal company context.
- [x] I reviewed any agent-generated text before submission.

## Release And Compliance

- [x] No secrets or credentials are included, including API keys, access tokens, passwords, local `.env` files, private certificates, or token caches.
- [x] No nonpublic project names, environment names, hostnames, URLs, ticket identifiers, workspace paths, logs, screenshots, or configuration values are included.
- [x] Third-party dependency changes are reflected in `THIRD-PARTY-NOTICES` — not applicable; no third-party content changed.
- [x] Public content uses sanitized examples and placeholders instead of private values.
- [x] I added my DCO sign-off declaration to this pull request description.

Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>