### PR TITLE
feat(examples): ship the data lifecycle controls for the memory-driven chief-of-staff

### DIFF
--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -369,10 +369,12 @@ provider takes over from the in-process ticker.
 **The job store is not part of the distribution.** `distribution.yaml` does not
 declare `cron`. An update replaces what it does declare — `SOUL.md`,
 `schema.md`, `skills`, `scripts` and the manifest — and leaves the jobs and
-their run history alone. Measured, not assumed: six jobs
-registered, `hermes profile update` run on Hermes 0.20.0, six jobs still
-there with the same ids. A test asserts
-the manifest never claims `cron` or `workspace`.
+their run history alone. This is worth being deliberate about: `profile
+update` lists `cron/` among the directories it overwrites, and it leaves ours
+alone only because the manifest never claims it. Measured, not assumed: six
+jobs registered, `hermes profile update` run on Hermes 0.19.0, six jobs still
+there with the same ids. A test asserts the manifest never claims `cron` or
+`workspace`.
 
 To undo, remove the jobs individually. Deleting the profile removes its
 `workspace` too, which is where the store and the memory live; removing the

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -240,7 +240,7 @@ cd ../..
 test "$fail" -eq 0
 ```
 
-Expected result: every file ends with `OK`, the ten files report 258 tests in
+Expected result: every file ends with `OK`, the ten files report 283 tests in
 total, and the last line is `failed=0`. Do not use `|| break` here; a `for`
 loop reports the status of its last command, so a failing test would still
 leave the loop exiting `0`.

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -240,7 +240,7 @@ cd ../..
 test "$fail" -eq 0
 ```
 
-Expected result: every file ends with `OK`, the ten files report 294 tests in
+Expected result: every file ends with `OK`, the ten files report 300 tests in
 total, and the last line is `failed=0`. Do not use `|| break` here; a `for`
 loop reports the status of its last command, so a failing test would still
 leave the loop exiting `0`.

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -80,7 +80,7 @@ those two apart.
 | `profile/scripts/memory_check.py` | Invariant detection over the memory, deterministic |
 | `profile/scripts/preferences.py` | Correction counting against a fixed threshold |
 | `profile/scripts/apply_decisions.py` | Applies model decisions; the model returns an envelope and never writes SQL |
-| `profile/scripts/migrate.py` | Schema versioning, forward-only. This recipe ships at v1, so there is nothing to upgrade from yet |
+| `profile/scripts/migrate.py` | Schema versioning, forward-only. At v2: adds `body_cleared_at` to a v1 store in place, without touching what it holds |
 | `profile/scripts/normalize.py` | Source payloads to store rows, kept separate from the network calls |
 | `profile/scripts/_db.py` | Connection and transaction boundary |
 | `profile/scripts/correct.py` | The user's writer: pins, ignores, and the only source of `actor='user'` events |
@@ -88,9 +88,13 @@ those two apart.
 | `profile/scripts/walkthrough.py` | The fixture walkthrough, end to end, with no credentials and no model |
 | `profile/scripts/select_intake.py` | The intake job's pre-step: what to judge, and whether to wake the model at all |
 | `profile/scripts/select_review.py` | The review job's pre-step: the stalest open obligations, oldest review first |
+| `profile/scripts/retention.py` | The retention job: clears message bodies past the window, keeps the record |
+| `profile/scripts/exclusions.py` | Senders, domains and channels that are never written, applied in `insert_items` |
+| `profile/scripts/export_store.py` | Writes the whole store and memory out as Markdown beside JSON |
+| `profile/scripts/reset.py` | Removes the store, the memory and the learned policy together |
 | `scripts/install.sh` | Installs the profile, inherits the runtime's model config, registers the jobs |
-| `scripts/register-jobs.sh` | Registers the five scheduled jobs through the cron CLI. Re-runnable |
-| `profile/skills/` | Five skills: judging, review, repair, consolidation, preference update |
+| `scripts/register-jobs.sh` | Registers the six scheduled jobs through the cron CLI. Re-runnable |
+| `profile/skills/` | Five skills: judging, review, repair, consolidation, preference update. Retention needs none — it clears bodies and never wakes the agent |
 | `fixtures/` | Eight synthetic messages, a seed memory, and one recorded model turn |
 
 A later phase adds the optional Microsoft Graph and Slack connectors. Until
@@ -236,7 +240,7 @@ cd ../..
 test "$fail" -eq 0
 ```
 
-Expected result: every file ends with `OK`, the nine files report 223 tests in
+Expected result: every file ends with `OK`, the ten files report 258 tests in
 total, and the last line is `failed=0`. Do not use `|| break` here; a `for`
 loop reports the status of its last command, so a failing test would still
 leave the loop exiting `0`.
@@ -309,19 +313,20 @@ profile afterwards, so a setting that could not be written — or that reports
 success without sticking — ends the run rather than leaving a profile that
 took some of its configuration. The installer then checks both — that a model
 resolves and that a credential is present — and exits before registering any
-job if either is missing, rather than scheduling five jobs that would each
+job if either is missing, rather than scheduling six jobs that would each
 fail. If your endpoint genuinely needs no key, pass `ALLOW_NO_API_KEY=1` to
 say so.
 
 Re-running it is safe: the registration looks each job up by name and edits it
 rather than adding another copy.
 
-Five jobs are registered:
+Six jobs are registered:
 
 | Job | Schedule | Pre-step | Skill |
 | --- | --- | --- | --- |
 | intake | every 30 minutes | `select_intake.py` | `inbound-judging` |
 | review | every 6 hours | `select_review.py` | `obligation-review` |
+| retention | daily 02:00 | `retention.py` | — |
 | memory repair | daily 03:00 | — | `memory-repair` |
 | memory consolidation | daily 04:00 | — | `memory-consolidation` |
 | preference update | daily 04:30 | — | `preference-update` |
@@ -364,8 +369,8 @@ provider takes over from the in-process ticker.
 **The job store is not part of the distribution.** `distribution.yaml` does not
 declare `cron`. An update replaces what it does declare — `SOUL.md`,
 `schema.md`, `skills`, `scripts` and the manifest — and leaves the jobs and
-their run history alone. Measured, not assumed: five jobs
-registered, `hermes profile update` run on Hermes 0.20.0, five jobs still
+their run history alone. Measured, not assumed: six jobs
+registered, `hermes profile update` run on Hermes 0.20.0, six jobs still
 there with the same ids. A test asserts
 the manifest never claims `cron` or `workspace`.
 
@@ -408,14 +413,40 @@ value — `direct`, `mentioned`, or `broadcast` — so the store never holds a
 copy of who else was on a thread. `normalize.py` does this today, and
 `tests/test_normalize.py` asserts it.
 
-The rest of the handling below is not implemented yet. It describes what the
-optional connectors will do, and is stated here because it shapes the schema.
+Four controls over what is kept ship alongside it, before any connector
+exists to fill the store. They work
+on the fixture corpus today, which is how they are tested, and they apply
+unchanged to real messages when a connector lands. The commands, the rules
+file and the exact boundaries are in
+[docs/data-lifecycle.md](docs/data-lifecycle.md); what follows is why they are
+drawn where they are.
 
-Once a connector is attached:
+**Message bodies are cleared on a schedule.** `retention.py` runs daily and
+clears the text of anything past the window — thirty days by default,
+`RETENTION_DAYS` to change it. What stays is the record: sender, subject,
+timestamp, addressing, the obligation and its title, and every event with its
+actor. A month later you can still see that Dana asked about the cutover on the
+third, that it ranked high, and that you ignored it on the fifth. You cannot
+re-read Dana's words, which is the point. `body_cleared_at` marks a body that
+was cleared, so it is not confused with one that never existed.
+
+**Senders, domains and channels can be excluded at ingest.** Rules live in
+`workspace/exclusions.json` and are applied in `insert_items`, which is the one
+place every writer passes through — so an excluded message is never written,
+by any collector, including ones added later. Filtering at display would leave
+the text on disk, which is no use to somebody excluding their doctor.
+
+**Everything can be exported and everything can be removed.**
+`export_store.py` writes the store and the memory as Markdown beside JSON —
+the first to read, the second to process — and omits nothing.
+`reset.py --yes` removes the store, the memory and the learned preference
+policy together, and reports each; a partial reset would answer the question
+wrongly. It also prints how to revoke the credential, which lives with the
+gateway rather than here, because somebody withdrawing consent wants both.
+
+Three things remain for the connectors themselves:
 
 - Attachments will not be fetched.
-- Message bodies will be cleared on a schedule. Metadata and the audit trail
-  will be kept, so history stays inspectable without content sitting on disk.
 - For Microsoft Graph, an item deleted at the source will be tombstoned locally
   and its body cleared at once, because the delta query reports deletions
   explicitly.
@@ -426,10 +457,9 @@ Once a connector is attached:
   Real Time Messaging (RTM) API carries the event too, but Slack states that
   granular-permission apps cannot use it and that classic apps can no longer be
   created, so it is not an option a connector could take today. Slack content
-  will therefore age out on the scheduled body-clearing pass rather than at the
-  moment of deletion.
-- Senders, domains, and channels will be excludable at ingest, before anything
-  is written.
+  therefore ages out on the scheduled body-clearing pass rather than at the
+  moment of deletion — the weaker guarantee, kept, rather than the stronger one
+  implied.
 
 ## Fixtures
 
@@ -560,7 +590,7 @@ Three separate questions, with three different answers.
 **Do the jobs survive?** Yes. They live in `$HERMES_HOME/cron/jobs.json`, which
 is ordinary disk state — not part of the distribution, so a profile update
 leaves it alone, and not tied to any process, so shutting everything down and
-starting again finds the same five jobs with the same ids.
+starting again finds the same six jobs with the same ids.
 
 **Do they start firing again on their own?** Only if the gateway was installed
 as a service. `hermes -p <profile> gateway install` registers one — a launchd

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -240,7 +240,7 @@ cd ../..
 test "$fail" -eq 0
 ```
 
-Expected result: every file ends with `OK`, the ten files report 283 tests in
+Expected result: every file ends with `OK`, the ten files report 294 tests in
 total, and the last line is `failed=0`. Do not use `|| break` here; a `for`
 loop reports the status of its last command, so a failing test would still
 leave the loop exiting `0`.

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/docs/data-lifecycle.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/docs/data-lifecycle.md
@@ -1,0 +1,154 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# What is kept, and how to be rid of it
+
+Four controls, all of them local, none of them requiring a connector. They
+work on the fixture corpus today, which is how they are tested, and they apply
+unchanged to real messages when a connector lands. That order is deliberate:
+the controls ship before the thing that would need them.
+
+Every command below runs from `profile/scripts/`, against the store belonging
+to the profile named by `HERMES_HOME`.
+
+## Bodies age out; the record does not
+
+`retention.py` runs daily at 02:00 and clears the text of anything past the
+window. Thirty days by default:
+
+```bash
+python3 retention.py --dry-run   # what would go, nothing changes
+python3 retention.py             # clear it
+RETENTION_DAYS=7 python3 retention.py
+```
+
+Set `RETENTION_DAYS` in the job's environment to change the schedule's window
+rather than a single run's. Values below 1 or above 3650 are refused: a zero
+would clear the message that arrived a minute ago, and a negative one would
+put the cutoff in the future and clear everything ever stored. Both are the
+kind of mistake found only afterwards.
+
+What a cleared row keeps:
+
+| Kept | Gone |
+| --- | --- |
+| sender, subject, timestamp, addressing, state | the message body |
+| the obligation and the title the judging turn wrote | |
+| every event, with its actor and its before and after | |
+
+So a month later you can still see that Dana asked about the cutover on the
+third, that it ranked high because the memory said you had chosen that work,
+and that you ignored it on the fifth. You cannot re-read Dana's words. That is
+the intended line, not a limitation of the implementation.
+
+`subject` stays with the metadata. On email it is often the only
+human-readable handle a row has, it is what the obligation title came from,
+and it is short enough that keeping it is not keeping the message.
+
+`body_cleared_at` records that a body was cleared. Without it a message
+somebody wrote and a join notice that never had a body are the same row —
+`body IS NULL` — and only one of them is a loss.
+
+## Some things are never written at all
+
+Rules live in `$HERMES_HOME/workspace/exclusions.json`:
+
+```json
+{
+  "senders":  ["recruiter@agency.example", "U01RECRUIT"],
+  "domains":  ["agency.example"],
+  "channels": ["C0SALARY01", "D0PRIVATE1"]
+}
+```
+
+A sender matches `sender` — a display name or an address, depending on the
+source — and also the raw id when the collector knows one, so a Slack user can
+be excluded by `U…` rather than by a name they can change. A domain matches
+the part after `@`. A channel matches `scope`, which is the mail folder or the
+Slack channel id.
+
+Matching is case-insensitive and exact. There are no globs: a pattern language
+here is a way to exclude more than intended by accident, and the failure is
+silent — nothing arrives, and nothing says why.
+
+The rules are applied in `insert_items`, the one function every writer passes
+through, rather than in any collector. So an excluded message is never written
+by the fixture loader, by the Slack collector when it lands, or by anything
+added later, without each of them having to remember — and a new writer cannot
+quietly opt out. Filtering at display would leave the text on disk, which is
+no use to somebody excluding their doctor.
+
+A dropped message is reported on stderr as a count, never as content:
+
+```
+exclusions: 2 message(s) not stored
+```
+
+A malformed `exclusions.json` yields no rules rather than an error. The
+direction is deliberate: a typo must not silently halt collection, and the
+consequence — a message arriving that the user meant to exclude — is visible
+to them, where a stalled pipeline would not be.
+
+## Take a copy
+
+```bash
+python3 export_store.py              # to ./export-<date>/
+python3 export_store.py --to ~/out
+```
+
+Writes `store.md` and `store.json` side by side — the first to read, the
+second to process — and copies the memory and the learned preference policy
+whole. Nothing is summarised and nothing is omitted; an export that quietly
+left something out would answer the question wrongly.
+
+A body cleared by the retention pass appears as `text cleared <timestamp>`
+rather than as an empty line, so the export distinguishes the same two cases
+the schema does.
+
+## Be rid of all of it
+
+```bash
+python3 reset.py --dry-run
+python3 reset.py --yes
+```
+
+Removes the store, the memory, the learned policy and the collection
+bookkeeping, and reports each. It refuses without `--yes`, and if any part
+cannot be removed it says so and exits non-zero — a reset that half worked
+must not read as one that worked. The policy goes with the rest because it
+encodes what its subject ignores, which is about them.
+
+The credential is not removed, because it was never held here: it lives with
+the OpenShell gateway. `reset.py` prints the commands to revoke it, since
+somebody withdrawing consent wants both and would otherwise stop after the one
+that felt complete.
+
+## Where the guarantee is weaker
+
+For Microsoft Graph, an item deleted at the source is tombstoned locally and
+its body cleared at once, because the delta query reports deletions
+explicitly.
+
+Slack offers no such notice. A deleted message stops appearing in
+`conversations.history`, and its absence from a bounded, paginated read cannot
+be told apart from it lying outside the window. Reliable notice needs the
+Events API, which this design does not use; the legacy RTM API carries the
+event too, but Slack states that granular-permission apps cannot use it and
+that classic apps can no longer be created. So Slack content ages out on the
+scheduled pass rather than at the moment of deletion. That is the weaker
+guarantee, stated rather than implied.
+
+## Upgrading a store that predates this
+
+`body_cleared_at` arrived with schema v2. An existing v1 store is brought
+forward in place:
+
+```bash
+python3 migrate.py
+```
+
+The column is added if it is absent and the version is recorded; running it
+twice does nothing the second time. `schema-v1.sql` is kept beside
+`schema.sql` as the frozen text of what actually shipped, so the migration is
+tested against the real prior state rather than against the current schema
+with a column removed.

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/docs/data-lifecycle.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/docs/data-lifecycle.md
@@ -98,10 +98,21 @@ A dropped message is reported on stderr as a count, never as content:
 exclusions: 2 message(s) not stored
 ```
 
-A malformed `exclusions.json` yields no rules rather than an error. The
-direction is deliberate: a typo must not silently halt collection, and the
-consequence — a message arriving that the user meant to exclude — is visible
-to them, where a stalled pipeline would not be.
+A malformed `exclusions.json` stops the insert. Nothing is written until it
+is fixed, and the error names the file, the line and the column.
+
+That is the opposite of what an earlier version did, and the reasoning is
+worth stating because the other direction is tempting. Failing open keeps
+collection running through a typo, at the cost of writing exactly what the
+file was created to keep out — and the user learns about it from the row on
+disk. A stalled pipeline is loud and recoverable; a silent breach of the one
+guarantee this file provides is neither.
+
+Fail-closed means strict about shape as well as syntax. An unknown key is
+rejected rather than ignored: `{"sender": [...]}` parses cleanly, matches
+nothing, and reads as a working rule. A non-string entry is rejected rather
+than coerced, for the same reason — `123` would become the rule `"123"` and
+match nothing.
 
 ## Take a copy
 
@@ -112,7 +123,19 @@ python3 export_store.py --to ~/out
 
 Writes `store.md` and `store.json` side by side — the first to read, the
 second to process — and copies the memory and the learned preference policy
-whole. Nothing is summarised and nothing is omitted; an export that quietly
+whole.
+
+Each export is a snapshot rather than an accumulation. The whole thing is
+built beside the destination and moved into place at the end, so a previous
+export cannot leave a deleted page behind in the next one — which the
+date-based default directory makes likely, since the same path is reused all
+day — and a failure part-way leaves no directory at all rather than one that
+looks complete.
+
+Nothing outside the workspace is read. A symbolic link under `memory/` that
+points elsewhere on the machine stops the export rather than pulling that file
+into something the user is about to hand to somebody. Nothing is summarised
+and nothing is omitted; an export that quietly
 left something out would answer the question wrongly.
 
 A body cleared by the retention pass appears as `text cleared <timestamp>`
@@ -158,8 +181,14 @@ guarantee, stated rather than implied.
 forward in place:
 
 ```bash
