### PR TITLE
docs(contributing): add an above-the-fold example README template

### DIFF
--- a/.agents/skills/nemoclaw-community-contributor-examples/SKILL.md
+++ b/.agents/skills/nemoclaw-community-contributor-examples/SKILL.md
@@ -16,19 +16,23 @@ changing an example's runtime or security boundaries accidentally.
 1. Read [references/example-taxonomy.md](references/example-taxonomy.md).
    For issue and pull request metadata, also read the canonical
    [maintainer taxonomy](../nemoclaw-community-maintainer-policies/references/label-taxonomy.md).
-2. Read the target example's README and nearby deployment documentation before
+2. Before drafting or reviewing a new top-level example README, follow the
+   canonical [Example README Template](../../../CONTRIBUTING.md#example-readme-template).
+   Treat it as the required information contract instead of copying the
+   template into this skill.
+3. Read the target example's README and nearby deployment documentation before
    classifying or naming it.
-3. Select the artifact type first. For recipes, select contributor provenance
+4. Select the artifact type first. For recipes, select contributor provenance
    second. Use an outcome-oriented leaf name.
-4. When moving or renaming an existing example, also read
+5. When moving or renaming an existing example, also read
    [references/restructure-checklist.md](references/restructure-checklist.md)
    and inventory every repository reference before editing.
-5. Preserve contributor attribution, deployment behavior, security policy,
+6. Preserve contributor attribution, deployment behavior, security policy,
    credential handling, teardown behavior, and Compose/Helm parity.
-6. Update the public catalog, repository links, contribution commands, notices,
+7. Update the public catalog, repository links, contribution commands, notices,
    submodule configuration, and external-document follow-ups in the same
    change.
-7. Run the smallest relevant example checks, then the repository-wide checks
+8. Run the smallest relevant example checks, then the repository-wide checks
    required by `CONTRIBUTING.md`.
 
 ## Boundaries
@@ -40,5 +44,12 @@ changing an example's runtime or security boundaries accidentally.
   agent authority as part of a catalog change.
 - Do not retain duplicate compatibility directories. Document path migrations
   and update callers.
+- Base README commands, results, compatibility, support, security, and
+  performance claims on repository evidence. Do not draft from an issue alone.
+- Keep public drafts sanitized. Do not include secrets, internal links, tenant
+  details, private paths, or nonpublic environment names. Use obvious
+  placeholders for private values.
+- Require a human contributor to review and correct coding-agent drafts before
+  submission.
 - Ask maintainers when ownership or artifact type remains ambiguous after
   inspecting the example.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -310,6 +310,20 @@ Remove secrets and nonpublic information, and use obvious placeholders for
 private values. A human contributor must review and correct the draft before
 submission.
 
+### Evidence Levels
+
+Choose the lowest level that fully matches the completed verification:
+
+- `live end-to-end`: The intended user workflow completed in the documented
+  target environment, including its required live services or hardware.
+- `integration`: Multiple connected components were exercised, but the full
+  intended workflow or target environment was not.
+- `local/static`: Verification was limited to local, unit, syntax,
+  configuration, documentation, or other non-live checks.
+
+Do not infer a higher evidence level from intended architecture, partial
+results, or unverified contributor claims.
+
 ### Copyable Template
 
 ````markdown
@@ -343,7 +357,7 @@ also preserve the essential expected output as searchable text.
 
 | Question | Answer |
 | --- | --- |
-| Category | [Choose one: NVIDIA Recipe, Partner Recipe, Community Recipe, NVIDIA Field Demo, Launchable, or Developer Tool] |
+| Category | [Choose one: NVIDIA Recipe, Partner Recipe, Community Recipe, Field Demo, Launchable, or Developer Tool] |
 | Contributor or provenance | [Name the person or organization responsible for the example.] |
 | Use this when | [Name the specific user, scenario, or operational need.] |
 | You will get | [Name the observable workflow, output, artifact, or result.] |
@@ -363,7 +377,8 @@ provenance.
 Use "verified on" only when completed evidence supports the exact environment.
 Do not substitute "supported on" unless there is an actual support commitment.
 Evidence level describes completed verification; it does not establish support
-or maturity.
+or maturity. Use the definitions in CONTRIBUTING.md and choose the lowest level
+that fully matches the completed verification.
 -->
 
 ## [Choose: Start Here, Quickstart, Or Setup]
@@ -403,7 +418,7 @@ remaining validation.]
 - Preserve partner and community attribution.
 - Distinguish `required`, `designed for`, `verified on`, and `supported`. These
   terms are not interchangeable.
