### PR TITLE
docs: streamline repository front door

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,8 +238,9 @@ git diff --cached --check
 These commands do not replace example-specific verification. For each changed
 example, run the checks that its README specifies.
 
-Catalog pull requests include a preview artifact. Merges to `main` deploy
-automatically through GitHub Pages. Maintainers can use the
+Catalog pull requests that trigger the Pages workflow include a preview
+artifact. Matching changes merged to `main` deploy automatically through
+GitHub Pages. Maintainers can use the
 [catalog deployment runbook](docs/catalog-deployment.md) for setup and
 verification.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,6 +238,11 @@ git diff --cached --check
 These commands do not replace example-specific verification. For each changed
 example, run the checks that its README specifies.
 
+Catalog pull requests include a preview artifact. Merges to `main` deploy
+automatically through GitHub Pages. Maintainers can use the
+[catalog deployment runbook](docs/catalog-deployment.md) for setup and
+verification.
+
 Run the documented setup, syntax, unit, configuration, and teardown-safe checks.
 A stable check gives the same result when its inputs do not change. A
 teardown-safe check does not leave services or temporary resources active.

--- a/README.md
+++ b/README.md
@@ -3,19 +3,9 @@
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue)](LICENSE)
 [![Security Policy](https://img.shields.io/badge/Security-Report%20a%20Vulnerability-red)](SECURITY.md)
 
-## Table of Contents
-
-- [Reference Examples](#reference-examples)
-- [Getting Started](#getting-started)
-- [Requirements](#requirements)
-- [Catalog Deployment](#catalog-deployment)
-- [Contributing](#contributing)
-- [Security](#security)
-- [Support](#support)
-- [Governance And Maintainers](#governance-and-maintainers)
-- [License](#license)
-
 NemoClaw Community is a collection of examples that showcase NemoClaw blueprints for constrained, inspectable agent workflows.
+
+[**Browse examples**](https://nvidia.github.io/nemoclaw-community/) · [**Contribute an example**](CONTRIBUTING.md#add-a-new-example)
 
 NemoClaw is the blueprint layer for composing three things into a repeatable agent system:
 
@@ -23,64 +13,30 @@ NemoClaw is the blueprint layer for composing three things into a repeatable age
 - **Harness** — the agent runtime, skills, bridges, state, and workflow-specific behavior.
 - **OpenShell** — the sandbox, gateway, policy, provider, and networking substrate that runs the harness with explicit boundaries.
 
-The examples in this repository demonstrate complete blueprint patterns: they show how a model is wired to a harness, how the harness is packaged with skills and integrations, and how OpenShell constrains and runs the resulting agent.
+Recipes and demos show how a model, harness, and OpenShell come together. The catalog also includes launchables and developer tools.
 
 ## Reference Examples
 
-**[Browse examples on the web](https://nvidia.github.io/nemoclaw-community/)**
+Examples are organized as reusable NVIDIA and partner recipes, community
+recipes, NVIDIA field demos, environment launchables, and standalone developer
+tools. Browse the [source example catalog](examples/README.md) to choose an
+example.
 
-Examples are organized as reusable NVIDIA and partner recipes, NVIDIA field
-demos, environment launchables, and standalone developer tools. Browse the
-[source example catalog](examples/README.md) to choose an example and follow
-its independent setup and verification guide.
+Each example has its own prerequisites, credentials, setup, and limitations.
+Review the example README before setup.
 
 Additional NemoClaw examples are available in
 [brevdev/nemoclaw-demos](https://github.com/brevdev/nemoclaw-demos).
 
 ## Getting Started
 
-Choose an example from the [example catalog](examples/README.md) and follow its
-guide. To run an example from this repository, clone the repo first:
+Choose an example and follow its README. To run an example from this repository,
+clone the repo first:
 
 ```bash
 git clone https://github.com/NVIDIA/nemoclaw-community.git
 cd nemoclaw-community
 ```
-
-For examples maintained outside this repository, see [brevdev/nemoclaw-demos](https://github.com/brevdev/nemoclaw-demos). Each example documents its own host requirements, credentials, setup steps, and OpenShell policy details.
-
-## Requirements
-
-- Linux host with Docker or a compatible container runtime
-- OpenShell CLI and gateway
-- Access to an OpenAI-compatible inference endpoint
-- Optional integration credentials for Slack, Microsoft Graph/Outlook, GitHub live reads, and source ETL mirrors
-
-This project will download and install additional third-party open source software projects. Review the license terms of these open source projects before use. See [THIRD-PARTY-NOTICES](THIRD-PARTY-NOTICES) for the repository inventory.
-
-## Catalog Deployment
-
-The [Pages workflow](.github/workflows/pages.yml) validates the static catalog
-and local links. Pull requests attach an `example-catalog-preview` artifact and
-do not deploy. A push to `main`, or a manual run from `main`, packages `site/`
-and deploys it with the `github-pages` environment.
-
-Before the first deployment, a repository administrator must complete these
-GitHub settings:
-
-1. In **Settings > Pages**, select **GitHub Actions** as the source.
-2. Create or open the **github-pages** environment in **Settings > Environments**.
-3. Restrict its deployment branches and tags to `main`.
-
-Do not add a personal access token to enable Pages. After the settings are in
-place, merge the catalog change or run **Example catalog Pages** from `main` in
-the Actions tab. If an earlier deployment failed because Pages was disabled,
-rerun that workflow from `main`.
-
-After deployment, verify the HTTPS page, the stylesheet and logo under the
-`/nemoclaw-community/` project path, the category links, and the example README
-links. Then set the repository website field to
-`https://nvidia.github.io/nemoclaw-community/`.
 
 ## Contributing
 
@@ -100,6 +56,8 @@ See [SUPPORT.md](SUPPORT.md) for support channels and expectations.
 - Maintainers: [MAINTAINERS.md](MAINTAINERS.md)
 - Code owners: [.github/CODEOWNERS](.github/CODEOWNERS)
 
-## License
+## License And Notices
 
 This project is licensed under the Apache 2.0 License. See [LICENSE](LICENSE) for details.
+
+Some examples download additional third-party software. See [THIRD-PARTY-NOTICES](THIRD-PARTY-NOTICES).

--- a/docs/catalog-deployment.md
+++ b/docs/catalog-deployment.md
@@ -1,0 +1,35 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Catalog Deployment
+
+The [Pages workflow](../.github/workflows/pages.yml) validates the static catalog
+and local links. Pull requests attach an `example-catalog-preview` artifact and
+do not deploy. A push to `main`, or a manual run from `main`, packages `site/`
+and deploys it with the `github-pages` environment.
+
+## Enable GitHub Pages
+
+Before the first deployment, a repository administrator must complete these
+GitHub settings:
+
+1. In **Settings > Pages**, select **GitHub Actions** as the source.
+2. Create or open the **github-pages** environment in **Settings > Environments**.
+3. Restrict its deployment branches and tags to `main`.
+
+Do not add a personal access token to enable Pages.
+
+## Deploy The Catalog
+
+After the settings are in place, merge the catalog change or run **Example
+catalog Pages** from `main` in the Actions tab. If an earlier deployment failed
+because Pages was disabled, rerun that workflow from `main`.
+
+## Verify The Deployment
+
+After deployment, verify the HTTPS page, the stylesheet and logo under the
+`/nemoclaw-community/` project path, the category links, and the example README
+links. Then set the repository website field to
+`https://nvidia.github.io/nemoclaw-community/`.

--- a/docs/catalog-deployment.md
+++ b/docs/catalog-deployment.md
@@ -6,9 +6,10 @@
 # Catalog Deployment
 
 The [Pages workflow](../.github/workflows/pages.yml) validates the static catalog
-and local links. Pull requests attach an `example-catalog-preview` artifact and
-do not deploy. A push to `main`, or a manual run from `main`, packages `site/`
-and deploys it with the `github-pages` environment.
+and local links when a watched catalog path changes. Matching pull requests
+attach an `example-catalog-preview` artifact and do not deploy. A matching push
+to `main`, or a manual run from `main`, packages `site/` and deploys it with the
+`github-pages` environment.
 
 ## Enable GitHub Pages
 

--- a/scripts/check_catalog_parity.py
+++ b/scripts/check_catalog_parity.py
@@ -38,7 +38,7 @@ CATEGORY_HEADERS: dict[str, tuple[str, ...]] = {
 REQUIRED_CARD_FIELDS: set[str] = {"Fit"}
 REQUIRED_POLICY_LINKS: set[str] = {
     "https://github.com/NVIDIA/nemoclaw-community",
-    "https://github.com/NVIDIA/nemoclaw-community/blob/main/CONTRIBUTING.md",
+    "https://github.com/NVIDIA/nemoclaw-community/blob/main/CONTRIBUTING.md#add-a-new-example",
     "https://github.com/NVIDIA/nemoclaw-community/blob/main/SUPPORT.md",
     "https://github.com/NVIDIA/nemoclaw-community/blob/main/SECURITY.md",
     "https://github.com/brevdev/nemoclaw-demos",

--- a/site/index.html
+++ b/site/index.html
@@ -49,7 +49,7 @@
                 <a class="button button-primary" href="#catalog">Browse examples <span aria-hidden="true">↓</span></a>
                 <a
                   class="button button-secondary"
-                  href="https://github.com/NVIDIA/nemoclaw-community/blob/main/CONTRIBUTING.md"
+                  href="https://github.com/NVIDIA/nemoclaw-community/blob/main/CONTRIBUTING.md#add-a-new-example"
                 >
                   Contribute an example
                 </a>


### PR DESCRIPTION
## Related Issue

Closes #139

Follow-up to #131. Parent epic: NVIDIA/NemoClaw#8498.

## Description

- Streamline the root README around two primary actions: browse examples and contribute an example.
- Keep requirements in each example README and move catalog deployment administration into a maintainer runbook.
- Route contribution CTAs directly to the new-example guidance and update the catalog validator to enforce that destination.
- Preserve the existing catalog design, cards, categories, and example content.

## Verification

- [x] `python3 scripts/check_license_headers.py --check`
- [x] `python3 scripts/check_catalog_parity.py --check`
- [x] `python3 -m unittest discover -s scripts/tests -p "test_catalog_parity.py"`
- [x] `git diff --check origin/main...HEAD`
- [x] Label taxonomy check not required; governance metadata did not change.
- [x] Example-specific runtime checks not required; no example behavior changed.

## Documentation Writer Review

- [x] Documentation writer review completed for the final changes
- Result: `docs-updated`
- Evidence: `README.md`, `CONTRIBUTING.md`, `docs/catalog-deployment.md`, and `site/index.html`
- Reviewer: Will Curran
- [x] Changed user-facing text follows `WRITING.md` and the controlled-word guidance.
- [x] A public contributor can understand the changed text without internal company context.
- [x] I reviewed the agent-generated text before submission.

## Release And Compliance

- [x] No secrets or credentials are included.
- [x] No nonpublic project or environment details are included.
- [x] No third-party dependencies changed.
- [x] Public content uses sanitized examples and placeholders.
- [x] I added my DCO sign-off declaration to this pull request description.

Signed-off-by: Will Curran <wcurran@nvidia.com>