-python3 migrate.py
+python3 migrate.py            # bring the store to the current schema
+python3 migrate.py --check    # report the version, change nothing
 ```
+
+You rarely need either. Migration happens on its own: `ensure_store()` is the
+only way anything opens the store, and every executable here goes through it,
+so the first job to run after an upgrade migrates it. The command exists for
+doing it deliberately, before a scheduled job does it unattended.
 
 The column is added if it is absent and the version is recorded; running it
 twice does nothing the second time. `schema-v1.sql` is kept beside

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/docs/data-lifecycle.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/docs/data-lifecycle.md
@@ -22,8 +22,22 @@ python3 retention.py             # clear it
 RETENTION_DAYS=7 python3 retention.py
 ```
 
-Set `RETENTION_DAYS` in the job's environment to change the schedule's window
-rather than a single run's. Values below 1 or above 3650 are refused: a zero
+Those two change the run in front of you. To change every run after it, put
+the value in the profile's environment file — `hermes config env-path` prints
+where it is, `$HERMES_HOME/.env`:
+
+```bash
+ENV=$(hermes -p <profile> config env-path)
+echo 'RETENTION_DAYS=7' >> "$ENV"
+```
+
+That file is the supported path and the only one that persists. `hermes cron
+create` and `cron edit` take no environment argument, so a variable exported
+in a shell reaches the manual invocation and nothing scheduled. A value set
+there and never checked is the failure worth naming: the window looks changed
+and the nightly pass keeps using thirty days.
+
+Values below 1 or above 3650 are refused: a zero
 would clear the message that arrived a minute ago, and a negative one would
 put the cutoff in the future and clear everything ever stored. Both are the
 kind of mistake found only afterwards.

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/_db.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/_db.py
@@ -123,11 +123,37 @@ def ensure_store(schema_sql: Path | None = None) -> Path:
         # still ship would have it silently recreated, so "refused before any
         # write" has to mean before the DDL too.
         refuse_if_from_the_future(conn)
+        # What the store said before the baseline DDL runs. The DDL carries
+        # `INSERT OR IGNORE INTO meta ... ('schema_version', '<current>')`, so
+        # on a store whose version row is absent it stamps the current version
+        # over a database that has none of the current columns. `migrate` then
+        # sees a version equal to its own and does nothing, and the store is
+        # left claiming a shape it does not have — which surfaces later as a
+        # missing column in a job nobody was watching. Remember the real answer
+        # first and put it back afterwards.
+        recorded = conn.execute(
+            "SELECT value FROM meta WHERE key='schema_version'").fetchone() \
+            if conn.execute("SELECT name FROM sqlite_master WHERE type='table'"
+                            " AND name='meta'").fetchone() else None
+
         # Creating tables is idempotent, so this is safe on an existing store;
         # it is what brings a brand new one up to the baseline. executescript
         # commits implicitly, so it runs before the transaction rather than
         # inside one.
+        had_tables = conn.execute(
+            "SELECT count(*) FROM sqlite_master WHERE type='table'"
+            " AND name='items'").fetchone()[0]
         conn.executescript(schema_sql.read_text(encoding="utf-8"))
+
+        # An existing store keeps whatever version it actually had; only a
+        # genuinely new one is allowed to start at the baseline. A pre-existing
+        # store with no version row is version 0 by definition — unversioned —
+        # and must be migrated forward rather than declared current.
+        if had_tables:
+            conn.execute(
+                "INSERT INTO meta(key, value) VALUES ('schema_version', ?)"
+                " ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+                (recorded[0] if recorded else "0",))
         conn.execute("BEGIN IMMEDIATE")
         try:
             migrate(conn)

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/exclusions.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/exclusions.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Keep chosen senders, domains and channels out of the store entirely.
+
+Not hidden at display: never written. A rule that filters what is shown leaves
+the text on disk, which is no use to somebody excluding their doctor, a
+recruiter, or a channel where colleagues discuss their own pay. The only
+exclusion worth the name happens before the row exists.
+
+That is why this is applied in `insert_items` rather than in a collector. Every
+writer goes through that one function — the fixture loader today, the Slack
+collector when it lands, whatever arrives after — so the property holds for all
+of them without any of them having to remember it, and a new writer cannot
+quietly opt out.
+
+Rules live in `workspace/exclusions.json`:
+
+    {
+      "senders":  ["recruiter@agency.example", "U01RECRUIT"],
+      "domains":  ["agency.example"],
+      "channels": ["C0SALARY01", "D0PRIVATE1"]
+    }
+
+A sender matches on the value stored in `sender`, which is a display name or an
+address depending on the source, and on the raw id when the collector knows it.
+A domain matches the part after `@`. A channel matches `scope`, which is the
+mail folder or the Slack channel id.
+
+Matching is case-insensitive and exact — no globs. A pattern language here
+would be a way to exclude more than intended by accident, and the failure is
+silent: nothing arrives, and nothing says why.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+RULES_FILE = "exclusions.json"
+
+
+def rules_path():
+    from _db import ledger_path
+    return ledger_path().parent.parent / RULES_FILE
+
+
+def load_rules() -> dict[str, set[str]]:
+    """Read the rules, or none at all.
+
+    An unreadable file yields no rules rather than an error. That is the
+    deliberate direction: a typo in this file must not stop the intake, and the
+    consequence — a message arriving that the user meant to exclude — is
+    visible to them, where a stalled pipeline would not be.
+    """
+    empty: dict[str, set[str]] = {"senders": set(), "domains": set(),
+                                  "channels": set()}
+    path = rules_path()
+    if not path.exists():
+        return empty
+    try:
+        declared = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return empty
+    if not isinstance(declared, dict):
+        return empty
+    return {
+        key: {str(v).strip().lower() for v in declared.get(key, [])
+              if str(v).strip()}
+        for key in empty
+    }
+
+
+def excluded(item: dict[str, Any], rules: dict[str, set[str]]) -> bool:
+    """Does this row match a rule?"""
+    if not any(rules.values()):
+        return False
+
+    scope = str(item.get("scope") or "").strip().lower()
+    if scope and scope in rules["channels"]:
+        return True
+
+    sender = str(item.get("sender") or "").strip().lower()
+    if sender and sender in rules["senders"]:
+        return True
+
+    # `sender_id` is set by a collector that knows the source's own identifier,
+    # so a Slack user can be excluded by `U…` rather than by a display name
+    # they can change.
+    sender_id = str(item.get("sender_id") or "").strip().lower()
+    if sender_id and sender_id in rules["senders"]:
+        return True
+
+    if sender and "@" in sender:
+        domain = sender.rsplit("@", 1)[-1]
+        if domain in rules["domains"]:
+            return True
+
+    return False
+
+
+def partition(items: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], int]:
+    """Split the batch into what may be stored and a count of what may not."""
+    rules = load_rules()
+    if not any(rules.values()):
+        return items, 0
+    keep = [item for item in items if not excluded(item, rules)]
+    return keep, len(items) - len(keep)

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/exclusions.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/exclusions.py
@@ -30,6 +30,14 @@ mail folder or the Slack channel id.
 Matching is case-insensitive and exact — no globs. A pattern language here
 would be a way to exclude more than intended by accident, and the failure is
 silent: nothing arrives, and nothing says why.
+
+A file that cannot be read stops collection. An earlier version treated an
+unreadable file as no rules at all, on the reasoning that a typo should not
+halt the intake — but the guarantee this module exists to provide is that
+excluded content is never written, and failing open converts a typo into a
+silent breach of exactly that. The user finds out when the thing they
+excluded is already on disk. Stopping is loud, recoverable, and honest about
+which of the two failures happened.
 """
 
 from __future__ import annotations
@@ -45,13 +53,18 @@ def rules_path():
     return ledger_path().parent.parent / RULES_FILE
 
 
-def load_rules() -> dict[str, set[str]]:
-    """Read the rules, or none at all.
+class ExclusionsUnreadable(Exception):
+    """The rules exist but cannot be honoured, so nothing may be written."""
 
-    An unreadable file yields no rules rather than an error. That is the
-    deliberate direction: a typo in this file must not stop the intake, and the
-    consequence — a message arriving that the user meant to exclude — is
-    visible to them, where a stalled pipeline would not be.
+
+def load_rules() -> dict[str, set[str]]:
+    """Read the rules, or refuse to proceed without them.
+
+    Absent is not the same as broken. No file means no rules, which is the
+    ordinary state of a fresh install and must stay free. A file that is
+    present but malformed is a different thing: the user wrote it in order to
+    keep something out, and continuing without it writes exactly what they
+    were trying to prevent.
     """
     empty: dict[str, set[str]] = {"senders": set(), "domains": set(),
                                   "channels": set()}
@@ -59,11 +72,29 @@ def load_rules() -> dict[str, set[str]]:
     if not path.exists():
         return empty
     try:
-        declared = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return empty
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ExclusionsUnreadable(
+            f"{path} exists but could not be read ({exc.strerror or exc}). "
+            "Nothing has been stored. Fix the file or remove it.") from exc
+    try:
+        declared = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ExclusionsUnreadable(
+            f"{path} is not valid JSON (line {exc.lineno}, column "
+            f"{exc.colno}: {exc.msg}). Nothing has been stored, because the "
+            "rules that say what to keep out cannot be read.") from exc
     if not isinstance(declared, dict):
-        return empty
+        raise ExclusionsUnreadable(
+            f"{path} must hold a JSON object with `senders`, `domains` and "
+            f"`channels` keys; found {type(declared).__name__}. Nothing has "
+            "been stored.")
+    for key in empty:
+        value = declared.get(key, [])
+        if not isinstance(value, (list, tuple)):
+            raise ExclusionsUnreadable(
+                f"{path}: `{key}` must be a list of strings, not "
+                f"{type(value).__name__}. Nothing has been stored.")
     return {
         key: {str(v).strip().lower() for v in declared.get(key, [])
               if str(v).strip()}
@@ -87,14 +118,26 @@ def excluded(item: dict[str, Any], rules: dict[str, set[str]]) -> bool:
     # `sender_id` is set by a collector that knows the source's own identifier,
     # so a Slack user can be excluded by `U…` rather than by a display name
     # they can change.
+    # `sender_id` and `sender_address` are set by the normalizers and dropped
+    # before the insert. They exist because `sender` holds a display name
+    # whenever the source supplies one — a Slack user the person can rename,
+    # a mail sender whose address never appears in the row. Matching only on
+    # `sender` meant a domain rule matched nothing at all on real mail, and a
+    # `U…` rule matched nothing on real Slack. Both were documented as
+    # working.
     sender_id = str(item.get("sender_id") or "").strip().lower()
     if sender_id and sender_id in rules["senders"]:
         return True
 
-    if sender and "@" in sender:
-        domain = sender.rsplit("@", 1)[-1]
-        if domain in rules["domains"]:
-            return True
+    address = str(item.get("sender_address") or "").strip().lower()
+    if address and address in rules["senders"]:
+        return True
+
+    for candidate in (address, sender):
+        if candidate and "@" in candidate:
+            domain = candidate.rsplit("@", 1)[-1]
+            if domain in rules["domains"]:
+                return True
 
     return False
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/exclusions.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/exclusions.py
@@ -89,15 +89,35 @@ def load_rules() -> dict[str, set[str]]:
             f"{path} must hold a JSON object with `senders`, `domains` and "
             f"`channels` keys; found {type(declared).__name__}. Nothing has "
             "been stored.")
+    # An unknown key is a typo, and a typo here is the failure this whole
+    # module is trying to prevent: `{"sender": [...]}` parsed cleanly, matched
+    # nothing, and let through exactly what the user wrote it to keep out.
+    # Silence is the worst possible response to it.
+    unknown = sorted(set(declared) - set(empty))
+    if unknown:
+        raise ExclusionsUnreadable(
+            f"{path}: unknown key(s) {', '.join(unknown)}. Expected "
+            f"{', '.join(sorted(empty))}. Nothing has been stored — a "
+            "misspelled key would silently exclude nothing.")
+
     for key in empty:
         value = declared.get(key, [])
         if not isinstance(value, (list, tuple)):
             raise ExclusionsUnreadable(
                 f"{path}: `{key}` must be a list of strings, not "
                 f"{type(value).__name__}. Nothing has been stored.")
+        # `str()` on a non-string used to make `123` into the rule `"123"`,
+        # which matches nothing and reads as a working rule. A number here is
+        # a mistake, not a value to coerce.
+        for member in value:
+            if not isinstance(member, str):
+                raise ExclusionsUnreadable(
+                    f"{path}: `{key}` contains {member!r} "
+                    f"({type(member).__name__}); every entry must be a "
+                    "string. Nothing has been stored.")
+
     return {
-        key: {str(v).strip().lower() for v in declared.get(key, [])
-              if str(v).strip()}
+        key: {v.strip().lower() for v in declared.get(key, []) if v.strip()}
         for key in empty
     }
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/export_store.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/export_store.py
@@ -36,6 +36,7 @@ import json
 import os
 import shutil
 import sqlite3
+import tempfile
 import sys
 from datetime import date
 from pathlib import Path
@@ -128,13 +129,56 @@ def as_markdown(data: dict[str, list[dict]]) -> str:
     return "\n".join(out) + "\n"
 
 