-- State the evidence level for verification.
+- Use the lowest evidence level that fully matches the completed verification.
 - Include expected results as text even when a screenshot shows them.
 - Use obvious placeholders for credentials and private values.
 - Do not include secrets, internal links, tenant details, private paths, or

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -265,6 +265,10 @@ Before implementation, discuss the example's location, name, and provenance
 with the maintainers. Provenance identifies the example's origin, history,
 contributors, and contributor organizations.
 
+Use the canonical [example README template](#example-readme-template) for the
+top-level README. The template defines the required opening information. Keep
+the expanded sections appropriate for the example and its deployment paths.
+
 Document this information for a new example:
 
 - Its purpose, intended users, and support boundary.
@@ -281,6 +285,159 @@ Document this information for a new example:
 - Its third-party dependencies and license obligations.
 
 Add the example to the [example catalog](examples/README.md).
+
+## Example README Template
+
+Use this template as the required information contract for each new example.
+The opening gives a reader the information needed to decide whether to run or
+adapt the example. The expanded headings are flexible, but applicable
+credential, external-data, permission, cost, destructive-action, and security
+disclosures are required.
+
+### Before You Draft
+
+Before drafting, read this entire template, this contributor guide, the
+[writing guide](WRITING.md), the [support policy](SUPPORT.md), the
+[example taxonomy](.agents/skills/nemoclaw-community-contributor-examples/references/example-taxonomy.md),
+and the complete example directory. Inspect its implementation, scripts,
+configuration, tests, and existing documentation. Also read one strong README
+for a similar example type.
+
+Have your coding agent read the same sources. Ask it to draft from that
+evidence, not from an issue description alone. The agent must not invent
+commands, results, compatibility, support, security, or performance claims.
+Remove secrets and nonpublic information, and use obvious placeholders for
+private values. A human contributor must review and correct the draft before
+submission.
+
+### Copyable Template
+
+````markdown
+<!--
+Before drafting, read CONTRIBUTING.md, WRITING.md, the example taxonomy, and
+the complete example directory. Replace every placeholder and remove all
+authoring comments before submission.
+-->
+
+# [Replace with a recognizable example name]
+
+[For an intended user, this example performs a concrete job so they can obtain
+an observable result.]
+
+## Screenshot
+
+![Describe the visible workflow or result and its relevant context](path-to-current-sanitized-screenshot-or-gif)
+
+[Explain what the screenshot demonstrates and what the reader should notice.]
+
+<!--
+The screenshot or GIF must show the actual workflow, generated artifact, or
+observable result. A logo, branding banner, or architecture diagram alone does
+not satisfy this requirement.
+
+For a command-line example, show representative terminal-result evidence and
+also preserve the essential expected output as searchable text.
+-->
+
+## At A Glance
+
+| Question | Answer |
+| --- | --- |
+| Category | [Choose one: NVIDIA Recipe, Partner Recipe, Community Recipe, NVIDIA Field Demo, Launchable, or Developer Tool] |
+| Contributor or provenance | [Name the person or organization responsible for the example.] |
+| Use this when | [Name the specific user, scenario, or operational need.] |
+| You will get | [Name the observable workflow, output, artifact, or result.] |
+| Runs on | [Name the required host, platform, operating system, or hardware.] |
+| Requires | [List the software, services, credentials, and prerequisite state.] |
+| Verified on | [Give the exact environment and versions covered by completed evidence, or state "Not yet verified."] |
+| Evidence level | [Choose one: live end-to-end, integration, or local/static.] |
+| Support and maturity | [State the documented maturity and support boundary; otherwise state "Best-effort community support" and link to the repository support policy.] |
+| External access, data, and actions | [Name external destinations, data transmitted, write actions, costs, or state "None."] |
+| Start here | [Link to the recommended or lowest-risk start path.] |
+| Confirm success | [Link to verification instructions and expected results.] |
+
+<!--
+Use the canonical category exactly. Keep category separate from contributor
+provenance.
+
+Use "verified on" only when completed evidence supports the exact environment.
+Do not substitute "supported on" unless there is an actual support commitment.
+Evidence level describes completed verification; it does not establish support
+or maturity.
+-->
+
+## [Choose: Start Here, Quickstart, Or Setup]
+
+[Provide the shortest verified path to the first useful result, or link to the
+canonical deployment-specific instructions.]
+
+[When multiple paths exist, identify the recommended or lowest-risk path first,
+then link the alternatives.]
+
+## [Choose: Verification Or Confirm Success]
+
+**Evidence level:** [Choose: live end-to-end, integration, or local/static.]
+
+[Give the exact command or action used to verify the example.]
+
+**Expected result:**
+
+```text
+[Show the observable success result.]
+```
+
+**This verifies:** [State exactly what the check proves.]
+
+**This does not verify:** [State material boundaries, skipped live systems, or
+remaining validation.]
+````
+
+### Required Authoring Rules
+
+- Put material credential, data-sharing, permission, cost, write, or
+  destructive-action warnings before the command that triggers them.
+- Keep the example name recognizable. Put the audience, job, and result in the
+  sentence immediately below it.
+- Use the canonical category independently from contributor or organizational
+  provenance.
+- Preserve partner and community attribution.
+- Distinguish `required`, `designed for`, `verified on`, and `supported`. These
+  terms are not interchangeable.
+- State the evidence level for verification.
+- Include expected results as text even when a screenshot shows them.
+- Use obvious placeholders for credentials and private values.
+- Do not include secrets, internal links, tenant details, private paths, or
+  nonpublic environment names.
+- Do not use unqualified claims such as "secure," "safe," "production-ready,"
+  "easy," or "fast."
+- A logo, header graphic, or architecture diagram does not replace the required
+  result screenshot.
+- Quickstart and verification may link to deployment-specific guides instead of
+  duplicating them.
+- Remove unused placeholders, authoring comments, and optional sections before
+  submission.
+
+### Optional Expanded Sections
+
+Add these sections when they improve the example:
+
+- What this example does.
+- Architecture and major components.
+- Prerequisites and supported or verified environments.
+- Credentials and secret handling.
+- Security, data, permissions, network policy, and external side effects.
+- Setup and configuration.
+- Startup and operation.
+- Verification and expected results.
+- Teardown and cleanup.
+- Troubleshooting.
+- Known limitations.
+- Provenance, attribution, and support.
+- Third-party dependencies and license obligations.
+
+The headings are optional. Applicable credentials, external-data, permissions,
+cost, destructive-action, and security disclosures are not optional and must
+appear before the relevant action.
 
 ## Move or Rename an Example
 


### PR DESCRIPTION
## Related Issue

Closes #132

Related: #131

## Description

Adds one canonical, copyable example README template to `CONTRIBUTING.md` so a
developer can decide whether to run or adapt an example before reading lengthy
setup or architecture details.

The change:

- requires a recognizable name, an audience/job/result value sentence, and a
  current sanitized workflow or result image;
- adds a standard At-a-Glance decision block with canonical category,
  provenance, requirements, evidence, support, external-access, start, and
  verification fields;
- separates evidence-backed environments from support and maturity claims;
- requires expected results, the conclusion each check supports, and material
  validation limits;
- keeps expanded README sections flexible and allows deployment-specific setup
  and verification links;
- directs coding agents to inspect repository policy and the complete example
  before drafting, while preserving human review; and
- links the contributor-examples skill to the canonical template instead of
  duplicating it.

The added `Support and maturity` field is intentional. Related #131 requires a
support or maturity boundary, and verification evidence does not establish a
support commitment.

## Intent Verification

- **Audience:** Contributors and coding agents author the README; developers
  evaluating an example read it.
- **Decision enabled:** The opening answers who the example serves, what result
  it produces, whether it fits the reader's environment, what access or side
  effects it involves, and how to start and confirm success.
- **Differentiation:** The template is an information contract, not a prose
  mold. It standardizes the first decision screen and proof while leaving
  example-specific setup, architecture, and verification structures intact.
- **Claim discipline:** `required`, `verified on`, `evidence level`, and
  `support and maturity` remain separate. Unsupported fields must say what is
  unknown instead of inventing coverage.
- **Principal adoption barrier addressed:** The template explicitly rejects a
  logo or architecture diagram as a substitute for observable result evidence.

## Template Dry Run

These review-only walkthroughs apply the proposed opening to one recipe and one
non-recipe using existing repository evidence. Neither README is changed, and
these blocks are not additional maintained templates.

<details>
<summary><strong>NVIDIA Recipe: Kubernetes GPU Autoscaling</strong></summary>

### NemoClaw Kubernetes GPU Autoscaling

For Kubernetes operators with NVIDIA GPUs, this recipe runs an OpenClaw agent
in a CPU-only OpenShell sandbox and independently autoscales authenticated
GPU-backed Ollama inference so they can observe documented scale-up,
load distribution, and scale-down under GPU-utilization or latency load.

#### Screenshot

![HPA scaling to four GPU replicas when average per-pod latency exceeds 3000 ms](https://github.com/user-attachments/assets/c8cc50cd-455f-4348-9347-f45acc2e264b)

The live-validated result shows the Horizontal Pod Autoscaler increasing
Ollama capacity from one to four GPU replicas when the documented latency
threshold is exceeded.

#### At A Glance

| Question | Answer |
| --- | --- |
| Category | NVIDIA Recipe |
| Contributor or provenance | NVIDIA-authored or maintained, based on the canonical `recipes/nvidia/` classification |
| Use this when | You need a Kubernetes pattern that separates a CPU-only agent sandbox from independently autoscaled GPU inference. |
| You will get | An authenticated Ollama inference tier, Kubernetes HPA behavior, and documented end-to-end sandbox and load-test evidence. |
| Runs on | Kubernetes 1.25+ with allocatable NVIDIA GPUs; the documented live run used single-node MicroK8s on a Brev AWS instance with four NVIDIA L40S GPUs. |
| Requires | `kubectl`, Helm, NVIDIA GPU Operator and DCGM Exporter, Metrics Server, and the documented OpenShell image, registry, and identity prerequisites. |
| Verified on | Brev AWS, single-node MicroK8s (version not documented), four NVIDIA L40S 48 GB GPUs, and `llama3.2:3b`; the recipe pins NemoClaw `v0.0.104`, OpenShell `0.0.85`, and Agent Sandbox `v0.5.0`. |
| Evidence level | Live end-to-end, based on the existing documented run; not rerun by this documentation-only pull request. |
| Support and maturity | Experimental; [best-effort community support](https://github.com/NVIDIA/nemoclaw-community/blob/main/SUPPORT.md). The validated hardware is evidence, not a support limit. |
| External access, data, and actions | Installs or upgrades cluster components, pulls images and models, creates secrets and workloads, and consumes cluster and GPU resources. Review shared-cluster impact first. The default Ollama path uses local inference rather than a hosted inference API key. |
| Start here | [Quick start](https://github.com/NVIDIA/nemoclaw-community/blob/main/examples/recipes/nvidia/kubernetes-gpu-autoscaling/README.md#quick-start) |
| Confirm success | [Example test](https://github.com/NVIDIA/nemoclaw-community/blob/main/examples/recipes/nvidia/kubernetes-gpu-autoscaling/README.md#example-test) and [autoscaling/load-balancing test](https://github.com/NVIDIA/nemoclaw-community/blob/main/examples/recipes/nvidia/kubernetes-gpu-autoscaling/README.md#test-autoscaling-and-load-balancing) |

#### Confirm Success

**Evidence level:** Live end-to-end in the existing documented run.

```text
OK: sandbox nemoclaw-onprem reached https://inference.local for models and chat/completions (llama3.2:3b).
Envoy LeastRequest OK: <pod>:+<delta>, …
```

**This verifies:** The sandbox reached authenticated cluster-local inference,
and the load test distributed successful requests across multiple ready GPU
pods after scale-up.

**This does not verify:** Other Kubernetes distributions, an undocumented
MicroK8s version, other hardware or models, or production readiness.

</details>

<details>
<summary><strong>Field Demo: DGX Station Blender and Omniverse</strong></summary>

### NemoClaw Specialized Agents for Blender and Omniverse

For DGX Station operators, this field demo lets a sandboxed Hermes agent
control visible Blender, render with OVRTX, and run native OVPhysX so they can
produce host artifacts and native-simulation receipts.

#### Screenshot

![Native OVPhysX stair-drop replay with plastic spheres on wooden stairs](https://raw.githubusercontent.com/NVIDIA/nemoclaw-community/main/examples/demos/field/blender-omniverse-dgx-station/docs/assets/wooden-stairs-plastic-sphere-replay.gif)

The validated GIF shows the Blender replay of authoritative native OVPhysX
pose samples. The receipt below distinguishes native simulation from the
visual replay.

#### At A Glance

| Question | Answer |
| --- | --- |
| Category | Field Demo |
| Contributor or provenance | Originally contributed by Sean Lopp (`slopp`), with subsequent NemoClaw Community maintenance |
| Use this when | You need a documented DGX Station path for sandboxed Hermes control of visible Blender with native OVRTX and OVPhysX workflows. |
| You will get | Host-rendered artifacts plus bounded native-simulation and artifact receipts; Codex coordination is optional. |
| Runs on | NVIDIA DGX Station with Ubuntu 24.04 ARM64, a GB300 for local inference, and an RTX-capable GPU; validation used RTX PRO 6000 Blackwell. |
| Requires | At least 600 GiB free, `sudo` and Docker permission, NoMachine client and network access, Blender 5.1.x, the public OV add-on and runtime, local vLLM with Nemotron 3 Ultra, NemoClaw, Hermes, OpenShell, Docker with NVIDIA Container Toolkit, FFmpeg, and a Hugging Face read token. |
| Verified on | The [July 18, 2026 component matrix](https://github.com/NVIDIA/nemoclaw-community/blob/main/examples/demos/field/blender-omniverse-dgx-station/docs/setup-dgx-station-arm64.md#validated-component-matrix), including Ubuntu 24.04.4 LTS, Blender 5.1.0, OV add-on 0.1.0, vLLM 0.22.0, NemoHermes 0.0.83, Hermes Agent 0.18.0, and OpenShell 0.0.72. |
| Evidence level | Live end-to-end, based on the existing documented render, native simulation, and receipt evidence; not rerun by this documentation-only pull request. |
| Support and maturity | Field demo with [best-effort community support](https://github.com/NVIDIA/nemoclaw-community/blob/main/SUPPORT.md); validation is limited to the documented matrix and includes explicit temporary compatibility patches. |
| External access, data, and actions | Downloads public repositories, packages, release assets, and a gated Hugging Face model; installs host software; starts local services; controls and mutates the visible Blender scene; writes host artifacts; and uses substantial storage and GPU compute. No hosted LLM API key is required for the Hermes path. |
| Start here | [Read-only preflight](https://github.com/NVIDIA/nemoclaw-community/blob/main/examples/demos/field/blender-omniverse-dgx-station/docs/setup-dgx-station-arm64.md#0-run-the-read-only-preflight) |
| Confirm success | [Run the demo and validation](https://github.com/NVIDIA/nemoclaw-community/blob/main/examples/demos/field/blender-omniverse-dgx-station/docs/setup-dgx-station-arm64.md#11-run-the-demo) |

#### Confirm Success

**Evidence level:** Live end-to-end in the existing documented run.

```text
native_status: pass-real
physics_source: native-ovphysx-readback
render_class: blender-replay
sample_count: 25
```

**This verifies:** Native OVPhysX produced authoritative pose samples and
Blender rendered their visual replay with an explicit evidence receipt.

**This does not verify:** Other platforms or component versions, every prompt
in the evaluation suite, unsupported metadata-authoring capabilities, or a
general product support commitment.

</details>

## Verification

- [x] `python3 scripts/check_license_headers.py --check`
- [x] `python3 scripts/check_label_taxonomy.py --check`
- [x] `git diff --check`
- [x] New and changed local Markdown links resolve to repository files and headings.
- [x] GitHub's Markdown API renders the template and this pull request body with the expected headings, tables, image sources, links, and nested code fences.
- [ ] Relevant example setup or syntax checks — not run because no example implementation or README changed. The two live workflows require specialized hardware or external systems and are cited as existing evidence, not new verification.

## Documentation Writer Review

- [x] Documentation writer review completed for the final local changes
- Result: `docs-updated`
- Evidence or justification: `CONTRIBUTING.md` and `.agents/skills/nemoclaw-community-contributor-examples/SKILL.md`
- Reviewer: Codex documentation and intent review
- [x] Changed user-facing text follows the writing guide and controlled-word list.
- [x] A public contributor can understand the changed text without internal company context.
- [x] I reviewed any agent-generated text before submission.

## Release And Compliance

- [x] No secrets or credentials are included.
- [x] No nonpublic project names, environment names, hostnames, URLs, ticket identifiers, workspace paths, logs, screenshots, or configuration values are included.
- [x] No third-party dependencies changed; `THIRD-PARTY-NOTICES` does not require an update.
- [x] Public content uses sanitized examples and placeholders instead of private values.
- [x] I added my DCO sign-off declaration to this pull request description.

Signed-off-by: Will Curran <wcurran@nvidia.com>