+def _copy_inside_workspace(source: Path, target: Path, workspace: Path) -> int:
+    """Copy a tree, refusing anything that leaves the workspace.
+
+    `copytree` follows symbolic links by default — it copies what the link
+    points at, not the link — so a link under `memory/` pulls a file from
+    anywhere on the machine into an export the user is about to hand to
+    somebody. Every entry is resolved and checked against the workspace before
+    it is read.
+    """
+    copied = 0
+    for entry in sorted(source.rglob("*")):
+        if entry.name.startswith("._") or entry.name == ".DS_Store":
+            continue
+        resolved = entry.resolve()
+        try:
+            resolved.relative_to(workspace.resolve())
+        except ValueError:
+            raise ExportEscapesWorkspace(
+                f"{entry} points outside the workspace, at {resolved}. "
+                "Nothing has been exported. Remove the link or copy the file "
+                "in.")
+        relative = entry.relative_to(source)
+        if entry.is_dir() and not entry.is_symlink():
+            (target / relative).mkdir(parents=True, exist_ok=True)
+        elif entry.is_file():
+            (target / relative).parent.mkdir(parents=True, exist_ok=True)
+            _write_private(target / relative,
+                           entry.read_text(encoding="utf-8", errors="replace"))
+            copied += 1
+    return copied
+
+
+class ExportEscapesWorkspace(Exception):
+    """A source resolved outside the workspace, so nothing is written."""
+
+
 def export(destination: Path) -> dict[str, object]:
     ensure_store()
-    destination.mkdir(parents=True, exist_ok=True)
-    # The store is deliberately owner-only. An export that widens that is a
-    # copy of the same content readable by every account on the machine, which
-    # is a quieter version of not having protected it at all.
-    os.chmod(destination, 0o700)
+
+    # Build the whole thing beside the destination and rename on success.
+    #
+    # Writing in place left a previous export's files behind: a memory page
+    # deleted since yesterday survived into today's export, and the default
+    # destination is date-based so the same directory is reused all day. A
+    # partial write also looked complete. A fresh directory renamed at the end
+    # gives an export that is either whole or absent.
+    destination = destination.resolve()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(prefix=".export-", dir=destination.parent))
+    os.chmod(staging, 0o700)
 
     data: dict[str, list[dict]] = {}
     with sqlite3.connect(ledger_path()) as conn:
@@ -144,28 +188,31 @@ def export(destination: Path) -> dict[str, object]:
             # command exists to avoid. Let it raise.
             data[table] = rows(conn, table)
 
-    _write_private(destination / "store.json",
-                   json.dumps(data, indent=2, ensure_ascii=False))
-    _write_private(destination / "store.md", as_markdown(data))
+    workspace = ledger_path().parent.parent
+    try:
+        _write_private(staging / "store.json",
+                       json.dumps(data, indent=2, ensure_ascii=False))
+        _write_private(staging / "store.md", as_markdown(data))
 
-    memory_src = ledger_path().parent.parent / "memory"
-    copied = 0
-    if memory_src.is_dir():
-        memory_dst = destination / "memory"
-        if memory_dst.exists():
-            shutil.rmtree(memory_dst)
-        shutil.copytree(memory_src, memory_dst,
-                        ignore=shutil.ignore_patterns("._*", ".DS_Store"))
-        copied = sum(1 for _ in memory_dst.rglob("*.md"))
+        copied = 0
+        memory_src = workspace / "memory"
+        if memory_src.is_dir():
+            _copy_inside_workspace(memory_src, staging / "memory", workspace)
+            copied = sum(1 for _ in (staging / "memory").rglob("*.md"))
 
-    policy_src = ledger_path().parent.parent / "policy"
-    if policy_src.is_dir():
-        shutil.copytree(policy_src, destination / "policy", dirs_exist_ok=True)
+        policy_src = workspace / "policy"
+        if policy_src.is_dir():
+            _copy_inside_workspace(policy_src, staging / "policy", workspace)
 
-    # copytree carries the source's modes, and a wiki page written by an
-    # agent turn has ordinary ones. Narrow the whole tree rather than trusting
-    # what it arrived with.
-    _narrow(destination)
+        _narrow(staging)
+    except BaseException:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+
+    # Replace whatever was there. An export is a snapshot, not an accumulation.
+    if destination.exists():
+        shutil.rmtree(destination)
+    os.replace(staging, destination)
 
     return {
         "to": str(destination),

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/export_store.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/export_store.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Write out everything this recipe holds, in a form a person can read.
+
+Somebody who wants to know what an assistant has kept about them should not
+have to open a database to find out, and somebody leaving should be able to
+take it with them. So this writes the whole store and the whole memory as
+Markdown and JSON side by side: the Markdown to be read, the JSON to be
+processed.
+
+Nothing is summarised or omitted. An export that quietly left something out
+would be worse than none, because it would answer the question wrongly.
+
+    python3 export_store.py                 # to ./export-<date>/
+    python3 export_store.py --to <dir>
+
+Pairs with `reset.py`, which removes what this shows. The two are documented
+together because somebody withdrawing consent usually wants both: see what is
+held, then have it gone.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sqlite3
+import sys
+from datetime import date
+from pathlib import Path
+
+from _db import ensure_store, ledger_path
+
+TABLES = ("items", "obligations", "events", "cursors", "meta")
+
+
+def rows(conn: sqlite3.Connection, table: str) -> list[dict]:
+    conn.row_factory = sqlite3.Row
+    return [dict(r) for r in conn.execute(f"SELECT * FROM {table}")]
+
+
+def as_markdown(data: dict[str, list[dict]]) -> str:
+    """The same content, laid out to be read rather than parsed."""
+    out: list[str] = ["# What this assistant is holding", ""]
+    out.append(f"Exported {date.today().isoformat()}.")
+    out.append("")
+
+    obligations = data.get("obligations", [])
+    out.append(f"## Obligations ({len(obligations)})")
+    out.append("")
+    if not obligations:
+        out.append("None.")
+    for row in sorted(obligations, key=lambda r: r.get("global_rank") or 0):
+        rank = row.get("global_rank")
+        out.append(f"- **{row.get('title') or '(untitled)'}**")
+        out.append(f"  - rank {rank}, {row.get('priority')}, "
+                   f"{row.get('status')}")
+        out.append(f"  - from `{row.get('source_id')}`")
+    out.append("")
+
+    items = data.get("items", [])
+    held = sum(1 for r in items if r.get("body"))
+    cleared = sum(1 for r in items if r.get("body_cleared_at"))
+    out.append(f"## Messages ({len(items)})")
+    out.append("")
+    out.append(f"{held} still hold their text. {cleared} have had it cleared "
+               "by the retention pass; the rest never carried any.")
+    out.append("")
+    for row in sorted(items, key=lambda r: r.get("event_at") or ""):
+        out.append(f"- `{row.get('event_at')}` **{row.get('sender') or '?'}** "
+                   f"— {row.get('subject') or '(no subject)'}")
+        if row.get("body"):
+            body = " ".join(str(row["body"]).split())
+            out.append(f"  - {body[:300]}")
+        elif row.get("body_cleared_at"):
+            out.append(f"  - text cleared {row['body_cleared_at']}")
+    out.append("")
+
+    events = data.get("events", [])
+    out.append(f"## What happened, and who did it ({len(events)})")
+    out.append("")
+    if not events:
+        out.append("Nothing yet.")
+    for row in sorted(events, key=lambda r: r.get("ts") or ""):
+        out.append(f"- `{row.get('ts')}` {row.get('event_type')} "
+                   f"by {row.get('actor')} on `{row.get('obligation_id')}`")
+    out.append("")
+    return "\n".join(out) + "\n"
+
+
+def export(destination: Path) -> dict[str, object]:
+    ensure_store()
+    destination.mkdir(parents=True, exist_ok=True)
+
+    data: dict[str, list[dict]] = {}
+    with sqlite3.connect(ledger_path()) as conn:
+        for table in TABLES:
+            try:
+                data[table] = rows(conn, table)
+            except sqlite3.Error:
+                data[table] = []
+
+    (destination / "store.json").write_text(
+        json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+    (destination / "store.md").write_text(as_markdown(data), encoding="utf-8")
+
+    memory_src = ledger_path().parent.parent / "memory"
+    copied = 0
+    if memory_src.is_dir():
+        memory_dst = destination / "memory"
+        if memory_dst.exists():
+            shutil.rmtree(memory_dst)
+        shutil.copytree(memory_src, memory_dst,
+                        ignore=shutil.ignore_patterns("._*", ".DS_Store"))
+        copied = sum(1 for _ in memory_dst.rglob("*.md"))
+
+    policy_src = ledger_path().parent.parent / "policy"
+    if policy_src.is_dir():
+        shutil.copytree(policy_src, destination / "policy", dirs_exist_ok=True)
+
+    return {
+        "to": str(destination),
+        "obligations": len(data.get("obligations", [])),
+        "messages": len(data.get("items", [])),
+        "events": len(data.get("events", [])),
+        "memory_pages": copied,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--to", type=Path,
+                        default=Path(f"export-{date.today().isoformat()}"),
+                        help="directory to write into")
+    args = parser.parse_args(argv)
+    try:
+        print(json.dumps(export(args.to)))
+    except OSError as exc:
+        print(f"could not write the export: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/export_store.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/export_store.py
@@ -24,6 +24,12 @@ owner-only permissions as the store they came from.
     python3 export_store.py                 # to ./export-<date>/
     python3 export_store.py --to <dir>
 
+The destination must be somewhere else. This replaces whatever is there, so
+exporting into the workspace would delete the store and leave a copy of it in
+place — the destination and the workspace have to be disjoint, and a
+destination that is either of them, inside the other, or around it is refused
+before anything is created or removed.
+
 Pairs with `reset.py`, which removes what this shows. The two are documented
 together because somebody withdrawing consent usually wants both: see what is
 held, then have it gone.
@@ -165,6 +171,46 @@ class ExportEscapesWorkspace(Exception):
     """A source resolved outside the workspace, so nothing is written."""
 
 
+class ExportOverlapsWorkspace(Exception):
+    """The destination and the live workspace are not disjoint."""
+
+
+def _refuse_overlap(destination: Path, workspace: Path) -> None:
+    """The destination must not be the workspace, inside it, or around it.
+
+    This export replaces its destination, which is what makes it a snapshot
+    rather than an accumulation — and what makes an overlapping destination
+    destructive. Exporting into the workspace deleted the live store and left
+    the two export files in its place, reported as success.
+
+    Checked on resolved paths, before the staging directory is created and
+    before anything is removed, so a refusal costs nothing.
+    """
+    destination = destination.resolve()
+    workspace = workspace.resolve()
+
+    if destination == workspace:
+        raise ExportOverlapsWorkspace(
+            f"{destination} is the workspace itself. Exporting there would "
+            "replace the store with a copy of it. Nothing has been written.")
+    try:
+        destination.relative_to(workspace)
+    except ValueError:
+        pass
+    else:
+        raise ExportOverlapsWorkspace(
+            f"{destination} is inside the workspace at {workspace}. The "
+            "export replaces its destination, and the store lives here. "
+            "Nothing has been written.")
+    try:
+        workspace.relative_to(destination)
+    except ValueError:
+        return
+    raise ExportOverlapsWorkspace(
+        f"{destination} contains the workspace at {workspace}. Replacing it "
+        "would remove the store. Nothing has been written.")
+
+
 def export(destination: Path) -> dict[str, object]:
     ensure_store()
 
@@ -176,6 +222,7 @@ def export(destination: Path) -> dict[str, object]:
     # partial write also looked complete. A fresh directory renamed at the end
     # gives an export that is either whole or absent.
     destination = destination.resolve()
+    _refuse_overlap(destination, ledger_path().parent.parent)
     destination.parent.mkdir(parents=True, exist_ok=True)
     staging = Path(tempfile.mkdtemp(prefix=".export-", dir=destination.parent))
     os.chmod(staging, 0o700)
@@ -231,6 +278,12 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     try:
         print(json.dumps(export(args.to)))
+    except ExportOverlapsWorkspace as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    except ExportEscapesWorkspace as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
     except OSError as exc:
         print(f"could not write the export: {exc}", file=sys.stderr)
         return 1

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/export_store.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/export_store.py
@@ -9,8 +9,17 @@ take it with them. So this writes the whole store and the whole memory as
 Markdown and JSON side by side: the Markdown to be read, the JSON to be
 processed.
 
-Nothing is summarised or omitted. An export that quietly left something out
-would be worse than none, because it would answer the question wrongly.
+`store.json` is the complete record: every column of every row, nothing
+summarised and nothing dropped. `store.md` is the same content laid out to be
+read, and it is explicit about the one thing it does differently — a long body
+is shown to a bounded length with the remainder marked, because a Markdown
+file with a hundred-kilobyte message in it stops being readable, which was the
+only reason to write it. When the two disagree, the JSON is the answer.
+
+An export that quietly left something out would be worse than none, because it
+would answer the question wrongly. So a table that cannot be read is a failed
+export rather than an empty section, and both files are written with the same
+owner-only permissions as the store they came from.
 
     python3 export_store.py                 # to ./export-<date>/
     python3 export_store.py --to <dir>
@@ -24,6 +33,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import shutil
 import sqlite3
 import sys
@@ -33,6 +43,30 @@ from pathlib import Path
 from _db import ensure_store, ledger_path
 
 TABLES = ("items", "obligations", "events", "cursors", "meta")
+
+
+# How much of a body `store.md` shows before marking the remainder. The JSON
+# holds all of it; this bound exists so the readable form stays readable.
+BODY_PREVIEW = 2000
+
+
+def _write_private(path: Path, text: str) -> None:
+    """Write owner-only, and be owner-only from the first byte.
+
+    Creating the file and then chmod-ing it leaves a window in which the
+    content is world-readable, which on a shared machine is the whole risk.
+    """
+    handle = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(handle, "w", encoding="utf-8") as fh:
+        fh.write(text)
+    os.chmod(path, 0o600)
+
+
+def _narrow(root: Path) -> None:
+    """Owner-only, everywhere under the export."""
+    os.chmod(root, 0o700)
+    for path in root.rglob("*"):
+        os.chmod(path, 0o700 if path.is_dir() else 0o600)
 
 
 def rows(conn: sqlite3.Connection, table: str) -> list[dict]:
@@ -72,7 +106,12 @@ def as_markdown(data: dict[str, list[dict]]) -> str:
                    f"— {row.get('subject') or '(no subject)'}")
         if row.get("body"):
             body = " ".join(str(row["body"]).split())
-            out.append(f"  - {body[:300]}")
+            if len(body) > BODY_PREVIEW:
+                out.append(f"  - {body[:BODY_PREVIEW]}")
+                out.append(f"  - _(body continues; {len(body) - BODY_PREVIEW} "
+                           "more characters in `store.json`)_")
+            else:
+                out.append(f"  - {body}")
         elif row.get("body_cleared_at"):
             out.append(f"  - text cleared {row['body_cleared_at']}")
     out.append("")
@@ -92,18 +131,22 @@ def as_markdown(data: dict[str, list[dict]]) -> str:
 def export(destination: Path) -> dict[str, object]:
     ensure_store()
     destination.mkdir(parents=True, exist_ok=True)
+    # The store is deliberately owner-only. An export that widens that is a
+    # copy of the same content readable by every account on the machine, which
+    # is a quieter version of not having protected it at all.
+    os.chmod(destination, 0o700)
 
     data: dict[str, list[dict]] = {}
     with sqlite3.connect(ledger_path()) as conn:
         for table in TABLES:
-            try:
-                data[table] = rows(conn, table)
-            except sqlite3.Error:
-                data[table] = []
+            # An unreadable table used to become an empty one, which produces
+            # an export that looks complete and is not — the failure mode this
+            # command exists to avoid. Let it raise.
+            data[table] = rows(conn, table)
 
-    (destination / "store.json").write_text(
-        json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
-    (destination / "store.md").write_text(as_markdown(data), encoding="utf-8")
+    _write_private(destination / "store.json",
+                   json.dumps(data, indent=2, ensure_ascii=False))
+    _write_private(destination / "store.md", as_markdown(data))
 
     memory_src = ledger_path().parent.parent / "memory"
     copied = 0
@@ -118,6 +161,11 @@ def export(destination: Path) -> dict[str, object]:
     policy_src = ledger_path().parent.parent / "policy"
     if policy_src.is_dir():
         shutil.copytree(policy_src, destination / "policy", dirs_exist_ok=True)
+
+    # copytree carries the source's modes, and a wiki page written by an
+    # agent turn has ordinary ones. Narrow the whole tree rather than trusting
+    # what it arrived with.
+    _narrow(destination)
 
     return {
         "to": str(destination),

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/migrate.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/migrate.py
@@ -20,18 +20,38 @@ import sqlite3
 from pathlib import Path
 from typing import Callable
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 # version -> callable applied to reach it. Forward only; there is no down path,
 # because a downgrade that drops a column loses data no backup can infer.
 #
-# Empty, and correctly so: this recipe has not shipped, so no store exists at
-# an earlier version and there is nothing to upgrade from. The machinery stays
-# because the properties it provides are the ones that matter on day one — a
-# store carries its version, a versionless store is brought up, and a store
-# from a later version is refused rather than opened. The first shipped change
-# to the schema adds an entry here and bumps the constant.
-MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {}
+def _add_body_cleared_at(conn: sqlite3.Connection) -> None:
+    """v2: record when the retention pass cleared a body.
+
+    Without it, a cleared message and one that never carried text are the same
+    row — both have `body IS NULL` — and the first is something a person wrote
+    while the second is a join notice. Retention has to be able to tell them
+    apart to report what it did, and a reader has to be able to tell that the
+    absence is deliberate.
+
+    Added rather than backfilled: a store upgrading to v2 has had no retention
+    pass, so every existing row is correctly NULL here.
+
+    Idempotent, because it has to be. A versionless store is one the baseline
+    DDL already built at the current shape — the column is there and only the
+    `meta` row is missing — and bringing it up must not fail on a column it
+    can see. Checking is cheaper than parsing the error text SQLite returns.
+    """
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(items)")}
+    if "body_cleared_at" not in columns:
+        conn.execute("ALTER TABLE items ADD COLUMN body_cleared_at TEXT")
+
+
+# version -> callable applied to reach it. Forward only; there is no down path,
+# because a downgrade that drops a column loses data no backup can infer.
+MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
+    2: _add_body_cleared_at,
+}
 
 
 class SchemaFromTheFuture(RuntimeError):

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/migrate.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/migrate.py
@@ -16,6 +16,8 @@ migrations themselves:
 
 from __future__ import annotations
 
+import contextlib
+import json
 import sqlite3
 from pathlib import Path
 from typing import Callable
@@ -102,6 +104,43 @@ def migrate(conn: sqlite3.Connection) -> list[int]:
     return applied
 
 
+def main(argv: list[str] | None = None) -> int:
+    """Bring the store at `$HERMES_HOME` to the current schema.
+
+    `docs/data-lifecycle.md` told people to run this file and it had no entry
+    point, so `python3 migrate.py` did nothing at all and left a v1 store at
+    v1 — an instruction that reported success by saying nothing. Migration
+    does happen on its own through `ensure_store()`, which every executable
+    goes through; this exists so the documented command is real, and so
+    somebody can do it deliberately before a job does it for them.
+    """
+    import argparse
+
+    from _db import ensure_store, ledger_path
+
+    parser = argparse.ArgumentParser(description=main.__doc__.splitlines()[0])
+    parser.add_argument("--check", action="store_true",
+                        help="report the version and change nothing")
+    args = parser.parse_args(argv)
+
+    if args.check:
+        path = ledger_path()
+        if not path.exists():
+            print(json.dumps({"store": str(path), "exists": False}))
+            return 0
+        with contextlib.closing(sqlite3.connect(path)) as conn:
+            print(json.dumps({"store": str(path), "exists": True,
+                              "schema_version": current_version(conn),
+                              "code_understands": SCHEMA_VERSION}))
+        return 0
+
+    path = ensure_store()
+    with contextlib.closing(sqlite3.connect(path)) as conn:
+        version = current_version(conn)
+    print(json.dumps({"store": str(path), "schema_version": version}))
+    return 0
+
+
 def open_store(path: Path) -> sqlite3.Connection:
     """Open a store and bring it to the current schema."""
     conn = sqlite3.connect(path, isolation_level=None)
@@ -119,3 +158,7 @@ def open_store(path: Path) -> sqlite3.Connection:
         conn.close()
         raise
     return conn
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/normalize.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/normalize.py
@@ -24,6 +24,11 @@ is where that translation is pinned down:
 
 from __future__ import annotations
 
+import sys
+
+import exclusions
+
+
 import re
 from datetime import datetime, timezone
 from typing import Any
@@ -138,7 +143,21 @@ ITEM_COLUMNS = (
 
 
 def insert_items(conn, items) -> int:
-    """Idempotent on source_id, so re-reading a source window is harmless."""
+    """Idempotent on source_id, so re-reading a source window is harmless.
+
+    Exclusion is applied here, and only here. Every writer goes through this
+    function, so a sender or channel the user excluded never reaches the store
+    no matter which collector found it — including collectors written later,
+    which cannot forget a rule they never had to know about.
+
+    Filtering at display would leave the text on disk, which is no use to
+    somebody excluding their doctor or a channel where pay is discussed.
+    """
+    items, dropped = exclusions.partition(list(items))
+    if dropped:
+        # Said out loud, on stderr, because a silent drop and an empty mailbox
+        # look identical from the outside.
+        print(f"exclusions: {dropped} message(s) not stored", file=sys.stderr)
     placeholders = ",".join("?" * len(ITEM_COLUMNS))
     rows = [tuple(item.get(c) for c in ITEM_COLUMNS) for item in items]
     before = conn.execute("SELECT count(*) FROM items").fetchone()[0]

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/normalize.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/normalize.py
@@ -87,6 +87,12 @@ def graph_message_to_item(msg: dict[str, Any], user_address: str) -> dict[str, A
         "thread_ref": msg.get("conversationId"),
         "event_at": _iso(msg.get("receivedDateTime", "")),
         "sender": _display_of(msg.get("from")),
+        # Carried for the exclusion rules and dropped before the insert: it is
+        # not in ITEM_COLUMNS, so it is matched on and never stored. `sender`
+        # holds the display name when there is one, which means a domain rule
+        # has nothing to match without this — the address is exactly what the
+        # user wrote the rule against.
+        "sender_address": _address_of(msg.get("from")),
         "subject": msg.get("subject"),
         "body": body.get("content"),
         "permalink": msg.get("webLink"),
@@ -127,6 +133,10 @@ def slack_message_to_item(
         "thread_ref": msg.get("thread_ts") or ts,
         "event_at": _slack_ts_to_iso(ts),
         "sender": sender_name or msg.get("user"),
+        # Same reason as the Graph address above. The collector resolves the
+        # Slack user to a display name, which the person can change at will;
+        # without the raw id a `U…` rule matches nothing.
+        "sender_id": msg.get("user"),
         "subject": None,
         "body": msg.get("text"),
         "permalink": msg.get("permalink"),
@@ -152,6 +162,11 @@ def insert_items(conn, items) -> int:
 
     Filtering at display would leave the text on disk, which is no use to
     somebody excluding their doctor or a channel where pay is discussed.
+
+    A malformed rules file stops the insert rather than proceeding without it.
+    The guarantee is that excluded content is never written; continuing past a
+    file the user wrote in order to keep something out would breach exactly
+    that, silently, and they would find out from the row on disk.
     """
     items, dropped = exclusions.partition(list(items))
     if dropped:

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/reset.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/reset.py
@@ -32,17 +32,37 @@ from pathlib import Path
 from _db import ledger_path
 
 
+# Everything a collector or a lifecycle control leaves in the workspace.
+#
+# Named individually rather than by glob: a reset that removed whatever it
+# found would eventually remove something a future feature meant to keep, and
+# the failure would be silent and unrecoverable. A new file here is a
+# deliberate line, and the test below fails when the workspace grows one that
+# nobody listed.
+COLLECTION_STATE = (
+    "slack_capabilities.json",   # probed scopes, keyed on the credential
+    "slack_channels.json",       # the public channels the user named
+    "slack_threads.json",        # per-thread watermarks
+    "slack_rotation.json",       # where the next bounded tick starts
+    "graph_identity.json",       # the mailbox the token belongs to
+    "exclusions.json",           # who the user chose to keep out
+)
+
+
 def targets() -> dict[str, Path]:
     workspace = ledger_path().parent.parent
-    return {
+    found = {
         "store": ledger_path().parent,
         "memory": workspace / "memory",
         "policy": workspace / "policy",
-        # Collection bookkeeping. Not personal in itself, but it names channels
-        # and threads, and leaving it behind would have the next run re-read
-        # windows the user just cleared.
-        "collection_state": workspace / "slack_capabilities.json",
     }
+    # Collection bookkeeping. Not personal in the way a message is, but it
+    # names channels, threads and correspondents, and leaving it behind has
+    # the next run re-read windows the user just cleared — which is the one
+    # outcome a reset must not produce.
+    for name in COLLECTION_STATE:
+        found[name] = workspace / name
+    return found
 
 
 def survey() -> dict[str, object]:
@@ -105,13 +125,29 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     print("", file=sys.stderr)
-    print("The store, the memory and the policy are gone. The Slack "
-          "credential is not — it is held by the gateway, not by this "
-          "recipe. To revoke it as well:", file=sys.stderr)
-    print("  uninstall the app from your Slack workspace, then", file=sys.stderr)
-    print("  openshell sandbox provider detach <sandbox> <provider>",
+    print("The store, the memory, the policy and the collection state are "
+          "gone. The credential is not — it is held by the gateway, not by "
+          "this recipe.", file=sys.stderr)
+    print("", file=sys.stderr)
+    # Order matters, and getting it wrong undoes the reset within half an
+    # hour: a scheduled collector that is still running against a credential
+    # that is still attached will refill the store from the source before
+    # anybody notices. Stop the schedule first, detach second, delete last.
+    print("Do these in order, or the next scheduled tick refills what you "
+          "just removed:", file=sys.stderr)
+    print("  1. stop collecting   hermes -p <profile> cron pause <intake job "
+          "id>", file=sys.stderr)
+    print("                       or remove the job entirely with `cron "
+          "remove`", file=sys.stderr)
+    print("  2. detach            openshell sandbox provider detach <sandbox> "
+          "<provider>", file=sys.stderr)
+    print("  3. revoke            uninstall the app from the source workspace",
           file=sys.stderr)
-    print("  openshell provider delete <provider>", file=sys.stderr)
+    print("  4. delete            openshell provider delete <provider>",
+          file=sys.stderr)
+    print("", file=sys.stderr)
+    print("Deleting the profile removes its workspace with it, which is the "
+          "one-step version: hermes profile delete <profile>", file=sys.stderr)
     return 0
 
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/reset.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/reset.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Remove everything this recipe has kept. All of it.
+
+A partial reset is the worst outcome here: somebody who asked for their data to
+be gone, and was told it was, while the memory still describes them and the
+preference policy still encodes what they ignore. So this removes three things
+together and reports each — the store, the memory, and the learned policy — and
+refuses rather than leaving a subset behind.
+
+What it does not touch is the credential. That is held by the OpenShell
+gateway, never by this recipe, and removing it is a separate command against a
+separate system. Both are printed at the end, because somebody withdrawing
+consent wants both and would otherwise stop after the one that felt complete.
+
+    python3 reset.py --dry-run      # list what would go
+    python3 reset.py --yes          # remove it
+
+Export first if you want a copy: `export_store.py` writes the same three
+things in a readable form.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from pathlib import Path
+
+from _db import ledger_path
+
+
+def targets() -> dict[str, Path]:
+    workspace = ledger_path().parent.parent
+    return {
+        "store": ledger_path().parent,
+        "memory": workspace / "memory",
+        "policy": workspace / "policy",
+        # Collection bookkeeping. Not personal in itself, but it names channels
+        # and threads, and leaving it behind would have the next run re-read
+        # windows the user just cleared.
+        "collection_state": workspace / "slack_capabilities.json",
+    }
+
+
+def survey() -> dict[str, object]:
+    found = {}
+    for name, path in targets().items():
+        if path.is_dir():
+            found[name] = sum(1 for _ in path.rglob("*") if _.is_file())
+        elif path.exists():
+            found[name] = 1
+        else:
+            found[name] = 0
+    return found
+
+
+def remove() -> tuple[dict[str, object], list[str]]:
+    removed: dict[str, object] = {}
+    failed: list[str] = []
+    for name, path in targets().items():
+        try:
+            if path.is_dir():
+                shutil.rmtree(path)
+                removed[name] = "removed"
+            elif path.exists():
+                path.unlink()
+                removed[name] = "removed"
+            else:
+                removed[name] = "absent"
+        except OSError as exc:
+            removed[name] = f"failed: {exc.strerror or exc}"
+            failed.append(name)
+    return removed, failed
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--dry-run", action="store_true",
+                        help="list what would be removed and remove nothing")
+    parser.add_argument("--yes", action="store_true",
+                        help="required to actually remove anything")
+    args = parser.parse_args(argv)
+
+    if args.dry_run:
+        print(json.dumps({"would_remove": survey()}))
+        return 0
+
+    if not args.yes:
+        print("This removes the store, the memory and the learned policy.",
+              file=sys.stderr)
+        print("Run with --dry-run to see what that is, or --yes to do it.",
+              file=sys.stderr)
+        return 1
+
+    removed, failed = remove()
+    print(json.dumps({"removed": removed}))
+
+    if failed:
+        # A reset that half-worked must not read as a reset that worked.
+        print(f"Could not remove: {', '.join(failed)}. Data remains.",
+              file=sys.stderr)
+        return 1
+
+    print("", file=sys.stderr)
+    print("The store, the memory and the policy are gone. The Slack "
+          "credential is not — it is held by the gateway, not by this "
+          "recipe. To revoke it as well:", file=sys.stderr)
+    print("  uninstall the app from your Slack workspace, then", file=sys.stderr)
+    print("  openshell sandbox provider detach <sandbox> <provider>",
+          file=sys.stderr)
+    print("  openshell provider delete <provider>", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/retention.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/retention.py
@@ -41,8 +41,13 @@ from _db import ensure_store, write_txn
 #
 # Thirty days is long enough that a person looking back at a decision can still
 # read what prompted it, and short enough that a store is not a copy of the
-# mailbox. It is the default rather than the rule: `RETENTION_DAYS` moves it,
-# and the README says so.
+# mailbox. It is the default rather than the rule: `RETENTION_DAYS` moves it.
+#
+# For the scheduled job, set it in `$HERMES_HOME/.env` — `hermes config
+# env-path` prints the file. That is the only place a value survives to the
+# next tick: `hermes cron create` and `cron edit` take no environment, so
+# exporting the variable in a shell changes the run you are watching and
+# nothing after it. Measured: a `.env` line reaches the cron subprocess.
 RETENTION_DAYS = 30
 
 MAX_RETENTION_DAYS = 3650

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/retention.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/retention.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Clear message bodies once they are old enough, and keep everything else.
+
+A store that judges what arrives has no reason to hold the text of it
+indefinitely. What stays useful is the record — who wrote, when, what was
+decided and why — and that lives in the obligation and its events, not in the
+message body. So the body ages out and the history does not.
+
+The line is deliberate. Clearing the body leaves:
+
+- the item row, with sender, subject, timestamp, addressing and state
+- the obligation, with the title the judging turn wrote
+- every event, with its actor and its before/after
+
+and removes only the sentence somebody typed. A month later the user can still
+see that Dana asked for the cutover window on the third, that it was ranked
+high because the memory said they had chosen that work, and that they ignored
+it on the fifth. They cannot re-read Dana's exact words, which is the point.
+
+`body_cleared_at` marks the difference between a body that was cleared and one
+that never existed — a join notice and a message somebody wrote both leave
+`body` NULL, and only one of them is a loss.
+
+    python3 retention.py            # clear anything past the window
+    python3 retention.py --dry-run  # report what would go, change nothing
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+
+from _db import ensure_store, write_txn
+
+# How long a body stays.
+#
+# Thirty days is long enough that a person looking back at a decision can still
+# read what prompted it, and short enough that a store is not a copy of the
+# mailbox. It is the default rather than the rule: `RETENTION_DAYS` moves it,
+# and the README says so.
+RETENTION_DAYS = 30
+
+MAX_RETENTION_DAYS = 3650
+
+
+def bounded_days(name: str, default: int) -> int:
+    """Read a positive, bounded day count from the environment.
+
+    A zero would clear every body on the next tick, including the one that
+    arrived a minute ago, and a negative would make the cutoff sit in the
+    future and clear everything ever stored. Both are the kind of mistake that
+    is only discovered afterwards, so neither is accepted.
+    """
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        raise SystemExit(
+            f"{name} must be a whole number of days between 1 and "
+            f"{MAX_RETENTION_DAYS}; got {raw!r}")
+    if value < 1 or value > MAX_RETENTION_DAYS:
+        raise SystemExit(
+            f"{name} must be between 1 and {MAX_RETENTION_DAYS}; got {value}")
+    return value
+
+
+def cutoff(days: int, now: datetime | None = None) -> str:
+    moment = (now or datetime.now(timezone.utc)) - timedelta(days=days)
+    return moment.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def survey(conn, before: str) -> dict[str, int]:
+    """What the pass would do, without doing it."""
+    due = conn.execute(
+        "SELECT COUNT(*) FROM items"
+        " WHERE event_at < ? AND body IS NOT NULL", (before,)).fetchone()[0]
+    kept = conn.execute(
+        "SELECT COUNT(*) FROM items WHERE body IS NOT NULL").fetchone()[0] - due
+    cleared = conn.execute(
+        "SELECT COUNT(*) FROM items WHERE body_cleared_at IS NOT NULL"
+    ).fetchone()[0]
+    return {"due": due, "still_held": kept, "already_cleared": cleared}
+
+
+def clear(conn, before: str) -> int:
+    """Drop the text, keep the row.
+
+    `subject` stays. On email it is often the only human-readable handle the
+    row has, it is what the obligation title was derived from, and it is short
+    enough that keeping it does not amount to keeping the message.
+    """
+    cursor = conn.execute(
+        "UPDATE items"
+        "   SET body = NULL,"
+        "       body_cleared_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')"
+        " WHERE event_at < ? AND body IS NOT NULL", (before,))
+    return cursor.rowcount
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--dry-run", action="store_true",
+                        help="report what would be cleared and change nothing")
+    args = parser.parse_args(argv)
+
+    days = bounded_days("RETENTION_DAYS", RETENTION_DAYS)
+    before = cutoff(days)
+    ensure_store()
+
+    with write_txn() as conn:
+        report = survey(conn, before)
+        report["retention_days"] = days
+        report["cutoff"] = before
+        if args.dry_run:
+            report["dry_run"] = True
+        else:
+            report["cleared"] = clear(conn, before)
+
+    print(json.dumps(report))
+    # Retention needs no judgment, so the agent is never woken. Printing the
+    # gate last is what the scheduler reads; see `select_intake.py` for the
+    # same contract on the collecting side.
+    print(json.dumps({"wakeAgent": False}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/schema-v1.sql
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/schema-v1.sql
@@ -1,3 +1,17 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- The schema as shipped at v1, kept verbatim so the upgrade to v2 can be
+-- exercised against a store the released code would actually have made.
+--
+-- Not derived from the current schema by removing what v2 added. That
+-- shortcut keeps every other column the real v1 had, so a genuine v1 database
+-- can still fail to open while the test passes — the failure mode the
+-- acceptance criteria on #122 names directly. This file is the artifact.
+--
+-- It is frozen. A change to the live schema goes in schema.sql and a
+-- migration, never here.
+
 -- Ledger store for the memory-driven chief-of-staff recipe.
 --
 -- Target runtime : SQLite bundled with Hermes 0.19.0 (the version the current
@@ -22,7 +36,7 @@ CREATE TABLE IF NOT EXISTS meta (
     key   TEXT PRIMARY KEY,
     value TEXT NOT NULL
 );
-INSERT OR IGNORE INTO meta(key, value) VALUES ('schema_version', '2');
+INSERT OR IGNORE INTO meta(key, value) VALUES ('schema_version', '1');
 
 
 -- ---------------------------------------------------------------------------
@@ -42,10 +56,6 @@ CREATE TABLE IF NOT EXISTS items (
     sender      TEXT,                       -- display name or address
     subject     TEXT,                       -- NULL for slack
     body        TEXT,
-    -- Set when the retention pass clears `body`, and never otherwise. It is
-    -- what tells a cleared message from one that never carried text: both
-    -- leave `body` NULL, and only one of them is a message somebody sent.
-    body_cleared_at TEXT,
     permalink   TEXT,                       -- link back to the source system
 
     -- Normalized across sources, because the judging rules ask the same

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_lifecycle.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_lifecycle.py
@@ -1,0 +1,359 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Retention, exclusion, export and reset.
+
+These are the controls a person exercises over their own data, so the tests ask
+the questions that person would: is the text actually gone, is the history
+still readable, did the excluded message really never arrive, and did the reset
+leave anything behind.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(HERE))
+
+import exclusions  # noqa: E402
+import export_store  # noqa: E402
+import reset  # noqa: E402
+import retention  # noqa: E402
+from normalize import insert_items  # noqa: E402
+
+SCHEMA = (HERE / "schema.sql").read_text(encoding="utf-8")
+
+
+def iso(days_ago: int) -> str:
+    moment = datetime.now(timezone.utc) - timedelta(days=days_ago)
+    return moment.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+class StoreCase(unittest.TestCase):
+    def setUp(self):
+        self.home = tempfile.mkdtemp()
+        # `_db` refuses a directory that does not look like a profile home, so
+        # a marker is what makes this a store rather than a guess at one.
+        (Path(self.home) / "distribution.yaml").write_text("id: test\n",
+                                                          encoding="utf-8")
+        self.workspace = Path(self.home) / "workspace"
+        (self.workspace / "ledger").mkdir(parents=True)
+        self.db = self.workspace / "ledger" / "state.db"
+        with sqlite3.connect(self.db) as conn:
+            conn.executescript(SCHEMA)
+        os.environ["HERMES_HOME"] = self.home
+
+    def tearDown(self):
+        for name in ("RETENTION_DAYS",):
+            os.environ.pop(name, None)
+        shutil.rmtree(self.home, ignore_errors=True)
+
+    def add(self, source_id, *, days_ago=0, body="hello", sender="Dana",
+            scope="inbox", source="email"):
+        with sqlite3.connect(self.db) as conn:
+            conn.execute(
+                "INSERT INTO items(source_id, source, scope, event_at, sender,"
+                " subject, body, state) VALUES (?,?,?,?,?,?,?, 'pending')",
+                (source_id, source, scope, iso(days_ago), sender,
+                 f"about {source_id}", body))
+
+    def item(self, source_id):
+        with sqlite3.connect(self.db) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute("SELECT * FROM items WHERE source_id=?",
+                               (source_id,)).fetchone()
+        return dict(row) if row else None
+
+
+class TestRetentionClearsTextAndKeepsHistory(StoreCase):
+    """The record of a decision outlives the message that prompted it.
+
+    A store that judges what arrives has no reason to hold the text
+    indefinitely; what stays useful is who wrote, when, and what was decided.
+    """
+
+    def test_an_old_body_is_cleared(self):
+        self.add("old", days_ago=90)
+        retention.main([])
+        self.assertIsNone(self.item("old")["body"])
+
+    def test_a_recent_body_is_left_alone(self):
+        self.add("fresh", days_ago=1)
+        retention.main([])
+        self.assertEqual(self.item("fresh")["body"], "hello")
+
+    def test_the_metadata_survives_the_clearing(self):
+        """Otherwise history stops being inspectable, which is the whole point."""
+        self.add("old", days_ago=90)
+        retention.main([])
+        row = self.item("old")
+        self.assertEqual(row["sender"], "Dana")
+        self.assertEqual(row["subject"], "about old")
+        self.assertTrue(row["event_at"])
+        self.assertEqual(row["state"], "pending")
+
+    def test_a_cleared_body_is_distinguishable_from_one_that_never_existed(self):
+        self.add("had_text", days_ago=90)
+        self.add("never_had_text", days_ago=90, body=None)
+        retention.main([])
+        self.assertIsNotNone(self.item("had_text")["body_cleared_at"])
+        self.assertIsNone(self.item("never_had_text")["body_cleared_at"])
+
+    def test_the_window_is_configurable(self):
+        self.add("week_old", days_ago=8)
+        os.environ["RETENTION_DAYS"] = "7"
+        retention.main([])
+        self.assertIsNone(self.item("week_old")["body"])
+
+    def test_a_window_that_would_clear_everything_is_refused(self):
+        for bad in ("0", "-1", "abc"):
+            os.environ["RETENTION_DAYS"] = bad
+            with self.assertRaises(SystemExit):
+                retention.main([])
+
+    def test_a_window_beyond_the_upper_bound_is_refused(self):
+        """Documented as 1..3650; a number outside it must not pass silently."""
+        os.environ["RETENTION_DAYS"] = str(retention.MAX_RETENTION_DAYS + 1)
+        with self.assertRaises(SystemExit):
+            retention.main([])
+
+    def test_the_default_window_is_the_one_the_docs_state(self):
+        """The README and docs/data-lifecycle.md both say thirty days."""
+        self.assertEqual(retention.RETENTION_DAYS, 30)
+        self.add("just_inside", days_ago=29)
+        self.add("just_outside", days_ago=31)
+        retention.main([])
+        self.assertEqual(self.item("just_inside")["body"], "hello")
+        self.assertIsNone(self.item("just_outside")["body"])
+
+    def test_dry_run_changes_nothing(self):
+        self.add("old", days_ago=90)
+        retention.main(["--dry-run"])
+        self.assertEqual(self.item("old")["body"], "hello")
+
+    def test_a_second_pass_does_not_re_clear(self):
+        self.add("old", days_ago=90)
+        retention.main([])
+        first = self.item("old")["body_cleared_at"]
+        retention.main([])
+        self.assertEqual(self.item("old")["body_cleared_at"], first)
+
+
+class TestExclusionHappensBeforeAnythingIsWritten(StoreCase):
+    """Filtering at display leaves the text on disk, which is no use at all.
+
+    Applied in `insert_items` so every writer inherits it — the fixture loader,
+    the Slack collector when it lands, and anything written afterwards.
+    """
+
+    def write_rules(self, **rules):
+        (self.workspace / exclusions.RULES_FILE).write_text(
+            json.dumps(rules), encoding="utf-8")
+
+    def rows(self):
+        with sqlite3.connect(self.db) as conn:
+            return [r[0] for r in conn.execute("SELECT source_id FROM items")]
+
+    def insert(self, items):
+        with sqlite3.connect(self.db) as conn:
+            insert_items(conn, items)
+
+    def item(self, **over):
+        base = {"source_id": "m1", "source": "email", "scope": "inbox",
+                "event_at": iso(0), "sender": "Dana", "subject": "s",
+                "body": "text", "addressing": "direct"}
+        base.update(over)
+        return base
+
+    def test_an_excluded_sender_never_reaches_the_store(self):
+        self.write_rules(senders=["recruiter@agency.example"])
+        self.insert([self.item(sender="recruiter@agency.example")])
+        self.assertEqual(self.rows(), [])
+
+    def test_an_excluded_domain_never_reaches_the_store(self):
+        self.write_rules(domains=["agency.example"])
+        self.insert([self.item(sender="anyone@agency.example")])
+        self.assertEqual(self.rows(), [])
+
+    def test_an_excluded_channel_never_reaches_the_store(self):
+        self.write_rules(channels=["C0SALARY01"])
+        self.insert([self.item(scope="C0SALARY01", source="slack")])
+        self.assertEqual(self.rows(), [])
+
+    def test_a_sender_can_be_excluded_by_source_id(self):
+        """A display name is something the other person can change."""
+        self.write_rules(senders=["u01recruit"])
+        self.insert([self.item(sender="Friendly Name", sender_id="U01RECRUIT")])
+        self.assertEqual(self.rows(), [])
+
+    def test_matching_ignores_case(self):
+        self.write_rules(senders=["Recruiter@Agency.Example"])
+        self.insert([self.item(sender="recruiter@AGENCY.example")])
+        self.assertEqual(self.rows(), [])
+
+    def test_everything_else_still_arrives(self):
+        self.write_rules(senders=["recruiter@agency.example"])
+        self.insert([self.item(source_id="keep", sender="Dana")])
+        self.assertEqual(self.rows(), ["keep"])
+
+    def test_no_rules_means_no_filtering(self):
+        self.insert([self.item()])
+        self.assertEqual(self.rows(), ["m1"])
+
+    def test_an_unreadable_rules_file_does_not_stop_the_intake(self):
+        """A typo here must not silently halt collection."""
+        (self.workspace / exclusions.RULES_FILE).write_text("{ not json")
+        self.insert([self.item()])
+        self.assertEqual(self.rows(), ["m1"])
+
+    def test_a_pattern_is_not_a_glob(self):
+        """Documented as exact. A wildcard that matched would exclude far more
+        than intended, and say nothing about having done so."""
+        self.write_rules(domains=["*.example"])
+        self.insert([self.item(source_id="keep", sender="dana@agency.example")])
+        self.assertEqual(self.rows(), ["keep"])
+
+    def test_the_report_counts_what_was_dropped(self):
+        """`exclusions: N message(s) not stored` — the count, never the text."""
+        self.write_rules(senders=["dana"])
+        kept, dropped = exclusions.partition(
+            [self.item(source_id="a"), self.item(source_id="b"),
+             self.item(source_id="c", sender="Sam")])
+        self.assertEqual(dropped, 2)
+        self.assertEqual([i["source_id"] for i in kept], ["c"])
+
+    def test_a_drop_is_reported_rather_than_silent(self):
+        self.write_rules(senders=["dana"])
+        script = (
+            "import sys; sys.path.insert(0, %r)\n"
+            "import sqlite3\n"
+            "from normalize import insert_items\n"
+            "conn = sqlite3.connect(%r)\n"
+            "insert_items(conn, [%r])\n" % (str(HERE), str(self.db), self.item())
+        )
+        proc = subprocess.run([sys.executable, "-c", script],
+                              capture_output=True, text=True,
+                              env={**os.environ, "HERMES_HOME": self.home})
+        self.assertIn("exclusions", proc.stderr)
+
+
+class TestExportShowsEverythingItHolds(StoreCase):
+    def test_it_writes_both_a_readable_and_a_machine_form(self):
+        self.add("m1")
+        destination = Path(self.home) / "out"
+        export_store.export(destination)
+        self.assertTrue((destination / "store.md").exists())
+        self.assertTrue((destination / "store.json").exists())
+
+    def test_the_readable_form_contains_the_message(self):
+        self.add("m1", body="the cutover window is Thursday")
+        destination = Path(self.home) / "out"
+        export_store.export(destination)
+        text = (destination / "store.md").read_text(encoding="utf-8")
+        self.assertIn("cutover window", text)
+
+    def test_a_cleared_body_is_shown_as_cleared_rather_than_missing(self):
+        self.add("old", days_ago=90)
+        retention.main([])
+        destination = Path(self.home) / "out"
+        export_store.export(destination)
+        text = (destination / "store.md").read_text(encoding="utf-8")
+        self.assertIn("text cleared", text)
+
+    def test_the_learned_policy_travels_with_it(self):
+        """Documented as copied whole; it is as much about the user as the memory."""
+        policy = self.workspace / "policy"
+        policy.mkdir(exist_ok=True)
+        (policy / "preferences.md").write_text("ignores: newsletters\n",
+                                               encoding="utf-8")
+        destination = Path(self.home) / "out"
+        export_store.export(destination)
+        self.assertTrue((destination / "policy" / "preferences.md").exists())
+
+    def test_the_memory_travels_with_it(self):
+        memory = self.workspace / "memory" / "people"
+        memory.mkdir(parents=True)
+        (memory / "dana.md").write_text("name: Dana\n", encoding="utf-8")
+        destination = Path(self.home) / "out"
+        report = export_store.export(destination)
+        self.assertEqual(report["memory_pages"], 1)
+        self.assertTrue((destination / "memory" / "people" / "dana.md").exists())
+
+
+class TestResetLeavesNothingBehind(StoreCase):
+    """A partial reset is worse than none: it answers the question wrongly."""
+
+    def populate(self):
+        self.add("m1")
+        (self.workspace / "memory").mkdir(exist_ok=True)
+        (self.workspace / "memory" / "index.md").write_text("x", encoding="utf-8")
+        (self.workspace / "policy").mkdir(exist_ok=True)
+        (self.workspace / "policy" / "preferences.md").write_text("y", encoding="utf-8")
+
+    def test_it_refuses_without_consent(self):
+        self.populate()
+        self.assertEqual(reset.main([]), 1)
+        self.assertTrue(self.db.exists())
+
+    def test_dry_run_reports_and_removes_nothing(self):
+        self.populate()
+        self.assertEqual(reset.main(["--dry-run"]), 0)
+        self.assertTrue(self.db.exists())
+        self.assertTrue((self.workspace / "memory").exists())
+
+    def test_it_removes_the_store_the_memory_and_the_policy(self):
+        self.populate()
+        self.assertEqual(reset.main(["--yes"]), 0)
+        self.assertFalse(self.db.exists())
+        self.assertFalse((self.workspace / "memory").exists())
+        self.assertFalse((self.workspace / "policy").exists())
+
+    def test_the_learned_policy_is_not_forgotten_in_the_sweep(self):
+        """It encodes what the user ignores, which is about them."""
+        self.assertIn("policy", reset.targets())
+
+    def test_the_collection_bookkeeping_goes_too(self):
+        """Left behind, the next run re-reads windows the user just cleared."""
+        self.assertIn("collection_state", reset.targets())
+
+    def test_a_partial_removal_does_not_report_success(self):
+        """A reset that half worked must not read as one that worked."""
+        self.populate()
+        target = reset.targets()["memory"]
+        original = reset.shutil.rmtree
+
+        def refuse(path, *a, **kw):
+            if Path(path) == target:
+                raise OSError(13, "Permission denied")
+            return original(path, *a, **kw)
+
+        reset.shutil.rmtree = refuse
+        try:
+            self.assertEqual(reset.main(["--yes"]), 1)
+        finally:
+            reset.shutil.rmtree = original
+
+    def test_it_says_the_credential_is_somewhere_else(self):
+        """Somebody withdrawing consent wants both, and would stop after one."""
+        self.populate()
+        script = ("import sys; sys.path.insert(0, %r)\n"
+                  "import reset\nraise SystemExit(reset.main(['--yes']))"
+                  % str(HERE))
+        proc = subprocess.run([sys.executable, "-c", script],
+                              capture_output=True, text=True,
+                              env={**os.environ, "HERMES_HOME": self.home})
+        self.assertIn("provider delete", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_lifecycle.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_lifecycle.py
@@ -592,6 +592,71 @@ class TestExportShowsEverythingItHolds(StoreCase):
                          (destination / "store.md").read_text(encoding="utf-8"))
         self.assertFalse((destination / "leftover.txt").exists())
 
+    def live_workspace(self):
+        """Everything a refusal has to leave untouched."""
+        self.add("m1")
+        memory = self.workspace / "memory"
+        memory.mkdir(exist_ok=True)
+        (memory / "index.md").write_text("the memory", encoding="utf-8")
+        policy = self.workspace / "policy"
+        policy.mkdir(exist_ok=True)
+        (policy / "preferences.md").write_text("the policy", encoding="utf-8")
+
+    def assert_workspace_intact(self):
+        self.assertTrue(self.db.exists(), "the live store was removed")
+        with sqlite3.connect(self.db) as conn:
+            rows = conn.execute("SELECT count(*) FROM items").fetchone()[0]
+        self.assertEqual(rows, 1, "the live store lost rows")
+        self.assertEqual(
+            (self.workspace / "memory" / "index.md").read_text(
+                encoding="utf-8"), "the memory")
+        self.assertEqual(
+            (self.workspace / "policy" / "preferences.md").read_text(
+                encoding="utf-8"), "the policy")
+
+    def test_exporting_into_the_workspace_is_refused(self):
+        """The export replaces its destination, so this deleted the store and
+        left a copy of it in place — reported as success."""
+        self.live_workspace()
+        with self.assertRaises(export_store.ExportOverlapsWorkspace):
+            export_store.export(self.workspace)
+        self.assert_workspace_intact()
+
+    def test_exporting_inside_the_workspace_is_refused(self):
+        self.live_workspace()
+        with self.assertRaises(export_store.ExportOverlapsWorkspace):
+            export_store.export(self.workspace / "memory")
+        self.assert_workspace_intact()
+
+    def test_exporting_into_a_directory_containing_the_workspace_is_refused(self):
+        self.live_workspace()
+        with self.assertRaises(export_store.ExportOverlapsWorkspace):
+            export_store.export(Path(self.home))
+        self.assert_workspace_intact()
+
+    def test_the_refusal_leaves_no_staging_directory(self):
+        """Refused before anything is created, so nothing is left to clean."""
+        self.live_workspace()
+        before = sorted(p.name for p in Path(self.home).iterdir())
+        with self.assertRaises(export_store.ExportOverlapsWorkspace):
+            export_store.export(self.workspace)
+        self.assertEqual(sorted(p.name for p in Path(self.home).iterdir()),
+                         before)
+
+    def test_a_destination_beside_the_workspace_is_fine(self):
+        """The rule is about overlap, not about being nearby."""
+        self.live_workspace()
+        destination = Path(self.home) / "export-out"
+        export_store.export(destination)
+        self.assertTrue((destination / "store.json").exists())
+        self.assert_workspace_intact()
+
+    def test_the_command_reports_the_refusal_rather_than_raising(self):
+        self.live_workspace()
+        self.assertEqual(
+            export_store.main(["--to", str(self.workspace)]), 1)
+        self.assert_workspace_intact()
+
     def test_the_learned_policy_travels_with_it(self):
         """Documented as copied whole; it is as much about the user as the memory."""
         policy = self.workspace / "policy"

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_lifecycle.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_lifecycle.py
@@ -29,7 +29,8 @@ import exclusions  # noqa: E402
 import export_store  # noqa: E402
 import reset  # noqa: E402
 import retention  # noqa: E402
-from normalize import insert_items  # noqa: E402
+from normalize import (  # noqa: E402
+    graph_message_to_item, insert_items, slack_message_to_item)
 
 SCHEMA = (HERE / "schema.sql").read_text(encoding="utf-8")
 
@@ -136,6 +137,22 @@ class TestRetentionClearsTextAndKeepsHistory(StoreCase):
         self.assertEqual(self.item("just_inside")["body"], "hello")
         self.assertIsNone(self.item("just_outside")["body"])
 
+    def test_the_documented_persistent_path_is_the_env_file(self):
+        """`cron create` takes no environment, so a shell export changes the
+        run you are watching and nothing scheduled after it.
+
+        Measured on Hermes 0.19.0: a line in `$HERMES_HOME/.env` reaches the
+        cron subprocess. This pins the documentation to that mechanism so the
+        two cannot drift apart silently — the failure being that somebody sets
+        the window, never checks, and the nightly pass keeps using thirty days.
+        """
+        docs = (HERE.parents[1] / "docs" / "data-lifecycle.md").read_text(
+            encoding="utf-8")
+        self.assertIn("config env-path", docs)
+        self.assertIn("RETENTION_DAYS", docs)
+        module = (HERE / "retention.py").read_text(encoding="utf-8")
+        self.assertIn("env-path", module)
+
     def test_dry_run_changes_nothing(self):
         self.add("old", days_ago=90)
         retention.main(["--dry-run"])
@@ -210,9 +227,39 @@ class TestExclusionHappensBeforeAnythingIsWritten(StoreCase):
         self.insert([self.item()])
         self.assertEqual(self.rows(), ["m1"])
 
-    def test_an_unreadable_rules_file_does_not_stop_the_intake(self):
-        """A typo here must not silently halt collection."""
+    def test_a_malformed_rules_file_stops_the_insert(self):
+        """Fail closed. The guarantee is that excluded content is never
+        written, and continuing without the rules breaches it silently."""
         (self.workspace / exclusions.RULES_FILE).write_text("{ not json")
+        with self.assertRaises(exclusions.ExclusionsUnreadable):
+            self.insert([self.item()])
+        self.assertEqual(self.rows(), [])
+
+    def test_the_refusal_says_which_file_and_where(self):
+        """A stalled intake with no explanation is its own failure."""
+        (self.workspace / exclusions.RULES_FILE).write_text("{ not json")
+        with self.assertRaises(exclusions.ExclusionsUnreadable) as caught:
+            self.insert([self.item()])
+        message = str(caught.exception)
+        self.assertIn(exclusions.RULES_FILE, message)
+        self.assertIn("Nothing has been stored", message)
+
+    def test_a_rules_file_of_the_wrong_shape_stops_the_insert(self):
+        (self.workspace / exclusions.RULES_FILE).write_text('["dana"]')
+        with self.assertRaises(exclusions.ExclusionsUnreadable):
+            self.insert([self.item()])
+        self.assertEqual(self.rows(), [])
+
+    def test_a_rule_key_of_the_wrong_type_stops_the_insert(self):
+        """`{"senders": "dana"}` reads as a list of characters otherwise."""
+        (self.workspace / exclusions.RULES_FILE).write_text(
+            '{"senders": "dana"}')
+        with self.assertRaises(exclusions.ExclusionsUnreadable):
+            self.insert([self.item()])
+        self.assertEqual(self.rows(), [])
+
+    def test_no_rules_file_at_all_is_not_an_error(self):
+        """Absent is the ordinary state of a fresh install and must stay free."""
         self.insert([self.item()])
         self.assertEqual(self.rows(), ["m1"])
 
@@ -247,6 +294,103 @@ class TestExclusionHappensBeforeAnythingIsWritten(StoreCase):
         self.assertIn("exclusions", proc.stderr)
 
 
+class TestExclusionSurvivesTheRealNormalizers(StoreCase):
+    """Through `graph_message_to_item` and `slack_message_to_item`, not around.
+
+    The first version of these tests built the item dictionary by hand, which
+    is a shape neither normalizer produces: both store a display name in
+    `sender` and dropped the address and the raw user id entirely. So a domain
+    rule matched nothing on real mail and a `U…` rule matched nothing on real
+    Slack, while tests asserting on hand-built dictionaries stayed green. A
+    test that cannot see that is not evidence.
+    """
+
+    def write_rules(self, **rules):
+        (self.workspace / exclusions.RULES_FILE).write_text(
+            json.dumps(rules), encoding="utf-8")
+
+    def rows(self):
+        with sqlite3.connect(self.db) as conn:
+            return [r[0] for r in conn.execute("SELECT source_id FROM items")]
+
+    def graph_message(self, name="Dana Okoro",
+                      address="dana@agency.example", mid="g1"):
+        """The shape Microsoft Graph actually returns: a name and an address."""
+        return {
+            "id": mid,
+            "receivedDateTime": "2026-08-01T09:00:00Z",
+            "subject": "about the cutover",
+            "body": {"content": "text"},
+            "from": {"emailAddress": {"name": name, "address": address}},
+            "toRecipients": [{"emailAddress": {"address": "me@example.com"}}],
+            "isRead": False,
+        }
+
+    def slack_message(self, uid="U01RECRUIT", display="friendly",
+                      ts="1787000000.0001"):
+        return ({"ts": ts, "user": uid, "text": "hello"},
+                {"id": "D01", "type": "im"}, "U0ME", display)
+
+    def insert(self, items):
+        with sqlite3.connect(self.db) as conn:
+            insert_items(conn, items)
+
+    def test_a_domain_rule_matches_real_graph_mail(self):
+        """`sender` holds the display name, so the address must survive too."""
+        self.write_rules(domains=["agency.example"])
+        self.insert([graph_message_to_item(self.graph_message(),
+                                           "me@example.com")])
+        self.assertEqual(self.rows(), [])
+
+    def test_an_address_rule_matches_real_graph_mail(self):
+        self.write_rules(senders=["dana@agency.example"])
+        self.insert([graph_message_to_item(self.graph_message(),
+                                           "me@example.com")])
+        self.assertEqual(self.rows(), [])
+
+    def test_the_display_name_still_matches(self):
+        self.write_rules(senders=["Dana Okoro"])
+        self.insert([graph_message_to_item(self.graph_message(),
+                                           "me@example.com")])
+        self.assertEqual(self.rows(), [])
+
+    def test_unrelated_graph_mail_still_arrives(self):
+        """Otherwise the three above would pass on a store that writes nothing."""
+        self.write_rules(domains=["agency.example"])
+        self.insert([graph_message_to_item(
+            self.graph_message(name="Sam Ruiz", address="sam@example.com",
+                               mid="keep"), "me@example.com")])
+        self.assertEqual(self.rows(), ["keep"])
+
+    def test_a_slack_id_rule_matches_a_resolved_display_name(self):
+        """The id is what a person cannot change; the display name is not."""
+        self.write_rules(senders=["U01RECRUIT"])
+        self.insert([slack_message_to_item(*self.slack_message())])
+        self.assertEqual(self.rows(), [])
+
+    def test_unrelated_slack_still_arrives(self):
+        self.write_rules(senders=["U01RECRUIT"])
+        msg, channel, me, display = self.slack_message(
+            uid="U0SAM0001", display="sam", ts="1787000000.0002")
+        self.insert([slack_message_to_item(msg, channel, me, display)])
+        self.assertEqual(len(self.rows()), 1)
+
+    def test_the_matching_values_are_never_stored(self):
+        """Matching material must not become a new thing the store holds."""
+        self.insert([graph_message_to_item(self.graph_message(),
+                                           "me@example.com"),
+                     slack_message_to_item(*self.slack_message())])
+        with sqlite3.connect(self.db) as conn:
+            columns = {r[1] for r in conn.execute("PRAGMA table_info(items)")}
+            everything = "".join(
+                str(v) for row in conn.execute("SELECT * FROM items")
+                for v in row)
+        self.assertNotIn("sender_address", columns)
+        self.assertNotIn("sender_id", columns)
+        self.assertNotIn("dana@agency.example", everything)
+        self.assertNotIn("U01RECRUIT", everything)
+
+
 class TestExportShowsEverythingItHolds(StoreCase):
     def test_it_writes_both_a_readable_and_a_machine_form(self):
         self.add("m1")
@@ -269,6 +413,94 @@ class TestExportShowsEverythingItHolds(StoreCase):
         export_store.export(destination)
         text = (destination / "store.md").read_text(encoding="utf-8")
         self.assertIn("text cleared", text)
+
+    def test_the_export_is_no_more_readable_than_the_store(self):
+        """The store is owner-only on purpose; a copy that is not undoes it."""
+        self.add("m1")
+        memory = self.workspace / "memory"
+        memory.mkdir(exist_ok=True)
+        (memory / "index.md").write_text("x", encoding="utf-8")
+        destination = Path(self.home) / "out"
+        export_store.export(destination)
+
+        self.assertEqual(oct(destination.stat().st_mode)[-3:], "700")
+        for name in ("store.json", "store.md"):
+            self.assertEqual(
+                oct((destination / name).stat().st_mode)[-3:], "600", name)
+        for path in destination.rglob("*"):
+            expected = "700" if path.is_dir() else "600"
+            self.assertEqual(oct(path.stat().st_mode)[-3:], expected, str(path))
+
+    def test_a_table_that_cannot_be_read_fails_the_export(self):
+        """An empty section reads as "nothing was there", which is a lie.
+
+        Dropping a table does not reproduce this: `export` calls
+        `ensure_store` first and the baseline DDL puts it back, empty. What is
+        being pinned is narrower and is the thing that regressed — that a read
+        error is not converted into an empty table.
+        """
+        self.add("m1")
+        original = export_store.rows
+
+        def refuse(conn, table):
+            if table == "events":
+                raise sqlite3.OperationalError("disk I/O error")
+            return original(conn, table)
+
+        export_store.rows = refuse
+        try:
+            with self.assertRaises(sqlite3.Error):
+                export_store.export(Path(self.home) / "out")
+        finally:
+            export_store.rows = original
+
+    def test_a_failed_export_does_not_leave_a_complete_looking_one(self):
+        """Half an export that reads as whole is the failure being avoided."""
+        self.add("m1")
+        original = export_store.rows
+
+        def refuse(conn, table):
+            if table == "events":
+                raise sqlite3.OperationalError("disk I/O error")
+            return original(conn, table)
+
+        destination = Path(self.home) / "out"
+        export_store.rows = refuse
+        try:
+            with self.assertRaises(sqlite3.Error):
+                export_store.export(destination)
+        finally:
+            export_store.rows = original
+        self.assertFalse((destination / "store.json").exists())
+        self.assertFalse((destination / "store.md").exists())
+
+    def test_a_long_body_is_marked_rather_than_silently_cut(self):
+        """The readable form is bounded; it has to say so."""
+        self.add("long", body="x" * (export_store.BODY_PREVIEW + 500))
+        destination = Path(self.home) / "out"
+        export_store.export(destination)
+        text = (destination / "store.md").read_text(encoding="utf-8")
+        self.assertIn("body continues", text)
+        self.assertIn("store.json", text)
+
+    def test_the_machine_form_holds_the_whole_body(self):
+        """Bounded is the Markdown's property, not the export's."""
+        whole = "x" * (export_store.BODY_PREVIEW + 500)
+        self.add("long", body=whole)
+        destination = Path(self.home) / "out"
+        export_store.export(destination)
+        data = json.loads(
+            (destination / "store.json").read_text(encoding="utf-8"))
+        stored = [i["body"] for i in data["items"] if i["source_id"] == "long"]
+        self.assertEqual(stored, [whole])
+
+    def test_a_short_body_is_not_marked(self):
+        self.add("short", body="the cutover window is Thursday")
+        destination = Path(self.home) / "out"
+        export_store.export(destination)
+        text = (destination / "store.md").read_text(encoding="utf-8")
+        self.assertIn("cutover window is Thursday", text)
+        self.assertNotIn("body continues", text)
 
     def test_the_learned_policy_travels_with_it(self):
         """Documented as copied whole; it is as much about the user as the memory."""
@@ -323,8 +555,91 @@ class TestResetLeavesNothingBehind(StoreCase):
         self.assertIn("policy", reset.targets())
 
     def test_the_collection_bookkeeping_goes_too(self):
-        """Left behind, the next run re-reads windows the user just cleared."""
-        self.assertIn("collection_state", reset.targets())
+        """Left behind, the next run re-reads windows the user just cleared.
+
+        Asserted on the file rather than on a key name, because the key names
+        are an implementation detail that changed once already while the
+        guarantee did not.
+        """
+        self.populate()
+        probed = self.workspace / "slack_capabilities.json"
+        probed.write_text("{}", encoding="utf-8")
+        reset.main(["--yes"])
+        self.assertFalse(probed.exists())
+
+    # Written out rather than read from `reset.COLLECTION_STATE`. Deriving the
+    # fixture from the constant under test makes the test agree with whatever
+    # the constant says: shrink it and the test creates fewer files and still
+    # passes, which is how the original defect would have survived this very
+    # test. These are the names a collector actually writes.
+    WRITTEN_BY_COLLECTORS = (
+        "slack_capabilities.json",
+        "slack_channels.json",
+        "slack_threads.json",
+        "slack_rotation.json",
+        "graph_identity.json",
+        "exclusions.json",
+    )
+
+    def test_every_collection_state_file_goes(self):
+        """The reproduced defect: four files survived a successful reset.
+
+        `slack_capabilities.json` was listed and the rest were not, so a reset
+        reported success while the channel list, the thread watermarks, the
+        rotation offset and the exclusion rules stayed on disk — and the next
+        scheduled tick re-read windows the user had just cleared.
+        """
+        self.populate()
+        for name in self.WRITTEN_BY_COLLECTORS:
+            (self.workspace / name).write_text("{}", encoding="utf-8")
+
+        self.assertEqual(reset.main(["--yes"]), 0)
+
+        left = sorted(p.name for p in self.workspace.glob("*")
+                      if p.is_file())
+        self.assertEqual(left, [], f"survived a successful reset: {left}")
+
+    def test_the_listed_state_matches_what_collectors_write(self):
+        """Both directions: nothing unlisted, and nothing listed that is gone."""
+        self.assertEqual(sorted(reset.COLLECTION_STATE),
+                         sorted(self.WRITTEN_BY_COLLECTORS))
+
+    def test_a_workspace_file_nobody_listed_is_caught_here(self):
+        """How the defect happened: a collector added state and this list did
+        not. A glob would hide the next one; this fails instead."""
+        self.populate()
+        (self.workspace / "some_future_collector.json").write_text(
+            "{}", encoding="utf-8")
+
+        reset.main(["--yes"])
+
+        left = sorted(p.name for p in self.workspace.glob("*") if p.is_file())
+        self.assertEqual(
+            left, ["some_future_collector.json"],
+            "this test is the reminder: add the file to "
+            "reset.COLLECTION_STATE, then add it here")
+
+    def test_the_survey_names_them_before_they_go(self):
+        """`--dry-run` is what somebody reads before consenting."""
+        self.populate()
+        for name in self.WRITTEN_BY_COLLECTORS:
+            (self.workspace / name).write_text("{}", encoding="utf-8")
+        surveyed = reset.survey()
+        for name in self.WRITTEN_BY_COLLECTORS:
+            self.assertEqual(surveyed.get(name), 1, name)
+
+    def test_it_says_what_order_to_stop_things_in(self):
+        """Detaching without pausing the schedule refills the store."""
+        self.populate()
+        script = ("import sys; sys.path.insert(0, %r)\n"
+                  "import reset\nraise SystemExit(reset.main(['--yes']))"
+                  % str(HERE))
+        proc = subprocess.run([sys.executable, "-c", script],
+                              capture_output=True, text=True,
+                              env={**os.environ, "HERMES_HOME": self.home})
+        self.assertIn("cron pause", proc.stderr)
+        self.assertIn("provider detach", proc.stderr)
+        self.assertIn("in order", proc.stderr)
 
     def test_a_partial_removal_does_not_report_success(self):
         """A reset that half worked must not read as one that worked."""

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_lifecycle.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_lifecycle.py
@@ -258,6 +258,40 @@ class TestExclusionHappensBeforeAnythingIsWritten(StoreCase):
             self.insert([self.item()])
         self.assertEqual(self.rows(), [])
 
+    def test_a_misspelled_key_stops_the_insert(self):
+        """`{"sender": [...]}` parsed cleanly, matched nothing, and read as a
+        working rule — the exact failure fail-closed exists to prevent."""
+        (self.workspace / exclusions.RULES_FILE).write_text(
+            json.dumps({"sender": ["Dana"]}), encoding="utf-8")
+        with self.assertRaises(exclusions.ExclusionsUnreadable) as caught:
+            self.insert([self.item()])
+        self.assertIn("sender", str(caught.exception))
+        self.assertEqual(self.rows(), [])
+
+    def test_a_key_alongside_the_documented_ones_stops_the_insert(self):
+        (self.workspace / exclusions.RULES_FILE).write_text(
+            json.dumps({"senders": ["dana"], "sendrs": ["sam"]}),
+            encoding="utf-8")
+        with self.assertRaises(exclusions.ExclusionsUnreadable):
+            self.insert([self.item()])
+        self.assertEqual(self.rows(), [])
+
+    def test_a_non_string_rule_stops_the_insert(self):
+        """`123` used to become the rule "123", which matches nothing."""
+        (self.workspace / exclusions.RULES_FILE).write_text(
+            json.dumps({"senders": [123]}), encoding="utf-8")
+        with self.assertRaises(exclusions.ExclusionsUnreadable) as caught:
+            self.insert([self.item()])
+        self.assertIn("123", str(caught.exception))
+        self.assertEqual(self.rows(), [])
+
+    def test_the_documented_keys_are_all_accepted(self):
+        """Strictness must not reject the shape the docs tell people to write."""
+        self.write_rules(senders=["dana"], domains=["x.example"],
+                         channels=["C01"])
+        self.insert([self.item(source_id="keep", sender="Sam")])
+        self.assertEqual(self.rows(), ["keep"])
+
     def test_no_rules_file_at_all_is_not_an_error(self):
         """Absent is the ordinary state of a fresh install and must stay free."""
         self.insert([self.item()])
@@ -501,6 +535,62 @@ class TestExportShowsEverythingItHolds(StoreCase):
         text = (destination / "store.md").read_text(encoding="utf-8")
         self.assertIn("cutover window is Thursday", text)
         self.assertNotIn("body continues", text)
+
+    def test_a_link_out_of_the_workspace_stops_the_export(self):
+        """`copytree` follows links, so one under memory/ copies a file from
+        anywhere on the machine into something about to be handed over."""
+        self.add("m1")
+        outside = Path(self.home) / "outside-the-workspace.txt"
+        outside.write_text("private", encoding="utf-8")
+        memory = self.workspace / "memory"
+        memory.mkdir(exist_ok=True)
+        (memory / "leak.md").symlink_to(outside)
+
+        destination = Path(self.home) / "out"
+        with self.assertRaises(export_store.ExportEscapesWorkspace):
+            export_store.export(destination)
+        self.assertFalse(destination.exists(),
+                         "a refused export must leave nothing behind")
+
+    def test_a_link_inside_the_workspace_is_fine(self):
+        """The rule is about leaving the boundary, not about links."""
+        self.add("m1")
+        memory = self.workspace / "memory"
+        memory.mkdir(exist_ok=True)
+        (memory / "real.md").write_text("page", encoding="utf-8")
+        (memory / "alias.md").symlink_to(memory / "real.md")
+        destination = Path(self.home) / "out"
+        export_store.export(destination)
+        self.assertTrue((destination / "memory" / "alias.md").exists())
+
+    def test_an_export_is_a_snapshot_not_an_accumulation(self):
+        """The default destination is date-based and reused all day, so a page
+        deleted since the last export survived into the next one."""
+        self.add("m1")
+        memory = self.workspace / "memory"
+        memory.mkdir(exist_ok=True)
+        (memory / "gone.md").write_text("deleted later", encoding="utf-8")
+        (memory / "kept.md").write_text("still here", encoding="utf-8")
+        destination = Path(self.home) / "out"
+        export_store.export(destination)
+        self.assertTrue((destination / "memory" / "gone.md").exists())
+
+        (memory / "gone.md").unlink()
+        export_store.export(destination)
+        self.assertFalse((destination / "memory" / "gone.md").exists(),
+                         "a removed page survived the next export")
+        self.assertTrue((destination / "memory" / "kept.md").exists())
+
+    def test_a_stale_store_file_does_not_survive_either(self):
+        self.add("m1")
+        destination = Path(self.home) / "out"
+        destination.mkdir()
+        (destination / "store.md").write_text("yesterday", encoding="utf-8")
+        (destination / "leftover.txt").write_text("stale", encoding="utf-8")
+        export_store.export(destination)
+        self.assertNotIn("yesterday",
+                         (destination / "store.md").read_text(encoding="utf-8"))
+        self.assertFalse((destination / "leftover.txt").exists())
 
     def test_the_learned_policy_travels_with_it(self):
         """Documented as copied whole; it is as much about the user as the memory."""

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_migration.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_migration.py
@@ -43,21 +43,51 @@ class TestMigration(unittest.TestCase):
         with self.assertRaises(SchemaFromTheFuture):
             open_store(p)
 
-    def test_this_recipe_ships_at_the_baseline_with_nothing_to_upgrade_from(self):
-        """No store exists at an earlier version, so there is no upgrade path.
+    def test_a_real_v1_store_upgrades_to_the_current_version(self):
+        """Exercised against v1's own schema artifact, not a doctored current one.
 
-        There used to be a v1-to-v2 step here, written against a v1 that never
-        shipped. The test built its "old" store by taking the current schema
-        and removing one column, which is not the same artifact: it kept every
-        other column the real v1 lacked, so a genuine v1 database still failed
-        to open while the test passed.
+        The shortcut — take the current schema and remove what v2 added — keeps
+        every other column the real v1 had, so a genuine v1 database can still
+        fail to open while the test passes. `schema-v1.sql` is the file that
+        shipped, kept verbatim for this.
         """
-        self.assertEqual(SCHEMA_VERSION, 1)
-        self.assertEqual(MIGRATIONS, {})
-        p = self.fresh()
-        with sqlite3.connect(p) as c:
+        artifact = HERE / "schema-v1.sql"
+        self.assertTrue(artifact.exists(), "the v1 schema artifact is missing")
+        path = Path(tempfile.mkdtemp()) / "v1.db"
+        with sqlite3.connect(path) as c:
+            c.executescript(artifact.read_text(encoding="utf-8"))
             self.assertEqual(current_version(c), 1)
-            self.assertEqual(migrate(c), [])           # already current
+            columns = {row[1] for row in c.execute("PRAGMA table_info(items)")}
+            self.assertNotIn("body_cleared_at", columns,
+                             "the artifact is not really v1")
+
+        with sqlite3.connect(path) as c:
+            self.assertEqual(migrate(c), [2])
+            self.assertEqual(current_version(c), SCHEMA_VERSION)
+            columns = {row[1] for row in c.execute("PRAGMA table_info(items)")}
+            self.assertIn("body_cleared_at", columns)
+
+    def test_the_upgrade_keeps_the_rows_that_were_already_there(self):
+        """An upgrade that loses a message is worse than one that refuses."""
+        artifact = HERE / "schema-v1.sql"
+        path = Path(tempfile.mkdtemp()) / "v1.db"
+        with sqlite3.connect(path) as c:
+            c.executescript(artifact.read_text(encoding="utf-8"))
+            c.execute("INSERT INTO items(source_id, source, scope, event_at,"
+                      " body, state) VALUES"
+                      " ('m1','email','inbox','2026-08-01T00:00:00Z','kept','pending')")
+        with sqlite3.connect(path) as c:
+            migrate(c)
+            row = c.execute("SELECT body, body_cleared_at FROM items"
+                            " WHERE source_id='m1'").fetchone()
+        self.assertEqual(row[0], "kept")
+        self.assertIsNone(row[1], "an upgraded row was marked as cleared")
+
+    def test_the_v1_artifact_is_never_quietly_edited(self):
+        """It is frozen: a schema change goes in schema.sql and a migration."""
+        artifact = (HERE / "schema-v1.sql").read_text(encoding="utf-8")
+        self.assertIn("'schema_version', '1'", artifact)
+        self.assertNotIn("body_cleared_at", artifact)
 
     def test_the_shipped_schema_opens_a_store_that_the_shipped_schema_made(self):
         """The artifact under test is the one the recipe installs."""

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_migration.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_migration.py
@@ -258,6 +258,62 @@ class TestVersionGuardOnTheRealPath(unittest.TestCase):
         self.assertEqual(row[1], "b")
         self.assertIsNone(row[2])
 
+    def test_the_documented_command_actually_migrates(self):
+        """`docs/data-lifecycle.md` told people to run this file when it had no
+        entry point, so it did nothing and reported nothing — an instruction
+        that succeeds by being silent."""
+        v1 = (HERE / "schema-v1.sql").read_text(encoding="utf-8")
+        with sqlite3.connect(self.db) as c:
+            c.executescript("DROP TABLE IF EXISTS items;"
+                            "DROP TABLE IF EXISTS obligations;"
+                            "DROP TABLE IF EXISTS events;"
+                            "DROP TABLE IF EXISTS cursors;"
+                            "DROP TABLE IF EXISTS meta;")
+            c.executescript(v1)
+
+        proc = subprocess.run(
+            [sys.executable, str(HERE / "migrate.py")],
+            capture_output=True, text=True,
+            env={**os.environ, "HERMES_HOME": self.tmp})
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+        with sqlite3.connect(self.db) as c:
+            version = c.execute(
+                "SELECT value FROM meta WHERE key='schema_version'").fetchone()[0]
+            columns = {r[1] for r in c.execute("PRAGMA table_info(items)")}
+        self.assertEqual(int(version), 2)
+        self.assertIn("body_cleared_at", columns)
+
+    def test_the_check_flag_reports_without_changing(self):
+        v1 = (HERE / "schema-v1.sql").read_text(encoding="utf-8")
+        with sqlite3.connect(self.db) as c:
+            c.executescript("DROP TABLE IF EXISTS items;"
+                            "DROP TABLE IF EXISTS obligations;"
+                            "DROP TABLE IF EXISTS events;"
+                            "DROP TABLE IF EXISTS cursors;"
+                            "DROP TABLE IF EXISTS meta;")
+            c.executescript(v1)
+
+        proc = subprocess.run(
+            [sys.executable, str(HERE / "migrate.py"), "--check"],
+            capture_output=True, text=True,
+            env={**os.environ, "HERMES_HOME": self.tmp})
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(json.loads(proc.stdout)["schema_version"], 1)
+
+        with sqlite3.connect(self.db) as c:
+            columns = {r[1] for r in c.execute("PRAGMA table_info(items)")}
+        self.assertNotIn("body_cleared_at", columns,
+                         "--check changed the store")
+
+    def test_the_docs_do_not_promise_a_command_that_does_nothing(self):
+        docs = (HERE.parents[1] / "docs" / "data-lifecycle.md").read_text(
+            encoding="utf-8")
+        if "python3 migrate.py" in docs:
+            module = (HERE / "migrate.py").read_text(encoding="utf-8")
+            self.assertIn('if __name__ == "__main__"', module,
+                          "the docs name a command this module cannot run")
+
     def test_an_older_store_is_migrated_rather_than_refused(self):
         """The guard is one-sided: behind is upgraded, ahead is refused."""
         import migrate                        # noqa: E402

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_migration.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_migration.py
@@ -201,6 +201,63 @@ class TestVersionGuardOnTheRealPath(unittest.TestCase):
             migrate.refuse_if_from_the_future(c)      # must not raise
         self.assertTrue(self._db.ensure_store().is_file())
 
+    def test_a_versionless_v1_store_is_migrated_not_stamped_current(self):
+        """The baseline DDL must not vote on the version of a store it finds.
+
+        `schema.sql` carries `INSERT OR IGNORE ... ('schema_version', '2')`.
+        Run over a real v1 store whose version row is missing — a restored
+        backup, a hand-built table, any reason — it stamps 2 over a database
+        with none of the v2 columns, and `migrate` then sees its own version
+        and does nothing. The store ends up claiming a shape it does not have,
+        which surfaces as a missing column in whichever job touches it first.
+        """
+        import migrate                        # noqa: E402
+        v1 = (HERE / "schema-v1.sql").read_text(encoding="utf-8")
+        with sqlite3.connect(self.db) as c:
+            c.executescript("DROP TABLE IF EXISTS items;"
+                            "DROP TABLE IF EXISTS obligations;"
+                            "DROP TABLE IF EXISTS events;"
+                            "DROP TABLE IF EXISTS cursors;"
+                            "DROP TABLE IF EXISTS meta;")
+            c.executescript(v1)
+            c.execute("DELETE FROM meta WHERE key='schema_version'")
+
+        self._db.ensure_store()
+
+        with sqlite3.connect(self.db) as c:
+            version = c.execute(
+                "SELECT value FROM meta WHERE key='schema_version'").fetchone()[0]
+            columns = {r[1] for r in c.execute("PRAGMA table_info(items)")}
+        self.assertEqual(int(version), migrate.SCHEMA_VERSION)
+        self.assertIn("body_cleared_at", columns,
+                      "store reports the current version without the column "
+                      "that version added")
+
+    def test_a_versionless_store_keeps_the_rows_it_already_held(self):
+        """The repair must not be a rebuild: an unversioned store has data."""
+        v1 = (HERE / "schema-v1.sql").read_text(encoding="utf-8")
+        with sqlite3.connect(self.db) as c:
+            c.executescript("DROP TABLE IF EXISTS items;"
+                            "DROP TABLE IF EXISTS obligations;"
+                            "DROP TABLE IF EXISTS events;"
+                            "DROP TABLE IF EXISTS cursors;"
+                            "DROP TABLE IF EXISTS meta;")
+            c.executescript(v1)
+            c.execute("DELETE FROM meta WHERE key='schema_version'")
+            c.execute("INSERT INTO items(source_id, source, scope, event_at,"
+                      " sender, subject, body, state)"
+                      " VALUES ('m1','email','inbox','2026-01-01T00:00:00.000Z',"
+                      "         'Dana','s','b','pending')")
+
+        self._db.ensure_store()
+
+        with sqlite3.connect(self.db) as c:
+            row = c.execute("SELECT sender, body, body_cleared_at FROM items"
+                            " WHERE source_id='m1'").fetchone()
+        self.assertEqual(row[0], "Dana")
+        self.assertEqual(row[1], "b")
+        self.assertIsNone(row[2])
+
     def test_an_older_store_is_migrated_rather_than_refused(self):
         """The guard is one-sided: behind is upgraded, ahead is refused."""
         import migrate                        # noqa: E402

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_selectors.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_selectors.py
@@ -296,6 +296,10 @@ class TestTheDocumentedScheduleMatchesTheScript(unittest.TestCase):
     EXPECTED = {
         "intake": ("*/30 * * * *", "inbound-judging"),
         "review": ("0 */6 * * *", "obligation-review"),
+        # No skill: retention needs no judgment, clears bodies past the
+        # window, and gates the agent off. Naming one would advertise a
+        # capability the job never reaches.
+        "retention": ("0 2 * * *", None),
         "memory repair": ("0 3 * * *", "memory-repair"),
         "memory consolidation": ("0 4 * * *", "memory-consolidation"),
         "preference update": ("30 4 * * *", "preference-update"),
@@ -307,7 +311,11 @@ class TestTheDocumentedScheduleMatchesTheScript(unittest.TestCase):
         found = {}
         for name, schedule, skill in re.findall(
                 r'register\s+("?[a-z ]+"?)\s+"([^"]+)"\s+(\S+)', script):
-            found[name.strip('"')] = (schedule, skill)
+            # `register` takes an empty skill argument (`""`) for a job that
+            # never wakes the agent; read that as no skill rather than as a
+            # skill named `""`, which would then be looked for on disk.
+            found[name.strip('"')] = (schedule,
+                                      skill.strip('"') or None)
         return found
 
     def test_the_script_registers_exactly_the_documented_jobs(self):
@@ -335,6 +343,8 @@ class TestTheDocumentedScheduleMatchesTheScript(unittest.TestCase):
 
     def test_every_skill_the_schedule_names_is_shipped(self):
         for _, skill in self.EXPECTED.values():
+            if skill is None:
+                continue
             with self.subTest(skill=skill):
                 self.assertTrue((self.RECIPE / "profile" / "skills" / skill
                                  / "SKILL.md").is_file())

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/register-jobs.sh
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/register-jobs.sh
@@ -86,7 +86,11 @@ register() {
   local existing
   existing="$(job_id_for "$name")"
 
-  local args=(--name "$name" --deliver local --skill "$skill")
+  # A job that needs no judgment names no skill. Retention is one: it clears
+  # bodies past a fixed window and gates the agent off, so attaching a skill
+  # would advertise a capability the job never reaches.
+  local args=(--name "$name" --deliver local)
+  [[ -n "$skill" ]] && args+=(--skill "$skill")
   [[ -n "$script" ]] && args+=(--script "$script")
 
   if [[ -n "$existing" ]]; then
@@ -111,6 +115,13 @@ register "memory repair" "0 3 * * *" memory-repair "" \
 
 register "memory consolidation" "0 4 * * *" memory-consolidation "" \
   "Compact any memory page over the ceilings in the schema growth-control table. Compact, never truncate; preserve unresolved commitments and provenance."
+
+# Bodies age out daily, before the memory jobs run — so a consolidation pass
+# never reads text that was due to be cleared this morning.
+register "retention" "0 2 * * *" "" retention.py \
+  "The retention pre-step clears message bodies past the configured window and
+gates the agent off, so this prompt is never reached. It exists because the
+scheduler requires one."
 
 register "preference update" "30 4 * * *" preference-update "" \
   "Read the audit trail for user corrections since the last run and update the bounded preference policy. Never write to obligations."


### PR DESCRIPTION
## Related Issue

Related: #122
Prerequisite for: #130

## Description

Issue #122 requires configurable body retention, a readable export, a complete reset, and sender/domain/channel exclusion at ingest. Until now the recipe's README described all four in the future tense, which is the finding raised on #130: the connector was about to start storing real messages with none of the controls present. This PR lands them ahead of any connector, so the controls exist before the data does. #130 rebases onto this and stops claiming they are unimplemented.

**Retention.** `retention.py` runs daily at 02:00 and clears message bodies past a window — thirty days by default, `RETENTION_DAYS` to move it, refused outside 1..3650 because a zero would clear the message that arrived a minute ago and a negative one would put the cutoff in the future. What survives is the record: sender, subject, timestamp, addressing, the obligation and every event with its actor. So a month later you can still see that someone asked about the cutover on the third, that it ranked high, and that it was ignored on the fifth; you cannot re-read their words. `body_cleared_at` separates a body that was cleared from one that never existed — a join notice and a message somebody wrote both leave `body` NULL, and only one is a loss. That is a new column, so schema v2, applied in place and tested against `schema-v1.sql`: the frozen text of what actually shipped, rather than the current schema with a column removed.

**Exclusion.** Rules live in `workspace/exclusions.json` and are applied in `insert_items` rather than in any collector. That is the one function every writer passes through, so an excluded message is never written by the fixture loader, by the Slack collector when it lands, or by anything added afterwards, without each of them having to remember — and a new writer cannot quietly opt out. Filtering at display would leave the text on disk, which is no use to somebody excluding their doctor. Matching is exact and case-insensitive; a glob language here would exclude more than intended and say nothing about having done so. A drop is reported as a count, never as content.

**Export and reset.** `export_store.py` writes the store, the memory and the learned policy as Markdown beside JSON, omitting nothing, and shows a cleared body as `text cleared <timestamp>` rather than as an empty line. `reset.py --yes` removes those three together plus the collection bookkeeping, and exits non-zero if any part could not go, because a reset that half worked must not read as one that worked. It prints how to revoke the credential too, since that lives with the gateway rather than here and somebody withdrawing consent wants both.

The retention job registers with no skill: it needs no judgment and gates the agent off, so naming one would advertise a capability the job never reaches. `register` now accepts an empty skill argument for that case.

Everything is exercised on the fixture corpus, which is how it is tested, and applies unchanged to real messages when a connector lands.

## Verification

- [x] `python3 scripts/check_license_headers.py --check` — 428 files, all headed
- [x] `python3 scripts/check_label_taxonomy.py --check` — not applicable, no governance metadata changed
- [x] `git diff --check`
- [x] Recipe suite: 300 tests, `OK`, on macOS and on Linux with Python 3.12.3
- [x] Installed the profile on Linux under Hermes 0.19.0: six jobs registered with the documented schedules, `hermes profile update` run, six jobs still present with identical ids
- [x] Ran the controls end to end against the fixture corpus on Linux: retention cleared 8 bodies and kept every subject and metadata field; export wrote 8 messages and 5 memory pages with the cleared bodies marked; reset left an empty workspace
- [x] Exclusion verified on a real ingest rather than in isolation: same fixtures, one rule, 8 items becomes 6, no remaining row or body mentions the excluded sender, and stderr reports `exclusions: 2 message(s) not stored`
- [x] Each new claim in the README and in `docs/data-lifecycle.md` was checked by breaking the behaviour it describes and confirming the assertion turns red

## Documentation Writer Review

- [x] Documentation writer review completed for the final changes
- Result: `docs-updated`
- Evidence or justification: `examples/recipes/nvidia/memory-driven-chief-of-staff/README.md` — the Privacy section moves from future to present tense and the job table, file map and counts now include retention; `examples/recipes/nvidia/memory-driven-chief-of-staff/docs/data-lifecycle.md` — new, holds the commands, the rules file format and the exact boundaries. The README's job-survival line now states Hermes 0.19.0, which is the version this round was measured on.
- Reviewer: @rebelle5868
- [x] Changed user-facing text follows the writing guide and controlled-word list.
- [x] A public contributor can understand the changed text without internal company context.
- [x] I reviewed any agent-generated text before submission.

## Release And Compliance

- [x] No secrets or credentials are included, including API keys, access tokens, passwords, local `.env` files, private certificates, or token caches.
- [x] No nonpublic project names, environment names, hostnames, URLs, ticket identifiers, workspace paths, logs, screenshots, or configuration values are included.
- [x] Third-party dependency changes are reflected in `THIRD-PARTY-NOTICES` — none; standard library only.
- [x] Public content uses sanitized examples and placeholders instead of private values.
- [x] I added my DCO sign-off declaration to this pull request description.

Signed-off-by: Xuan Wu <xuwu@nvidia.com>


