### PR TITLE
feat(memory-driven-chief-of-staff): read the user's mailbox into the intake

### DIFF
--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -527,9 +527,14 @@ Three things about the connectors themselves:
 - Attachments are not fetched. The collector stores a file-sharing message's
   text and never requests the file behind it.
 - For Microsoft Graph, an item deleted at the source is tombstoned locally and
-  its body cleared at once, because the delta query reports deletions
-  explicitly. The row stays: obligations and events hang off it, and removing
-  it would break the record of why something was ranked.
+  its body cleared at once. The delta query reports that a message left the
+  folder, which is not the same as reporting a deletion — filing it in Archive
+  reads identically — so the collector asks a second question, by
+  `internetMessageId`, and only a message the mailbox no longer holds anywhere
+  is tombstoned. If that question cannot be answered the round stops and the
+  next one asks again, rather than advancing past a removal it did not
+  resolve. The row stays: obligations and events hang off it, and removing it
+  would break the record of why something was ranked.
 - For Slack, that guarantee is not available. A deleted message stops appearing
   in `conversations.history`, and its absence from a bounded, paginated read
   cannot be told apart from it lying outside the window. Reliable notice

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -248,7 +248,7 @@ cd ../..
 test "$fail" -eq 0
 ```
 
-Expected result: every file ends with `OK`, the thirteen files report 505 tests in
+Expected result: every file ends with `OK`, the thirteen files report 562 tests in
 total, and the last line is `failed=0`. Do not use `|| break` here; a `for`
 loop reports the status of its last command, so a failing test would still
 leave the loop exiting `0`.
@@ -387,12 +387,14 @@ script's output, so a gate printed anywhere else is ignored and the model
 wakes. A test asserts the gate exactly the way the scheduler parses it, rather
 than looking for the string somewhere in the output.
 
-The intake pre-step also runs whichever collectors are present. The Slack
-one ships with the recipe and reports `{"unconfigured": true}` until
-`scripts/setup-slack.sh` has run, exiting zero so an idle tick still costs
-nothing. A Graph collector is not here yet, so it is reported as
-`"absent": true`. Either way the tick carries on with whatever the store
-already holds.
+The intake pre-step also runs whichever collectors are present. Both ship
+with the recipe, and each reports `{"unconfigured": true}` until its setup
+script has run — `scripts/setup-slack.sh` or `scripts/setup-graph.sh` —
+exiting zero so an idle tick still costs nothing. They run in the same tick
+and independently: a mailbox credential that has expired does not stop Slack
+being read, and neither can hold the tick open, because each is bounded in
+requests and in the time it may spend waiting. Either way the tick carries on
+with whatever the store already holds.
 
 **Registering is not starting.** Under the builtin scheduler the jobs fire
 only while a gateway is serving the profile, and starting one takes two steps
@@ -533,7 +535,10 @@ Three things about the connectors themselves:
   `internetMessageId`, and only a message the mailbox no longer holds anywhere
   is tombstoned. If that question cannot be answered the round stops and the
   next one asks again, rather than advancing past a removal it did not
-  resolve. The row stays: obligations and events hang off it, and removing it
+  resolve. If there is no identity to ask about — a row collected before the
+  connector stored one — the removal is left unresolved and counted, never
+  guessed: reading an absent identity as a deletion cleared the body of a
+  message that had only been filed away. The row stays: obligations and events hang off it, and removing it
   would break the record of why something was ranked.
 - For Slack, that guarantee is not available. A deleted message stops appearing
   in `conversations.history`, and its absence from a bounded, paginated read
@@ -600,6 +605,49 @@ Until this is set up the collector still runs — it ships with the recipe — b
 reports `{"unconfigured": true}` and exits zero, so the schedule runs over
 whatever is already in the store and an idle tick still costs nothing. That is
 a supported state, not a broken one.
+
+### Connecting a mailbox
+
+Microsoft Graph is the other collector, and it is read-only: the messages in
+your Inbox. It never sends, never replies, and never touches a draft.
+
+```bash
+bash scripts/setup-graph.sh
+```
+
+Run it on the host, not in the sandbox, for the same reason as Slack — it
+needs `openshell`. It walks you through Microsoft's device-code flow: a code
+to type into a browser on any machine, and a consent your tenant may require
+an administrator to approve. Full walkthrough:
+[`docs/set-up-graph.md`](docs/set-up-graph.md).
+
+**The first synchronisation asks how far back to read.** The default is seven
+days; the prompt offers seven, fourteen or thirty, and takes any number you
+type instead. `GRAPH_BACKFILL_DAYS` sets it without the prompt. The window
+applies once — after the first round the collector tracks changes rather than
+re-reading, so a larger number costs a slower first sync and nothing after
+that.
+
+Two things are deliberate here as well. The scopes are **named** — `Mail.Read`,
+`User.Read`, `offline_access` — rather than `.default`, which would return
+whatever the application has already been granted and make the permission the
+recipe actually holds unknowable from the code. And `login.microsoftonline.com`
+is **not** in the sandbox's egress policy: the token exchange and every refresh
+belong to the gateway, so the collector holds a placeholder it cannot spend and
+cannot reach the endpoint that would turn it into a real one.
+
+Both connectors can be set up, or either one alone. They write into the same
+store and run in the same tick, independently — see [When a collector
+fails](#when-a-collector-fails) for what happens when one of them cannot.
+
+**A person who reaches you on both gets two pages.** Slack identifies people
+by user id and mail by address, and nothing links the two: a shared display
+name is not evidence, and the whole reason this recipe keeps a stable identity
+per sender is that guessing from a name puts two people on one page. So one
+colleague can hold a page for their Slack half and another for their mail
+half, and the selector reports the pair under `shared_display_name` so the
+agent can say so on each. Linking them on the user's word, rather than on a
+name, is not in this change.
 
 ### When a collector fails
 
@@ -700,12 +748,16 @@ profile home, and they also leave a Python bytecode cache beside the scripts —
 see [Cleanup](#cleanup). The six skill files a runtime loads add nothing to
 that.
 
-The collector reaches exactly one host, `slack.com`, and only for reads. That
-is declared in `providers/slack-user.yaml` as `access: read-only` with
-`enforcement: enforce`, so the egress proxy refuses anything else — the
-property is enforced by policy rather than promised by prose. The credential
-never enters the sandbox: the gateway holds it and substitutes it at the
-boundary, so the collector handles a placeholder it cannot spend.
+The collectors reach two hosts between them, `slack.com` and
+`graph.microsoft.com`, and only for reads. Each is declared in its provider
+profile — `providers/slack-user.yaml` and `providers/graph-user.yaml` — as
+`access: read-only` with `enforcement: enforce`, so the egress proxy refuses
+anything else, and refuses the other collector's host to each of them. The
+property is enforced by policy rather than promised by prose. Neither
+credential enters the sandbox: the gateway holds both and substitutes them at
+the boundary, so a collector handles a placeholder it cannot spend.
+`login.microsoftonline.com` is deliberately absent from the sandbox's
+allow-list — the token exchange is the gateway's, not the collector's.
 
 The scheduled path does reach one. A job that wakes runs an agent turn, and the
 runtime calls whichever inference provider it is configured for, over its own
@@ -713,9 +765,10 @@ egress path — the recipe holds no credential and opens no connection itself.
 A job that does not wake makes no call at all.
 
 Egress to a message source is here, and it is narrow: the Slack collector
-reaches `slack.com` and nothing else, declared in the provider profile at
-`access: read-only` with `enforcement: enforce`, so a write is refused at the
-boundary rather than caught by a test. The credential it uses is held by the
+reaches `slack.com` and nothing else, the Graph collector reaches
+`graph.microsoft.com` and nothing else, each declared in its own provider
+profile at `access: read-only` with `enforcement: enforce`, so a write is
+refused at the boundary rather than caught by a test. The credential it uses is held by the
 gateway and substituted there — see
 [Connecting Slack](#connecting-slack).
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -90,6 +90,8 @@ those two apart.
 | `profile/scripts/load_fixtures.py` | Replays the fixtures through the real ingest path |
 | `profile/scripts/walkthrough.py` | The fixture walkthrough, end to end, with no credentials and no model |
 | `profile/scripts/select_intake.py` | The intake job's pre-step: what to judge, and whether to wake the model at all |
+| `profile/scripts/ingest_graph.py` | The mailbox collector: a delta synchronisation, resumable, with deletions reconciled |
+| `profile/scripts/ingest_slack.py` | The Slack collector: bounded conversation coverage, per-thread watermarks |
 | `profile/scripts/select_review.py` | The review job's pre-step: the stalest open obligations, oldest review first |
 | `profile/scripts/select_memory.py` | The memory-writing job's pre-step: recurring correspondents, and whether the attention pages have gone stale |
 | `profile/scripts/retention.py` | The retention job: clears message bodies past the window, keeps the record |
@@ -102,8 +104,9 @@ those two apart.
 | `profile/skills/` | Six skills: judging, review, memory writing, repair, consolidation, preference update. Retention needs none — it clears bodies and never wakes the agent |
 | `fixtures/` | Eight synthetic messages, a seed memory, and one recorded model turn |
 
-Slack is connected through `scripts/setup-slack.sh`. Until a connector is set
-up, the scheduled jobs judge and re-judge whatever the store already holds.
+Slack is connected through `scripts/setup-slack.sh` and a mailbox through
+`scripts/setup-graph.sh`. Either can be set up alone; with neither, the
+scheduled jobs judge and re-judge whatever the store already holds.
 
 ## Requirements
 
@@ -245,7 +248,7 @@ cd ../..
 test "$fail" -eq 0
 ```
 
-Expected result: every file ends with `OK`, the twelve files report 505 tests in
+Expected result: every file ends with `OK`, the thirteen files report 505 tests in
 total, and the last line is `failed=0`. Do not use `|| break` here; a `for`
 loop reports the status of its last command, so a failing test would still
 leave the loop exiting `0`.
@@ -264,6 +267,7 @@ leave the loop exiting `0`.
 | What the memory job hands the agent: who is worth a page, stable identity across namesakes and renames, quiet days costing nothing, and corrections counted once | `tests/test_select_memory.py` |
 | Retention, exclusion, export and reset | `tests/test_lifecycle.py` |
 | The Slack collector: watermarks, partial failure, scope probing, thread discovery and rotation, the credential never reaching a stream, and the lifecycle controls applying to what it writes | `tests/test_ingest_slack.py` |
+| The mailbox collector: delta synchronisation, resumption, deletions reconciled, the window bound, and the credential never reaching a stream | `tests/test_ingest_graph.py` |
 
 Four points are worth calling out.
 
@@ -522,9 +526,10 @@ Three things about the connectors themselves:
 
 - Attachments are not fetched. The collector stores a file-sharing message's
   text and never requests the file behind it.
-- For Microsoft Graph, an item deleted at the source will be tombstoned locally
-  and its body cleared at once, because the delta query reports deletions
-  explicitly.
+- For Microsoft Graph, an item deleted at the source is tombstoned locally and
+  its body cleared at once, because the delta query reports deletions
+  explicitly. The row stays: obligations and events hang off it, and removing
+  it would break the record of why something was ranked.
 - For Slack, that guarantee is not available. A deleted message stops appearing
   in `conversations.history`, and its absence from a bounded, paginated read
   cannot be told apart from it lying outside the window. Reliable notice
@@ -606,9 +611,7 @@ stderr is captured by the scheduler into the job log, where something
 transient becomes a file that outlives the token in it.
 
 So both get the same sanitized triple — which collector, what exit code, which
-error class. After the connector phase supplies a collector, run that collector
-directly to read what it actually said. For example, once `ingest_graph.py` is
-installed:
+error class. To read what a collector actually said, run it directly:
 
 ```bash
 HERMES_HOME="/path/to/profile" python3 profile/scripts/ingest_graph.py

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -640,14 +640,16 @@ Both connectors can be set up, or either one alone. They write into the same
 store and run in the same tick, independently — see [When a collector
 fails](#when-a-collector-fails) for what happens when one of them cannot.
 
-**A person who reaches you on both gets two pages.** Slack identifies people
-by user id and mail by address, and nothing links the two: a shared display
-name is not evidence, and the whole reason this recipe keeps a stable identity
-per sender is that guessing from a name puts two people on one page. So one
-colleague can hold a page for their Slack half and another for their mail
-half, and the selector reports the pair under `shared_display_name` so the
-agent can say so on each. Linking them on the user's word, rather than on a
-name, is not in this change.
+**A person gets a page per source they reach you from.** Slack identifies
+people by user id and mail by address; nothing links them, and nothing should
+on the evidence available — a shared display name is not evidence, and the
+reason this recipe keeps a stable identity per sender at all is that guessing
+from a name puts two people on one page. So a colleague who writes from two
+places holds a page for each, and the selector reports them together under
+`shared_display_name` so the agent can say as much on both. That is a
+per-source split, not a Slack-and-mail one: a third connector would add a
+third page for the same person. Linking identities on the user's word rather
+than on a name is not in this change.
 
 ### When a collector fails
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -248,7 +248,7 @@ cd ../..
 test "$fail" -eq 0
 ```
 
-Expected result: every file ends with `OK`, the thirteen files report 562 tests in
+Expected result: every file ends with `OK`, the thirteen files report 564 tests in
 total, and the last line is `failed=0`. Do not use `|| break` here; a `for`
 loop reports the status of its last command, so a failing test would still
 leave the loop exiting `0`.

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/docs/data-lifecycle.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/docs/data-lifecycle.md
@@ -170,7 +170,9 @@ its body cleared at once. What the delta query reports is that a message left
 the tracked folder; a deletion and a move to Archive are indistinguishable in
 it, so the collector confirms by asking whether the mailbox still holds the
 message anywhere. A removal it cannot resolve stops the round instead of being
-guessed either way.
+guessed either way, and one with no identity to ask about — a row from before
+the connector stored one — is reported as unresolved rather than treated as a
+deletion.
 
 Slack, which is the connector that ships, offers no such notice. A deleted
 message stops appearing in

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/docs/data-lifecycle.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/docs/data-lifecycle.md
@@ -166,8 +166,11 @@ that felt complete.
 ## Where the guarantee is weaker
 
 For Microsoft Graph, an item deleted at the source is tombstoned locally and
-its body cleared at once, because the delta query reports deletions
-explicitly.
+its body cleared at once. What the delta query reports is that a message left
+the tracked folder; a deletion and a move to Archive are indistinguishable in
+it, so the collector confirms by asking whether the mailbox still holds the
+message anywhere. A removal it cannot resolve stops the round instead of being
+guessed either way.
 
 Slack, which is the connector that ships, offers no such notice. A deleted
 message stops appearing in

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/docs/set-up-graph.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/docs/set-up-graph.md
@@ -1,0 +1,156 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Connecting a mailbox
+
+Fifteen minutes, most of it waiting for a sign-in page. What you end up with is
+a credential the sandbox never holds and a collector that reads your inbox and
+writes nothing back to it.
+
+## What holds the credential
+
+The OpenShell gateway does, and it renews it. The sandbox receives
+`openshell:resolve:env:…` — sixty-odd bytes of placeholder — which the gateway
+substitutes at the egress boundary. A collector that leaked its environment
+would leak a string that is useless anywhere else.
+
+This is the arrangement [#122](https://github.com/NVIDIA/nemoclaw-community/issues/122)
+decision 1 settled on. The alternative was MSAL-managed renewal with an
+encrypted token cache, which keeps a recipe self-contained at the cost of the
+refresh token living inside the sandbox — where an encrypted cache is a
+mitigation rather than a boundary.
+
+## The one thing that goes wrong
+
+An application permission instead of a delegated one. `Mail.Read` exists in
+both flavours, and the application flavour reads every mailbox in the tenant.
+The collector refuses it — a token whose `/me` has no address is not a
+delegated token — but it is worth not requesting in the first place.
+
+## Where each step runs
+
+| Step | Where |
+| --- | --- |
+| Register the application | Your browser, at the Entra admin centre |
+| `scripts/setup-graph.sh` | The **host**, where `openshell` is |
+| Signing in with the device code | Any machine you trust |
+| `ingest_graph.py` | The **sandbox**, where `hermes` is |
+
+## 1. Encrypted storage
+
+The setup script checks this before anything else, and it is the same check
+the Slack connector uses. See [encrypted-storage.md](encrypted-storage.md) for
+what it can and cannot verify, and why the path has to be named rather than
+guessed.
+
+## 2. Register an application
+
+At the Microsoft Entra admin centre, register an application with:
+
+- **Delegated** `Mail.Read` and `offline_access`. Delegated, not application.
+- **Public client flows enabled** — the device-code flow needs it, and it is
+  off by default.
+- No redirect URI. There is no browser on the machine running the collector,
+  which is why this uses device code rather than a redirect.
+
+Take the application (client) id and the directory (tenant) id.
+
+## 3. Run the setup
+
+On the host:
+
+```bash
+cd <this recipe>
+GRAPH_CLIENT_ID=<client id> GRAPH_TENANT_ID=<tenant id> \
+    SANDBOX_STORAGE_PATH=<path> bash scripts/setup-graph.sh
+```
+
+It prints a short code and an address. Open the address anywhere you trust,
+enter the code, approve. The terminal waits; nothing is stored until you
+finish, and the refresh token that comes back goes to the gateway rather than
+into the sandbox.
+
+## 4. Choose how far back the first synchronisation reaches
+
+Seven days by default. Fourteen and thirty are the other usual answers, and any
+number from 1 to 3650 works:
+
+```bash
+ENV=$(hermes -p <profile> config env-path)
+echo 'GRAPH_BACKFILL_DAYS=14' >> "$ENV"
+```
+
+That file is the supported path and the only one that persists: `hermes cron
+create` takes no environment, so a variable exported in a shell reaches the run
+in front of you and nothing scheduled.
+
+**The window decides where the first round starts, and nothing else.** The
+delta cursor it produces carries no filter, so once the baseline exists every
+later change in the folder is reported — including an older message being
+deleted. Choosing seven days is choosing where to begin, not choosing to be
+told less afterwards.
+
+A wider window costs a longer first synchronisation. Each tick spends a bounded
+number of requests and saves its place, so a first round over thirty days
+finishes across several ticks rather than in one.
+
+## 5. Verify
+
+Inside the sandbox:
+
+```bash
+python3 <profile home>/scripts/ingest_graph.py
+```
+
+A configured mailbox reports what it did:
+
+```json
+{"source": "email", "scope": "inbox", "added": 42, "removed": 0,
+ "pages": 3, "resumed": false, "complete": true, "synchronised": true,
+ "backfill_days": 7}
+```
+
+`complete: false` with `synchronised: false` means the first round is still
+running and will continue on the next tick — expected on a wide window, not a
+failure. `resumed: true` says this tick continued one.
+
+### When it fails
+
+| Exit | Means |
+| --- | --- |
+| `0` | Collected, or never configured. Never configured is a state, not a fault |
+| `1` | Something else; the message says what |
+| `2` | The credential is missing, wrong, or was refused |
+| `3` | Rate limited before the work finished |
+| `4` | The token works but is not a delegated mailbox token |
+
+## What the schedule does with it
+
+The intake job runs the collector as its pre-step, every thirty minutes. A tick
+that collects nothing new emits the wake gate and costs no model call.
+
+## Deletions
+
+Graph reports them, so this acts on them. A message deleted in the mailbox is
+tombstoned locally on the next synchronisation and its body cleared at once,
+rather than ageing out on the retention pass a month later. The row itself
+stays: obligations and events hang off it, and removing it would break the
+record of why something was ranked or ignored.
+
+Slack has no equivalent on the surface this recipe reads, which is why the two
+connectors differ here — see [data-lifecycle.md](data-lifecycle.md).
+
+## Revoking
+
+Remove the application's consent in your Microsoft account, then:
+
+```bash
+openshell sandbox provider detach <sandbox> <provider>
+openshell provider delete <provider>
+```
+
+That ends collection. It does not remove what was already collected: the
+messages read up to that point are still in the store. `reset.py --yes` removes
+them, and `export_store.py` writes out a copy first if you want one — both in
+[data-lifecycle.md](data-lifecycle.md). Revoking and erasing are separate
+actions, and doing one is easy to mistake for both.

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/fixtures/graph_messages.json
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/fixtures/graph_messages.json
@@ -10,66 +10,147 @@
       "id": "msg-priorities-match",
       "receivedDateTime": "2026-08-18T08:10:00Z",
       "subject": "Billing migration — need the cutover window confirmed",
-      "from": {"emailAddress": {"name": "Dana Okoro", "address": "dana.okoro@example.com"}},
-      "toRecipients": [{"emailAddress": {"address": "avery.chen@example.com"}}],
+      "from": {
+        "emailAddress": {
+          "name": "Dana Okoro",
+          "address": "dana.okoro@example.com"
+        }
+      },
+      "toRecipients": [
+        {
+          "emailAddress": {
+            "address": "avery.chen@example.com"
+          }
+        }
+      ],
       "ccRecipients": [],
-      "body": {"contentType": "text", "content": "The vendor offered Sept 2 or Sept 9 for the billing cutover. I need one of them confirmed before I can book the freeze. Can you decide by Thursday?"},
+      "body": {
+        "contentType": "text",
+        "content": "The vendor offered Sept 2 or Sept 9 for the billing cutover. I need one of them confirmed before I can book the freeze. Can you decide by Thursday?"
+      },
       "parentFolderId": "inbox",
       "conversationId": "conv-billing-01",
       "webLink": "https://outlook.example.com/mail/id/msg-priorities-match",
-      "isRead": false
+      "isRead": false,
+      "internetMessageId": "<msg-priorities-match@example.com>"
     },
     {
       "id": "msg-urgent-not-chosen",
       "receivedDateTime": "2026-08-18T07:55:00Z",
       "subject": "URGENT: expense policy attestation closes Friday",
-      "from": {"emailAddress": {"name": "Finance Operations", "address": "finance-ops@example.com"}},
-      "toRecipients": [{"emailAddress": {"address": "avery.chen@example.com"}}],
+      "from": {
+        "emailAddress": {
+          "name": "Finance Operations",
+          "address": "finance-ops@example.com"
+        }
+      },
+      "toRecipients": [
+        {
+          "emailAddress": {
+            "address": "avery.chen@example.com"
+          }
+        }
+      ],
       "ccRecipients": [],
-      "body": {"contentType": "text", "content": "All staff must complete the annual expense policy attestation before Friday 17:00. This is mandatory and non-negotiable. Unattested accounts will be suspended."},
+      "body": {
+        "contentType": "text",
+        "content": "All staff must complete the annual expense policy attestation before Friday 17:00. This is mandatory and non-negotiable. Unattested accounts will be suspended."
+      },
       "parentFolderId": "inbox",
       "conversationId": "conv-attestation-01",
       "webLink": "https://outlook.example.com/mail/id/msg-urgent-not-chosen",
-      "isRead": false
+      "isRead": false,
+      "internetMessageId": "<msg-urgent-not-chosen@example.com>"
     },
     {
       "id": "msg-quiet-decay",
       "receivedDateTime": "2026-08-11T14:30:00Z",
       "subject": "Thoughts on the onboarding revamp doc?",
-      "from": {"emailAddress": {"name": "Sam Ruiz", "address": "sam.ruiz@example.com"}},
-      "toRecipients": [{"emailAddress": {"address": "avery.chen@example.com"}}],
+      "from": {
+        "emailAddress": {
+          "name": "Sam Ruiz",
+          "address": "sam.ruiz@example.com"
+        }
+      },
+      "toRecipients": [
+        {
+          "emailAddress": {
+            "address": "avery.chen@example.com"
+          }
+        }
+      ],
       "ccRecipients": [],
-      "body": {"contentType": "text", "content": "Dropped a draft of the onboarding revamp in the shared folder whenever you have a moment. No rush."},
+      "body": {
+        "contentType": "text",
+        "content": "Dropped a draft of the onboarding revamp in the shared folder whenever you have a moment. No rush."
+      },
       "parentFolderId": "inbox",
       "conversationId": "conv-onboarding-01",
       "webLink": "https://outlook.example.com/mail/id/msg-quiet-decay",
-      "isRead": false
+      "isRead": false,
+      "internetMessageId": "<msg-quiet-decay@example.com>"
     },
     {
       "id": "msg-automated-noise",
       "receivedDateTime": "2026-08-18T06:00:00Z",
       "subject": "[build] pipeline #4821 succeeded on main",
-      "from": {"emailAddress": {"name": "CI", "address": "noreply@ci.example.com"}},
-      "toRecipients": [{"emailAddress": {"address": "avery.chen@example.com"}}],
+      "from": {
+        "emailAddress": {
+          "name": "CI",
+          "address": "noreply@ci.example.com"
+        }
+      },
+      "toRecipients": [
+        {
+          "emailAddress": {
+            "address": "avery.chen@example.com"
+          }
+        }
+      ],
       "ccRecipients": [],
-      "body": {"contentType": "text", "content": "Pipeline #4821 completed successfully in 6m41s. No action required."},
+      "body": {
+        "contentType": "text",
+        "content": "Pipeline #4821 completed successfully in 6m41s. No action required."
+      },
       "parentFolderId": "inbox",
       "conversationId": "conv-ci-4821",
       "webLink": "https://outlook.example.com/mail/id/msg-automated-noise",
-      "isRead": false
+      "isRead": false,
+      "internetMessageId": "<msg-automated-noise@ci.example.com>"
     },
     {
       "id": "msg-cc-only",
       "receivedDateTime": "2026-08-18T09:05:00Z",
       "subject": "Re: vendor contract redlines",
-      "from": {"emailAddress": {"name": "Priya Raman", "address": "priya.raman@example.com"}},
-      "toRecipients": [{"emailAddress": {"address": "legal@example.com"}}],
-      "ccRecipients": [{"emailAddress": {"address": "avery.chen@example.com"}}],
-      "body": {"contentType": "text", "content": "Legal — attaching the redlines we discussed. Copying Avery so they have visibility on the timeline."},
+      "from": {
+        "emailAddress": {
+          "name": "Priya Raman",
+          "address": "priya.raman@example.com"
+        }
+      },
+      "toRecipients": [
+        {
+          "emailAddress": {
+            "address": "legal@example.com"
+          }
+        }
+      ],
+      "ccRecipients": [
+        {
+          "emailAddress": {
+            "address": "avery.chen@example.com"
+          }
+        }
+      ],
+      "body": {
+        "contentType": "text",
+        "content": "Legal — attaching the redlines we discussed. Copying Avery so they have visibility on the timeline."
+      },
       "parentFolderId": "inbox",
       "conversationId": "conv-vendor-01",
       "webLink": "https://outlook.example.com/mail/id/msg-cc-only",
-      "isRead": false
+      "isRead": false,
+      "internetMessageId": "<msg-cc-only@example.com>"
     }
   ],
   "@odata.deltaLink": "https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta?$deltatoken=FIXTURE"

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/ingest_graph.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/ingest_graph.py
@@ -41,6 +41,7 @@ Exit codes are the contract `select_intake.py` reads:
 from __future__ import annotations
 
 import json
+import sqlite3
 import os
 import sys
 import time
@@ -86,10 +87,6 @@ MAX_BACKFILL_DAYS = 3650
 # and the tick after that one still has to finish.
 REQUEST_BUDGET = 10
 
-# How many message identities are remembered for answering "moved or deleted".
-# A removal concerns something collected recently; an unbounded map would grow
-# with the mailbox for no benefit.
-REMEMBERED_IDENTITIES = 5000
 
 # How long one run may spend being told to wait.
 #
@@ -319,8 +316,13 @@ def first_round_url(days: int) -> str:
     return "/me/mailFolders/inbox/messages/delta?" + query
 
 
-def still_in_mailbox(source_id: str, token: str, budget: Budget) -> bool:
-    """Is this message somewhere else in the mailbox, or actually gone?
+def still_in_mailbox(source_id: str, token: str, budget: Budget) -> str:
+    """Is this message somewhere else in the mailbox, gone, or unanswerable?
+
+    Three answers, not two. A bool had to spend "I could not find out" on one
+    of the other two, and both were wrong: as "gone" it cleared the body of a
+    message that had merely been filed away, and as "present" it let a real
+    deletion pass unrecorded.
 
     Asked by `internetMessageId`, which a message keeps when it moves; the
     per-folder id does not, so it cannot be used here.
@@ -336,13 +338,18 @@ def still_in_mailbox(source_id: str, token: str, budget: Budget) -> bool:
     Stopping costs a re-read of pages this tick already handled, which is
     idempotent, and the next tick asks the question again.
     """
-    known = read_state().get("message_ids", {})
-    internet_id = known.get(source_id)
+    with sqlite3.connect(ledger_path()) as conn:
+        row = conn.execute(
+            "SELECT internet_message_id FROM items WHERE source_id = ?",
+            (source_id,)).fetchone()
+    internet_id = row[0] if row else None
     if not internet_id:
-        # Never seen with an identity of its own — collected before this
-        # existed, or the field was absent. Treat a removal as a removal
-        # rather than guessing that it moved.
-        return False
+        # Nothing to ask about: a row collected before this column existed,
+        # or a message that arrived without the field. Unknown, and unknown
+        # is not "deleted" — reading it that way tombstoned the row and
+        # cleared its body, which is the irreversible direction and was
+        # reached without contacting Graph at all.
+        return "unknown"
     query = urllib.parse.quote(
         "internetMessageId eq '%s'" % internet_id.replace("'", "''"), safe="")
     try:
@@ -355,7 +362,7 @@ def still_in_mailbox(source_id: str, token: str, budget: Budget) -> bool:
             "could not establish whether a removed message was deleted or "
             f"moved ({exc}); the round stops here rather than advancing past "
             "a removal it did not resolve", exc.kind) from exc
-    return bool(found.get("value"))
+    return "present" if found.get("value") else "gone"
 
 
 def tombstone(conn, source_ids: list[str]) -> int:
@@ -386,19 +393,33 @@ def tombstone(conn, source_ids: list[str]) -> int:
     return cursor.rowcount
 
 
-def commit(items: list[dict[str, Any]], removed: list[str]) -> tuple[int, int]:
-    """Rows and tombstones, in one transaction, taken after the fetch.
+def commit_rows(items: list[dict[str, Any]]) -> int:
+    """The page's messages, in their own transaction.
 
-    Holding a write transaction open across a network call holds a write lock
-    for the length of that call, and the user's own corrections queue behind
-    it. The delta cursor is saved by the caller and only after this returns:
-    a cursor recorded over rows that were never written would have the next
+    Separate from the tombstones, and before them, for two reasons. A write
+    transaction held across a network call holds a write lock for the length
+    of that call, and the user's own corrections queue behind it. And the
+    question a removal asks — what is this message's own identity — is
+    answered from the row, so the rows have to be there before it is asked;
+    a message collected in one page and removed in a later page of the same
+    round is otherwise unanswerable.
+
+    The delta cursor is saved by the caller and only after this returns: a
+    cursor recorded over rows that were never written would have the next
     round start past them.
     """
+    if not items:
+        return 0
     with write_txn() as conn:
-        added = insert_items(conn, items) if items else 0
-        gone = tombstone(conn, removed)
-    return added, gone
+        return insert_items(conn, items)
+
+
+def commit_tombstones(removed: list[str]) -> int:
+    """What the source no longer has, once that has actually been asked."""
+    if not removed:
+        return 0
+    with write_txn() as conn:
+        return tombstone(conn, removed)
 
 
 def collect(token: str, address: str, state: dict[str, Any],
@@ -424,7 +445,7 @@ def collect(token: str, address: str, state: dict[str, Any],
     else:
         url, absolute = first_round_url(days), False
 
-    added_total = removed_total = moved = pages = 0
+    added_total = removed_total = moved = unresolved = pages = 0
     delta_link = None
 
     while url and pages < REQUEST_BUDGET:
@@ -449,30 +470,28 @@ def collect(token: str, address: str, state: dict[str, Any],
         # own identity rather than its position. If a search of the mailbox
         # still finds it, it moved; if it does not, it is gone. One request
         # per removal, and removals are rare beside messages.
+        #
+        # That identity is kept on the row, by `normalize`, rather than in a
+        # map beside the cursor. The map was bounded at five thousand and
+        # evicted oldest-first, so filing away a message older than that
+        # produced a removal nobody could ask about — and the code read the
+        # absence as a deletion, cleared the body, and never made a request.
+        # The row is where the message already is, and it does not evict.
         gone_ids = [m["id"] for m in batch
                     if isinstance(m.get("@removed"), dict) and m.get("id")]
         present = [m for m in batch if "@removed" not in m and m.get("id")]
 
-        removals = [source_id for source_id in gone_ids
-                    if not still_in_mailbox(source_id, token, budget)]
-        moved += len(gone_ids) - len(removals)
-
-        # Remember each message's own identity, so a later removal can be
-        # asked about. Bounded, and oldest first out: a removal concerns
-        # something collected recently, and an unbounded map would grow with
-        # the mailbox.
-        known = state.setdefault("message_ids", {})
-        for m in present:
-            if m.get("internetMessageId"):
-                known[m["id"]] = m["internetMessageId"]
-        if len(known) > REMEMBERED_IDENTITIES:
-            for stale in list(known)[:len(known) - REMEMBERED_IDENTITIES]:
-                known.pop(stale, None)
-
+        # Written before the removals are resolved, so a message collected
+        # earlier in this same round can be asked about in a later page.
         items = [graph_message_to_item(m, address) for m in present]
-        added, gone = commit(items, removals)
-        added_total += added
-        removed_total += gone
+        added_total += commit_rows(items)
+
+        verdicts = {source_id: still_in_mailbox(source_id, token, budget)
+                    for source_id in gone_ids}
+        moved += sum(1 for v in verdicts.values() if v == "present")
+        unresolved += sum(1 for v in verdicts.values() if v == "unknown")
+        removed_total += commit_tombstones(
+            [s for s, verdict in verdicts.items() if verdict == "gone"])
 
         delta_link = payload.get("@odata.deltaLink")
         url = payload.get("@odata.nextLink")
@@ -494,7 +513,15 @@ def collect(token: str, address: str, state: dict[str, Any],
         complete = False
 
     return {"source": "email", "scope": "inbox", "added": added_total,
-            "removed": removed_total, "moved": moved, "pages": pages,
+            "removed": removed_total, "moved": moved,
+            # Removals that left the folder while the row had no identity of
+            # its own to ask about — collected before the column existed, or
+            # arrived without the field. Left alone rather than tombstoned,
+            # and counted rather than passed over in silence, because the
+            # alternative was clearing the body of a message that had only
+            # been filed away.
+            "unresolved_removals": unresolved,
+            "pages": pages,
             "resumed": resuming, "complete": complete,
             "synchronised": bool(state.get("delta"))}
 
@@ -550,7 +577,7 @@ def main(argv: list[str] | None = None) -> int:
             # would synchronise one mailbox against another's position.
             print("the mailbox has changed; discarding the previous "
                   "synchronisation state", file=sys.stderr)
-            for key in ("delta", "next", "message_ids"):
+            for key in ("delta", "next"):
                 state.pop(key, None)
         elif refresh:
             state.pop("delta", None)

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/ingest_graph.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/ingest_graph.py
@@ -1,0 +1,447 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Read the user's own mail into the intake, through a credential it never
+holds.
+
+The counterpart to `ingest_slack.py`, and deliberately the same shape where
+the two sources allow it: a bounded read, exit codes that say what went wrong,
+and a credential that is a placeholder inside the sandbox. What this sees in
+`MS_GRAPH_ACCESS_TOKEN` is `openshell:resolve:env:…`, sixty-odd bytes of
+nothing; the OpenShell gateway substitutes the real delegated token at the
+egress boundary and refreshes it on its own schedule. A compromised collector
+leaks a string that is useless off this host.
+
+Where the two sources differ is deletion, and the difference decides the
+design. Slack offers no way to learn that a message was removed — its absence
+from a bounded read cannot be told apart from it lying outside the window — so
+Slack content ages out on the retention pass. Graph reports deletions
+explicitly through the delta query, so this uses that rather than a time
+filter, and a message deleted at the source is tombstoned and its body cleared
+at once rather than a month later.
+
+That choice has a second benefit worth naming, because it removes a whole
+class of bug. A delta cursor is opaque and is only issued when a synchronisation
+round completes. There is no way to construct one from a message this run
+happened to see, so "only a complete crawl may advance the watermark" is
+enforced by the protocol rather than by remembering to write it correctly.
+
+    python3 ingest_graph.py            # incremental
+    python3 ingest_graph.py --recheck  # re-probe the mailbox identity
+
+Exit codes are the contract `select_intake.py` reads:
+
+    0  collected, or never configured
+    1  something else went wrong
+    2  the credential is missing, wrong, or refused
+    3  rate limited before the work finished
+    4  the token works but lacks the scope this needs
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from _db import ensure_store, ledger_path, write_txn
+from normalize import graph_message_to_item, insert_items
+
+API = "https://graph.microsoft.com/v1.0"
+
+EXIT_OK = 0
+EXIT_OTHER = 1
+EXIT_CREDENTIAL = 2
+EXIT_RATE_LIMIT = 3
+EXIT_SCOPE = 4
+
+# How far back the first synchronisation reaches.
+#
+# The delta query accepts a `receivedDateTime` filter on the initial request,
+# so this is a real choice rather than all-or-nothing — measured against the
+# live service, not assumed. Seven days is the default because it produces a
+# useful inbox on the first tick instead of a month of archaeology, and
+# `GRAPH_BACKFILL_DAYS` moves it.
+#
+# What it does *not* do is bound what comes later. The delta cursor the first
+# round issues carries no filter, so once the baseline exists every change in
+# the folder is reported — including an older message being deleted. Choosing
+# seven days is choosing where to start, not choosing to be told less
+# afterwards.
+BACKFILL_DAYS = 7
+MAX_BACKFILL_DAYS = 3650
+
+# Requests per run.
+#
+# A first synchronisation over a wide window can need many more pages than one
+# tick should spend, so it is resumable: the page link is kept and the next
+# tick continues from it. The bound exists because a scheduled job that can
+# issue unbounded requests will eventually meet a mailbox that makes it do so,
+# and the tick after that one still has to finish.
+REQUEST_BUDGET = 10
+PAGE_SIZE = 50
+MAX_BACKOFF_SECONDS = 30
+
+# Where the synchronisation stands. Not in `cursors`, because that table holds
+# one opaque string per scope and this needs two states — mid-round and
+# between rounds — plus the mailbox identity.
+STATE_FILE = "graph_state.json"
+
+FIELDS = ("id,parentFolderId,conversationId,receivedDateTime,from,subject,"
+          "body,webLink,isRead,toRecipients,ccRecipients")
+
+
+class GraphError(Exception):
+    """A failure with a class attached, so the exit code is not a guess."""
+
+    def __init__(self, message: str, kind: str = "other"):
+        super().__init__(message)
+        self.kind = kind
+
+
+def classify_token(raw: str | None) -> str:
+    """What kind of thing is in the variable.
+
+    The placeholder is the expected case and the only one this recipe is built
+    around. A real bearer token appearing here means somebody put a live
+    credential in the sandbox by hand, which works but is the arrangement this
+    design exists to avoid — so it runs, and says so once.
+    """
+    if raw is None or not raw.strip():
+        return "absent"
+    token = raw.strip()
+    if token.startswith("openshell:resolve:"):
+        return "placeholder"
+    if token.count(".") == 2 and token.startswith("ey"):
+        return "bearer"
+    return "unrecognised"
+
+
+def bounded_days(name: str, default: int) -> int:
+    """Read a positive, bounded day count from the environment.
+
+    Same shape and same reasons as the other bounded settings here: a zero
+    window synchronises nothing while reporting a clean run, and a negative one
+    puts the start in the future so the filter excludes everything. Both are
+    mistakes only noticed by their consequences.
+    """
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        raise SystemExit(
+            f"{name} must be a whole number of days between 1 and "
+            f"{MAX_BACKFILL_DAYS}; got {raw!r}")
+    if value < 1 or value > MAX_BACKFILL_DAYS:
+        raise SystemExit(
+            f"{name} must be between 1 and {MAX_BACKFILL_DAYS}; got {value}")
+    return value
+
+
+def state_path():
+    return ledger_path().parent.parent / STATE_FILE
+
+
+def read_state() -> dict[str, Any]:
+    try:
+        found = json.loads(state_path().read_text(encoding="utf-8"))
+        return found if isinstance(found, dict) else {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def save_state(state: dict[str, Any]) -> None:
+    path = state_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(state), encoding="utf-8")
+    except OSError:
+        # Losing this costs a re-synchronisation, not correctness: without it
+        # the next run starts a fresh delta round and the rows are idempotent
+        # on `source_id`.
+        pass
+
+
+def fingerprint(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
+
+
+def call(path: str, token: str, *, absolute: bool = False) -> dict[str, Any]:
+    """One Graph GET, with the failures that need distinguishing.
+
+    A 401 or 403 is the credential; a 429 is the service asking for patience;
+    a 410 means the delta cursor has expired and the round must start again.
+    Everything else is lumped together, because a collector that tries to
+    interpret Graph's full error surface will be wrong about it.
+    """
+    url = path if absolute else API + path
+    request = urllib.request.Request(url, headers={
+        "Authorization": "Bearer " + token,
+        # Ask for a plain-text body. Graph honours this per request; without
+        # it every message arrives as HTML, and the store would hold several
+        # kilobytes of layout for the sake of a paragraph.
+        "Prefer": 'outlook.body-content-type="text"',
+    })
+    delay = 1.0
+    while True:
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            if exc.code in (401, 403):
+                raise GraphError(
+                    "Microsoft Graph refused the credential (HTTP %d)." %
+                    exc.code,
+                    "credential") from exc
+            if exc.code == 410:
+                raise GraphError("delta cursor expired", "resync") from exc
+            if exc.code == 429:
+                retry = exc.headers.get("Retry-After")
+                wait = float(retry) if retry and retry.isdigit() else delay
+                if wait > MAX_BACKOFF_SECONDS:
+                    raise GraphError("rate limited beyond the backoff bound",
+                                     "rate_limit") from exc
+                time.sleep(wait)
+                delay = min(delay * 2, MAX_BACKOFF_SECONDS)
+                continue
+            raise GraphError("Graph returned HTTP %d" % exc.code) from exc
+        except urllib.error.URLError as exc:
+            # The egress boundary refuses a host it does not allow with a
+            # tunnel error, indistinguishable here from the network being
+            # down — and the operator's next step is the same either way.
+            raise GraphError("could not reach graph.microsoft.com",
+                             "other") from exc
+
+
+def identity(token: str, state: dict[str, Any], *,
+             refresh: bool = False) -> dict[str, Any]:
+    """Whose mailbox this is, cached.
+
+    The address decides addressing — being a To recipient is being asked,
+    being copied is being informed — so it is needed on every message and
+    fetched once. Keyed on the credential, so replacing the token re-probes
+    rather than inheriting the previous mailbox's identity along with its
+    delta cursor.
+    """
+    mark = fingerprint(token)
+    cached = state.get("identity")
+    if not refresh and isinstance(cached, dict) and cached.get("token") == mark:
+        return cached
+
+    me = call("/me?$select=mail,userPrincipalName,displayName", token)
+    address = me.get("mail") or me.get("userPrincipalName") or ""
+    if not address:
+        raise GraphError(
+            "The token works but the mailbox has no address. This usually "
+            "means an application token rather than a delegated one; this "
+            "recipe needs delegated Mail.Read.", "scope")
+    return {"token": mark, "address": address,
+            "display_name": me.get("displayName")}
+
+
+def first_round_url(days: int) -> str:
+    """The initial delta request, bounded to a window the user chose."""
+    start = (datetime.now(timezone.utc)
+             - timedelta(days=days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    query = urllib.parse.urlencode({
+        "$select": FIELDS,
+        "$top": PAGE_SIZE,
+        "$filter": "receivedDateTime ge %s" % start,
+    })
+    return "/me/mailFolders/inbox/messages/delta?" + query
+
+
+def tombstone(conn, source_ids: list[str]) -> int:
+    """Record that the source removed these, and drop their text now.
+
+    Not a DELETE. Obligations and events hang off `source_id`, so removing the
+    row would break the audit trail that explains why something was ranked or
+    ignored — the record of a decision outliving its subject is the point.
+    What goes is the content, immediately rather than at the next retention
+    pass, because somebody who deleted a message has said what they want.
+
+    `deleted_at` and `body_cleared_at` are both set and mean different things:
+    one is the person deleting, the other is this recipe ageing text out on
+    its own schedule. A report that conflated them would answer the wrong
+    question.
+    """
+    if not source_ids:
+        return 0
+    marks = ",".join("?" * len(source_ids))
+    cursor = conn.execute(
+        "UPDATE items"
+        "   SET deleted_at = strftime('%Y-%m-%dT%H:%M:%fZ','now'),"
+        "       body = NULL,"
+        "       body_cleared_at = COALESCE(body_cleared_at,"
+        " strftime('%Y-%m-%dT%H:%M:%fZ','now'))"
+        f" WHERE source_id IN ({marks}) AND deleted_at IS NULL",
+        source_ids)
+    return cursor.rowcount
+
+
+def commit(items: list[dict[str, Any]], removed: list[str]) -> tuple[int, int]:
+    """Rows and tombstones, in one transaction, taken after the fetch.
+
+    Holding a write transaction open across a network call holds a write lock
+    for the length of that call, and the user's own corrections queue behind
+    it. The delta cursor is saved by the caller and only after this returns:
+    a cursor recorded over rows that were never written would have the next
+    round start past them.
+    """
+    with write_txn() as conn:
+        added = insert_items(conn, items) if items else 0
+        gone = tombstone(conn, removed)
+    return added, gone
+
+
+def collect(token: str, address: str, state: dict[str, Any],
+            days: int) -> dict[str, Any]:
+    """One synchronisation round, or as much of one as the budget allows.
+
+    Three states, and which one this run is in decides where it starts:
+
+    - no cursor at all: begin a round, bounded to the chosen window
+    - `next`: a round was interrupted by the budget, continue from that page
+    - `delta`: a round completed, ask what has changed since
+
+    Only a completed round yields a new delta cursor, and one cannot be
+    fabricated from the messages this run happened to see. The rule that a
+    partial crawl must not advance the watermark is therefore enforced by the
+    protocol rather than by this code remembering it.
+    """
+    resuming = bool(state.get("next"))
+    if state.get("next"):
+        url, absolute = state["next"], True
+    elif state.get("delta"):
+        url, absolute = state["delta"], True
+    else:
+        url, absolute = first_round_url(days), False
+
+    added_total = removed_total = pages = 0
+    delta_link = None
+
+    while url and pages < REQUEST_BUDGET:
+        payload = call(url, token, absolute=absolute)
+        pages += 1
+
+        batch = payload.get("value") or []
+        # A delta page mixes changes and removals. `@removed` carries a reason
+        # — `deleted` or `changed` — and only the first is a deletion; the
+        # second means the item moved out of the scope being synchronised,
+        # which is not the same thing and must not tombstone it.
+        removals = [m["id"] for m in batch
+                    if isinstance(m.get("@removed"), dict)
+                    and m["@removed"].get("reason") == "deleted"
+                    and m.get("id")]
+        present = [m for m in batch if "@removed" not in m and m.get("id")]
+
+        items = [graph_message_to_item(m, address) for m in present]
+        added, gone = commit(items, removals)
+        added_total += added
+        removed_total += gone
+
+        delta_link = payload.get("@odata.deltaLink")
+        url = payload.get("@odata.nextLink")
+        absolute = True
+
+    # Save exactly one of the two, and only what the round actually reached.
+    if delta_link:
+        state.pop("next", None)
+        state["delta"] = delta_link
+        complete = True
+    elif url:
+        state["next"] = url
+        complete = False
+    else:
+        # No further page and no delta cursor: Graph gave neither, so the round
+        # is not finished and there is nothing to resume from. Start again next
+        # tick rather than recording a position that does not exist.
+        state.pop("next", None)
+        complete = False
+
+    return {"source": "email", "scope": "inbox", "added": added_total,
+            "removed": removed_total, "pages": pages,
+            "resumed": resuming, "complete": complete,
+            "synchronised": bool(state.get("delta"))}
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = argv if argv is not None else sys.argv[1:]
+    refresh = "--recheck" in args
+
+    raw = os.environ.get("MS_GRAPH_ACCESS_TOKEN")
+    kind = classify_token(raw)
+
+    ensure_store()
+    state = read_state()
+
+    # Never configured is not the same as broken, and the difference decides
+    # whether every idle tick wakes the model. This file exists as soon as the
+    # recipe is installed, long before most people connect a mailbox — so an
+    # absent credential has to be free, or the wake gate never fires again.
+    #
+    # The hole is a credential that *disappears*: a detached provider empties
+    # the variable, which then looks like "never set up". The saved state
+    # closes it, because it is only written after a mailbox answered once.
+    if kind == "absent":
+        if state:
+            print("Mail was connected and MS_GRAPH_ACCESS_TOKEN has gone. If "
+                  "this sandbox uses an OpenShell provider, check it is still "
+                  "attached: openshell sandbox provider list <sandbox>.",
+                  file=sys.stderr)
+            return EXIT_CREDENTIAL
+        print(json.dumps({"unconfigured": True}))
+        return EXIT_OK
+
+    if kind == "unrecognised":
+        print("MS_GRAPH_ACCESS_TOKEN holds something that is neither an "
+              "OpenShell placeholder nor a bearer token. Expected the gateway "
+              "to inject `openshell:resolve:env:…`.", file=sys.stderr)
+        return EXIT_CREDENTIAL
+
+    token = (raw or "").strip()
+    days = bounded_days("GRAPH_BACKFILL_DAYS", BACKFILL_DAYS)
+
+    try:
+        who = identity(token, state, refresh=refresh)
+        state["identity"] = who
+        try:
+            report = collect(token, who["address"], state, days)
+        except GraphError as exc:
+            if exc.kind != "resync":
+                raise
+            # Graph expires a delta cursor that has gone unused for too long.
+            # Recovering means a fresh round over the window; the rows are
+            # idempotent on `source_id`, so re-reading costs requests rather
+            # than duplicates.
+            print("delta cursor expired; starting a new synchronisation round",
+                  file=sys.stderr)
+            state.pop("delta", None)
+            state.pop("next", None)
+            report = collect(token, who["address"], state, days)
+            report["resynchronised"] = True
+    except GraphError as exc:
+        print(str(exc), file=sys.stderr)
+        return {"credential": EXIT_CREDENTIAL, "rate_limit": EXIT_RATE_LIMIT,
+                "scope": EXIT_SCOPE}.get(exc.kind, EXIT_OTHER)
+
+    # After the rows, never before: a cursor saved over rows that were not
+    # written would have the next round start past them.
+    save_state(state)
+
+    report["backfill_days"] = days
+    print(json.dumps(report))
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/ingest_graph.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/ingest_graph.py
@@ -185,7 +185,47 @@ def save_state(state: dict[str, Any]) -> None:
         pass
 
 
-def call(path: str, token: str, *, absolute: bool = False) -> dict[str, Any]:
+class Budget:
+    """How long one tick may spend waiting, across every request it makes.
+
+    The bound belongs to the tick, not to the request. Held per request it
+    multiplies by however many requests the tick makes — a page budget of ten
+    turned a 120-second ceiling into twenty minutes of a scheduled job sitting
+    in `sleep`, which is not a bound anybody set and not one anybody would see
+    until it happened.
+
+    Passed explicitly rather than defaulted, so a call site that forgets it is
+    a `TypeError` here rather than a request quietly given a budget of its
+    own — which is the defect this replaces.
+    """
+
+    def __init__(self, seconds: float | None = None):
+        # Read at construction, not bound as a default argument: a default is
+        # evaluated once at import, so a test or an operator changing the
+        # constant afterwards would be silently ignored.
+        self.limit = (MAX_TOTAL_BACKOFF_SECONDS if seconds is None
+                      else seconds)
+        self.waited = 0.0
+
+    def spend(self, wait: float) -> None:
+        """Wait, or refuse because this tick has waited enough already.
+
+        Refusing is not failing: the cursor is not advanced, so the next tick
+        continues from the same place. A rate limit is the service asking for
+        patience on a timescale longer than one tick, and the answer to it is
+        to come back later rather than to hold the job open.
+        """
+        if self.waited + wait > self.limit:
+            raise GraphError(
+                "rate limited for longer than one tick may wait "
+                f"({int(self.waited)}s so far); the next tick continues "
+                "from where this one stopped", "rate_limit")
+        time.sleep(wait)
+        self.waited += wait
+
+
+def call(path: str, token: str, budget: Budget, *,
+         absolute: bool = False) -> dict[str, Any]:
     """One Graph GET, with the failures that need distinguishing.
 
     A 401 or 403 is the credential; a 429 is the service asking for patience;
@@ -202,7 +242,6 @@ def call(path: str, token: str, *, absolute: bool = False) -> dict[str, Any]:
         "Prefer": 'outlook.body-content-type="text"',
     })
     delay = 1.0
-    waited = 0.0
     while True:
         try:
             with urllib.request.urlopen(request, timeout=30) as response:
@@ -221,13 +260,7 @@ def call(path: str, token: str, *, absolute: bool = False) -> dict[str, Any]:
                 if wait > MAX_BACKOFF_SECONDS:
                     raise GraphError("rate limited beyond the backoff bound",
                                      "rate_limit") from exc
-                if waited + wait > MAX_TOTAL_BACKOFF_SECONDS:
-                    raise GraphError(
-                        "rate limited for longer than one tick may wait "
-                        f"({int(waited)}s so far); the next tick continues "
-                        "from where this one stopped", "rate_limit") from exc
-                time.sleep(wait)
-                waited += wait
+                budget.spend(wait)
                 delay = min(delay * 2, MAX_BACKOFF_SECONDS)
                 continue
             raise GraphError("Graph returned HTTP %d" % exc.code) from exc
@@ -239,7 +272,8 @@ def call(path: str, token: str, *, absolute: bool = False) -> dict[str, Any]:
                              "other") from exc
 
 
-def identity(token: str, state: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+def identity(token: str, state: dict[str, Any],
+             budget: Budget) -> tuple[dict[str, Any], bool]:
     """Whose mailbox this is, checked every run. Returns it and whether it
     changed.
 
@@ -256,7 +290,8 @@ def identity(token: str, state: dict[str, Any]) -> tuple[dict[str, Any], bool]:
     credential presented for it. One request against a bounded budget, and
     the answer is the addressing input every message needs anyway.
     """
-    me = call("/me?$select=mail,userPrincipalName,displayName", token)
+    me = call("/me?$select=mail,userPrincipalName,displayName", token,
+              budget)
     address = me.get("mail") or me.get("userPrincipalName") or ""
     if not address:
         raise GraphError(
@@ -284,14 +319,22 @@ def first_round_url(days: int) -> str:
     return "/me/mailFolders/inbox/messages/delta?" + query
 
 
-def still_in_mailbox(source_id: str, token: str) -> bool:
+def still_in_mailbox(source_id: str, token: str, budget: Budget) -> bool:
     """Is this message somewhere else in the mailbox, or actually gone?
 
     Asked by `internetMessageId`, which a message keeps when it moves; the
-    per-folder id does not, so it cannot be used here. A failure to answer is
-    read as "still there", because the cost of being wrong in that direction
-    is a body kept a little longer, and the cost of the other is a body
-    cleared because a search timed out.
+    per-folder id does not, so it cannot be used here.
+
+    A failure to answer stops the round. Reading it as "still there" looked
+    like the safe direction — a body kept a little longer against a body
+    cleared because a search timed out — but "a little longer" was wrong. The
+    removal is only reported once. Treat it as a move and the round finishes,
+    the cursor advances past the page that carried it, and nothing ever asks
+    again: the message stays in the store as though it were never deleted,
+    permanently, and the person who deleted it is never told otherwise.
+
+    Stopping costs a re-read of pages this tick already handled, which is
+    idempotent, and the next tick asks the question again.
     """
     known = read_state().get("message_ids", {})
     internet_id = known.get(source_id)
@@ -303,9 +346,15 @@ def still_in_mailbox(source_id: str, token: str) -> bool:
     query = urllib.parse.quote(
         "internetMessageId eq '%s'" % internet_id.replace("'", "''"), safe="")
     try:
-        found = call("/me/messages?$filter=%s&$select=id&$top=1" % query, token)
-    except GraphError:
-        return True
+        found = call("/me/messages?$filter=%s&$select=id&$top=1" % query,
+                     token, budget)
+    except GraphError as exc:
+        # The class is carried through so the exit code still says whether
+        # this was the credential, a rate limit, or something else.
+        raise GraphError(
+            "could not establish whether a removed message was deleted or "
+            f"moved ({exc}); the round stops here rather than advancing past "
+            "a removal it did not resolve", exc.kind) from exc
     return bool(found.get("value"))
 
 
@@ -353,7 +402,7 @@ def commit(items: list[dict[str, Any]], removed: list[str]) -> tuple[int, int]:
 
 
 def collect(token: str, address: str, state: dict[str, Any],
-            days: int) -> dict[str, Any]:
+            days: int, budget: Budget) -> dict[str, Any]:
     """One synchronisation round, or as much of one as the budget allows.
 
     Three states, and which one this run is in decides where it starts:
@@ -379,7 +428,7 @@ def collect(token: str, address: str, state: dict[str, Any],
     delta_link = None
 
     while url and pages < REQUEST_BUDGET:
-        payload = call(url, token, absolute=absolute)
+        payload = call(url, token, budget, absolute=absolute)
         pages += 1
 
         batch = payload.get("value") or []
@@ -405,7 +454,7 @@ def collect(token: str, address: str, state: dict[str, Any],
         present = [m for m in batch if "@removed" not in m and m.get("id")]
 
         removals = [source_id for source_id in gone_ids
-                    if not still_in_mailbox(source_id, token)]
+                    if not still_in_mailbox(source_id, token, budget)]
         moved += len(gone_ids) - len(removals)
 
         # Remember each message's own identity, so a later removal can be
@@ -487,8 +536,13 @@ def main(argv: list[str] | None = None) -> int:
     token = (raw or "").strip()
     days = bounded_days("GRAPH_BACKFILL_DAYS", BACKFILL_DAYS)
 
+    # One budget for the whole tick, shared by every request it makes —
+    # the identity check, both rounds if the cursor expired, and every
+    # removal lookup in between.
+    budget = Budget()
+
     try:
-        who, mailbox_changed = identity(token, state)
+        who, mailbox_changed = identity(token, state, budget)
         if mailbox_changed:
             # A different account. Everything remembered describes the old
             # one: a delta cursor issued for its inbox, a resume link into
@@ -503,7 +557,8 @@ def main(argv: list[str] | None = None) -> int:
             state.pop("next", None)
         state["identity"] = who
         try:
-            report = collect(token, who["address"], state, days)
+            report = collect(token, who["address"], state, days,
+                             budget)
         except GraphError as exc:
             if exc.kind != "resync":
                 raise
@@ -515,7 +570,8 @@ def main(argv: list[str] | None = None) -> int:
                   file=sys.stderr)
             state.pop("delta", None)
             state.pop("next", None)
-            report = collect(token, who["address"], state, days)
+            report = collect(token, who["address"], state, days,
+                             budget)
             report["resynchronised"] = True
     except GraphError as exc:
         print(str(exc), file=sys.stderr)

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/ingest_graph.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/ingest_graph.py
@@ -40,7 +40,6 @@ Exit codes are the contract `select_intake.py` reads:
 
 from __future__ import annotations
 
-import hashlib
 import json
 import os
 import sys
@@ -86,6 +85,20 @@ MAX_BACKFILL_DAYS = 3650
 # issue unbounded requests will eventually meet a mailbox that makes it do so,
 # and the tick after that one still has to finish.
 REQUEST_BUDGET = 10
+
+# How many message identities are remembered for answering "moved or deleted".
+# A removal concerns something collected recently; an unbounded map would grow
+# with the mailbox for no benefit.
+REMEMBERED_IDENTITIES = 5000
+
+# How long one run may spend being told to wait.
+#
+# Graph answers 429 with a `Retry-After`, and a caller that honours it without
+# a total bound will honour it forever: the page budget counts successful
+# responses, and a scheduled pre-step has no timeout of its own. Reproduced at
+# review: 9,248 retries and still going. A tick that cannot make progress
+# inside this budget reports rate limiting and lets the next one try.
+MAX_TOTAL_BACKOFF_SECONDS = 120
 PAGE_SIZE = 50
 MAX_BACKOFF_SECONDS = 30
 
@@ -95,7 +108,8 @@ MAX_BACKOFF_SECONDS = 30
 STATE_FILE = "graph_state.json"
 
 FIELDS = ("id,parentFolderId,conversationId,receivedDateTime,from,subject,"
-          "body,webLink,isRead,toRecipients,ccRecipients")
+          "body,webLink,isRead,toRecipients,ccRecipients,"
+          "internetMessageId")
 
 
 class GraphError(Exception):
@@ -171,10 +185,6 @@ def save_state(state: dict[str, Any]) -> None:
         pass
 
 
-def fingerprint(token: str) -> str:
-    return hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
-
-
 def call(path: str, token: str, *, absolute: bool = False) -> dict[str, Any]:
     """One Graph GET, with the failures that need distinguishing.
 
@@ -192,6 +202,7 @@ def call(path: str, token: str, *, absolute: bool = False) -> dict[str, Any]:
         "Prefer": 'outlook.body-content-type="text"',
     })
     delay = 1.0
+    waited = 0.0
     while True:
         try:
             with urllib.request.urlopen(request, timeout=30) as response:
@@ -210,7 +221,13 @@ def call(path: str, token: str, *, absolute: bool = False) -> dict[str, Any]:
                 if wait > MAX_BACKOFF_SECONDS:
                     raise GraphError("rate limited beyond the backoff bound",
                                      "rate_limit") from exc
+                if waited + wait > MAX_TOTAL_BACKOFF_SECONDS:
+                    raise GraphError(
+                        "rate limited for longer than one tick may wait "
+                        f"({int(waited)}s so far); the next tick continues "
+                        "from where this one stopped", "rate_limit") from exc
                 time.sleep(wait)
+                waited += wait
                 delay = min(delay * 2, MAX_BACKOFF_SECONDS)
                 continue
             raise GraphError("Graph returned HTTP %d" % exc.code) from exc
@@ -222,30 +239,37 @@ def call(path: str, token: str, *, absolute: bool = False) -> dict[str, Any]:
                              "other") from exc
 
 
-def identity(token: str, state: dict[str, Any], *,
-             refresh: bool = False) -> dict[str, Any]:
-    """Whose mailbox this is, cached.
+def identity(token: str, state: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+    """Whose mailbox this is, checked every run. Returns it and whether it
+    changed.
 
-    The address decides addressing — being a To recipient is being asked,
-    being copied is being informed — so it is needed on every message and
-    fetched once. Keyed on the credential, so replacing the token re-probes
-    rather than inheriting the previous mailbox's identity along with its
-    delta cursor.
+    Not cached against the credential, which was the mistake here. Inside the
+    sandbox the credential is a placeholder that the gateway substitutes, and
+    the placeholder does not change when the token behind it is replaced — so
+    a digest of it stays the same across a re-authorisation to a completely
+    different account. The identity cache and the delta cursor would then be
+    carried over to somebody else's mailbox, which is the one outcome worth
+    spending a request per tick to prevent.
+
+    So `/me` is asked every run, and what is compared is the mailbox address
+    — a durable identifier belonging to the account rather than to the
+    credential presented for it. One request against a bounded budget, and
+    the answer is the addressing input every message needs anyway.
     """
-    mark = fingerprint(token)
-    cached = state.get("identity")
-    if not refresh and isinstance(cached, dict) and cached.get("token") == mark:
-        return cached
-
     me = call("/me?$select=mail,userPrincipalName,displayName", token)
     address = me.get("mail") or me.get("userPrincipalName") or ""
     if not address:
         raise GraphError(
             "The token works but the mailbox has no address. This usually "
             "means an application token rather than a delegated one; this "
-            "recipe needs delegated Mail.Read.", "scope")
-    return {"token": mark, "address": address,
-            "display_name": me.get("displayName")}
+            "recipe needs delegated Mail.Read and User.Read.", "scope")
+
+    previous = state.get("identity")
+    changed = bool(isinstance(previous, dict)
+                   and previous.get("address")
+                   and previous["address"].lower() != address.lower())
+    return ({"address": address, "display_name": me.get("displayName")},
+            changed)
 
 
 def first_round_url(days: int) -> str:
@@ -258,6 +282,31 @@ def first_round_url(days: int) -> str:
         "$filter": "receivedDateTime ge %s" % start,
     })
     return "/me/mailFolders/inbox/messages/delta?" + query
+
+
+def still_in_mailbox(source_id: str, token: str) -> bool:
+    """Is this message somewhere else in the mailbox, or actually gone?
+
+    Asked by `internetMessageId`, which a message keeps when it moves; the
+    per-folder id does not, so it cannot be used here. A failure to answer is
+    read as "still there", because the cost of being wrong in that direction
+    is a body kept a little longer, and the cost of the other is a body
+    cleared because a search timed out.
+    """
+    known = read_state().get("message_ids", {})
+    internet_id = known.get(source_id)
+    if not internet_id:
+        # Never seen with an identity of its own — collected before this
+        # existed, or the field was absent. Treat a removal as a removal
+        # rather than guessing that it moved.
+        return False
+    query = urllib.parse.quote(
+        "internetMessageId eq '%s'" % internet_id.replace("'", "''"), safe="")
+    try:
+        found = call("/me/messages?$filter=%s&$select=id&$top=1" % query, token)
+    except GraphError:
+        return True
+    return bool(found.get("value"))
 
 
 def tombstone(conn, source_ids: list[str]) -> int:
@@ -326,7 +375,7 @@ def collect(token: str, address: str, state: dict[str, Any],
     else:
         url, absolute = first_round_url(days), False
 
-    added_total = removed_total = pages = 0
+    added_total = removed_total = moved = pages = 0
     delta_link = None
 
     while url and pages < REQUEST_BUDGET:
@@ -334,15 +383,42 @@ def collect(token: str, address: str, state: dict[str, Any],
         pages += 1
 
         batch = payload.get("value") or []
-        # A delta page mixes changes and removals. `@removed` carries a reason
-        # — `deleted` or `changed` — and only the first is a deletion; the
-        # second means the item moved out of the scope being synchronised,
-        # which is not the same thing and must not tombstone it.
-        removals = [m["id"] for m in batch
-                    if isinstance(m.get("@removed"), dict)
-                    and m["@removed"].get("reason") == "deleted"
-                    and m.get("id")]
+        # A delta page mixes changes and removals, and the removals need a
+        # second question asked before any of them is believed.
+        #
+        # Graph reports `@removed.reason == "deleted"` when a message leaves
+        # the folder being tracked — whether it was deleted or filed
+        # somewhere else. An earlier version of this read a `"changed"`
+        # reason for a move; no such value is documented and the service does
+        # not send one, so archiving a message was recorded as the person
+        # deleting it and its body was cleared. Measured against the live
+        # service: moving a message to Archive produces exactly the removal a
+        # deletion produces, and the per-folder id changes, so the id cannot
+        # answer it either.
+        #
+        # What survives a move is `internetMessageId`, which is the message's
+        # own identity rather than its position. If a search of the mailbox
+        # still finds it, it moved; if it does not, it is gone. One request
+        # per removal, and removals are rare beside messages.
+        gone_ids = [m["id"] for m in batch
+                    if isinstance(m.get("@removed"), dict) and m.get("id")]
         present = [m for m in batch if "@removed" not in m and m.get("id")]
+
+        removals = [source_id for source_id in gone_ids
+                    if not still_in_mailbox(source_id, token)]
+        moved += len(gone_ids) - len(removals)
+
+        # Remember each message's own identity, so a later removal can be
+        # asked about. Bounded, and oldest first out: a removal concerns
+        # something collected recently, and an unbounded map would grow with
+        # the mailbox.
+        known = state.setdefault("message_ids", {})
+        for m in present:
+            if m.get("internetMessageId"):
+                known[m["id"]] = m["internetMessageId"]
+        if len(known) > REMEMBERED_IDENTITIES:
+            for stale in list(known)[:len(known) - REMEMBERED_IDENTITIES]:
+                known.pop(stale, None)
 
         items = [graph_message_to_item(m, address) for m in present]
         added, gone = commit(items, removals)
@@ -369,7 +445,7 @@ def collect(token: str, address: str, state: dict[str, Any],
         complete = False
 
     return {"source": "email", "scope": "inbox", "added": added_total,
-            "removed": removed_total, "pages": pages,
+            "removed": removed_total, "moved": moved, "pages": pages,
             "resumed": resuming, "complete": complete,
             "synchronised": bool(state.get("delta"))}
 
@@ -412,7 +488,19 @@ def main(argv: list[str] | None = None) -> int:
     days = bounded_days("GRAPH_BACKFILL_DAYS", BACKFILL_DAYS)
 
     try:
-        who = identity(token, state, refresh=refresh)
+        who, mailbox_changed = identity(token, state)
+        if mailbox_changed:
+            # A different account. Everything remembered describes the old
+            # one: a delta cursor issued for its inbox, a resume link into
+            # its pages, identities of its messages. Carrying any of it over
+            # would synchronise one mailbox against another's position.
+            print("the mailbox has changed; discarding the previous "
+                  "synchronisation state", file=sys.stderr)
+            for key in ("delta", "next", "message_ids"):
+                state.pop(key, None)
+        elif refresh:
+            state.pop("delta", None)
+            state.pop("next", None)
         state["identity"] = who
         try:
             report = collect(token, who["address"], state, days)

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/migrate.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/migrate.py
@@ -22,7 +22,7 @@ import sqlite3
 from pathlib import Path
 from typing import Callable
 
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 
 # version -> callable applied to reach it. Forward only; there is no down path,
 # because a downgrade that drops a column loses data no backup can infer.
@@ -67,9 +67,23 @@ def _add_sender_key(conn: sqlite3.Connection) -> None:
         conn.execute("ALTER TABLE items ADD COLUMN sender_key TEXT")
 
 
+def _add_deleted_at(conn: sqlite3.Connection) -> None:
+    """Somewhere to record that the source deleted a message.
+
+    Added with the Microsoft Graph collector, whose delta query reports
+    deletions explicitly. Idempotent: an ALTER that has already happened is
+    detected rather than attempted, because a migration that fails on a store
+    it already migrated is a migration that only works once.
+    """
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(items)")}
+    if "deleted_at" not in columns:
+        conn.execute("ALTER TABLE items ADD COLUMN deleted_at TEXT")
+
+
 MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
     2: _add_body_cleared_at,
     3: _add_sender_key,
+    4: _add_deleted_at,
 }
 
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/migrate.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/migrate.py
@@ -67,23 +67,30 @@ def _add_sender_key(conn: sqlite3.Connection) -> None:
         conn.execute("ALTER TABLE items ADD COLUMN sender_key TEXT")
 
 
-def _add_deleted_at(conn: sqlite3.Connection) -> None:
-    """Somewhere to record that the source deleted a message.
+def _add_removal_tracking(conn: sqlite3.Connection) -> None:
+    """v4: somewhere to record that the source removed a message.
 
-    Added with the Microsoft Graph collector, whose delta query reports
-    deletions explicitly. Idempotent: an ALTER that has already happened is
-    detected rather than attempted, because a migration that fails on a store
-    it already migrated is a migration that only works once.
+    Two columns, one feature. `deleted_at` is the verdict; the message's own
+    `internetMessageId` is what the verdict is reached by, and it has to be
+    on the row because by the time a removal is reported the message is gone
+    and there is nothing left to read it from.
+
+    Added with the Microsoft Graph collector. Idempotent: an ALTER that has
+    already happened is detected rather than attempted, because a migration
+    that fails on a store it already migrated is a migration that only works
+    once.
     """
     columns = {row[1] for row in conn.execute("PRAGMA table_info(items)")}
     if "deleted_at" not in columns:
         conn.execute("ALTER TABLE items ADD COLUMN deleted_at TEXT")
+    if "internet_message_id" not in columns:
+        conn.execute("ALTER TABLE items ADD COLUMN internet_message_id TEXT")
 
 
 MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
     2: _add_body_cleared_at,
     3: _add_sender_key,
-    4: _add_deleted_at,
+    4: _add_removal_tracking,
 }
 
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/normalize.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/normalize.py
@@ -101,6 +101,10 @@ def graph_message_to_item(msg: dict[str, Any], user_address: str) -> dict[str, A
         "permalink": msg.get("webLink"),
         "addressing": addressing,
         "unread": 0 if msg.get("isRead") else 1,
+        # Stored, unlike `sender_address`: a removal reported later can only
+        # be told apart from a move by asking about this, and by then the
+        # message is no longer available to read it from.
+        "internet_message_id": msg.get("internetMessageId"),
     }
 
 
@@ -156,6 +160,9 @@ ITEM_COLUMNS = (
     "source_id", "source", "scope", "thread_ref", "event_at",
     "sender", "sender_key", "subject", "body", "permalink", "addressing",
     "unread",
+    # Mail only. Slack has no equivalent and leaves it NULL; the collector
+    # that needs it is the one that can tell a move from a deletion.
+    "internet_message_id",
 )
 
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/schema-v3.sql
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/schema-v3.sql
@@ -1,0 +1,189 @@
+-- FROZEN. The v3 schema exactly as it shipped in #140.
+--
+-- Kept so the v3 -> v4 migration is tested against the database people
+-- actually have, rather than against the current schema with columns
+-- removed — a state that never existed and cannot fail the way a real one
+-- does. Never edit this file; add a migration instead.
+--
+-- Ledger store for the memory-driven chief-of-staff recipe.
+--
+-- Target runtime : SQLite bundled with Hermes 0.19.0 (the version the current
+--                  NemoClaw agent image pins).
+-- Location       : $HERMES_HOME/workspace/ledger/state.db
+--                  `workspace` is user-owned, so this file survives
+--                  `hermes profile install --force` and `hermes profile update`.
+--                  Verified empirically on Hermes 0.19.0.
+-- Writer         : scripts/apply_decisions.py is the ONLY writer. The model
+--                  never emits SQL; it returns a decision envelope as JSON.
+--
+-- Privacy note   : `items` retains message subjects, senders and bodies once a
+--                  source is connected. The containing directory is created
+--                  0700. Body retention is not implemented in this phase; it
+--                  arrives with the connectors that produce bodies.
+
+PRAGMA journal_mode = WAL;
+PRAGMA busy_timeout = 5000;
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS meta (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+INSERT OR IGNORE INTO meta(key, value) VALUES ('schema_version', '3');
+
+
+-- ---------------------------------------------------------------------------
+-- 1) items — every inbound message we have looked at.
+--    Intake is idempotent on source_id, so re-reading a source is safe.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS items (
+    -- Email: the Graph message id. Slack: "<channel_id>:<ts>", because a
+    -- Slack timestamp is only unique within its channel.
+    source_id   TEXT PRIMARY KEY,
+    source      TEXT NOT NULL CHECK (source IN ('email','slack')),
+    scope       TEXT NOT NULL,              -- mail folder id / slack channel id
+    thread_ref  TEXT,                       -- groups replies; NULL when standalone
+    -- ISO-8601 UTC. Slack returns an epoch float and must be converted at
+    -- ingest so both sources sort together.
+    event_at    TEXT NOT NULL,
+    sender      TEXT,
+    -- Who the sender is, as opposed to what they are called.
+    --
+    -- `sender` holds a display name whenever the source supplies one, and a
+    -- display name is not an identity: two people called the same thing share
+    -- a page, and the second overwrites the first's history under the first's
+    -- name. Neither is recoverable afterwards, because nothing else in the
+    -- row distinguishes them.
+    --
+    -- Both normalizers already compute a stable value — a mail address, a
+    -- Slack user id — and until now dropped it before the insert. It is kept
+    -- here so a page can be named after the person rather than after the
+    -- string they happen to be displayed as. Nullable: rows collected before
+    -- this column existed have none, and a collector that cannot supply one
+    -- is not a reason to refuse the message.
+    sender_key  TEXT,                       -- display name or address
+    subject     TEXT,                       -- NULL for slack
+    body        TEXT,
+    -- Set when the retention pass clears `body`, and never otherwise. It is
+    -- what tells a cleared message from one that never carried text: both
+    -- leave `body` NULL, and only one of them is a message somebody sent.
+    body_cleared_at TEXT,
+    permalink   TEXT,                       -- link back to the source system
+
+    -- Normalized across sources, because the judging rules ask the same
+    -- question of both: was this aimed at the user, or did they merely
+    -- receive it? Email: a To recipient is 'direct', Cc-only is 'broadcast'.
+    -- Slack: an im/mpim is 'direct', a channel message that @-mentions the
+    -- user is 'mentioned', anything else is 'broadcast'.
+    addressing  TEXT CHECK (addressing IN ('direct','mentioned','broadcast')),
+    -- Email only; Slack tracks read state per channel, not per message.
+    unread      INTEGER CHECK (unread IN (0,1)),
+    state       TEXT NOT NULL
+                CHECK (state IN ('pending','judged','skipped'))
+                DEFAULT 'pending',
+    state_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
+-- Intake selector reads this: oldest pending first.
+CREATE INDEX IF NOT EXISTS idx_items_pending ON items(state, event_at);
+-- Body pruning reads this.
+CREATE INDEX IF NOT EXISTS idx_items_event_at ON items(event_at) WHERE body IS NOT NULL;
+
+
+-- ---------------------------------------------------------------------------
+-- 2) obligations — the revisable judgment. At most one per item.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS obligations (
+    id              TEXT PRIMARY KEY,       -- generated by the writer, never by the model
+    source_id       TEXT NOT NULL UNIQUE
+                    REFERENCES items(source_id) ON DELETE CASCADE,
+
+    -- what the model judged
+    title           TEXT NOT NULL,
+    context         TEXT,
+    urgency_reason  TEXT,
+    kind            TEXT CHECK (kind IN ('response','action')),
+    est_effort      TEXT CHECK (est_effort IN ('minutes','hours','day','multi_day')),
+
+    -- ranking
+    priority        TEXT NOT NULL CHECK (priority IN ('high','medium','low')),
+    manual_priority TEXT CHECK (manual_priority IN ('high','medium','low')),
+    global_rank     INTEGER,
+    -- The position the model gave this row when it was last judged, within
+    -- that batch only. Tier and global_rank are derived from the whole open
+    -- population afterwards; a batch cannot see its siblings.
+    batch_rank      INTEGER,
+    -- Did this row pass the intent gate on its last ranking pass?
+    -- Recorded so the shortlist can explain WHY a row is capped at medium:
+    -- "urgent, but not something you chose to work on" is a different answer
+    -- from "not urgent". The gate itself is defined in the review skill.
+    intent_gated    INTEGER NOT NULL DEFAULT 0 CHECK (intent_gated IN (0,1)),
+
+    -- lifecycle
+    status          TEXT NOT NULL
+                    CHECK (status IN ('open','done','ignored'))
+                    DEFAULT 'open',
+    snoozed_until   TEXT,
+    snooze_count    INTEGER NOT NULL DEFAULT 0,
+
+    created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    updated_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    reviewed_at     TEXT                    -- NULL = never reviewed; drives selection
+);
+
+-- Review selector: stalest open rows first, NULL (never reviewed) ahead of all.
+CREATE INDEX IF NOT EXISTS idx_obl_review ON obligations(status, reviewed_at);
+-- Shortlist read path.
+CREATE INDEX IF NOT EXISTS idx_obl_rank ON obligations(status, global_rank);
+-- Two open rows must never claim the same position. Enforced here as well as
+-- in code, because a duplicate rank is the visible symptom of ranking a batch
+-- instead of the population.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_obl_rank_unique
+    ON obligations(global_rank) WHERE status='open' AND global_rank IS NOT NULL;
+-- Wake-up scan for expiring snoozes.
+CREATE INDEX IF NOT EXISTS idx_obl_snooze ON obligations(status, snoozed_until)
+    WHERE snoozed_until IS NOT NULL;
+
+CREATE TRIGGER IF NOT EXISTS obligations_touch
+AFTER UPDATE ON obligations
+BEGIN
+    UPDATE obligations
+       SET updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+     WHERE id = NEW.id;
+END;
+
+
+-- ---------------------------------------------------------------------------
+-- 3) events — append-only audit. Never pruned, never updated.
+--    This is what makes "corrections train policy" checkable rather than
+--    asserted: the policy generator counts user-actor rows.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS events (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    obligation_id TEXT NOT NULL REFERENCES obligations(id) ON DELETE CASCADE,
+    ts            TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    event_type    TEXT NOT NULL CHECK (event_type IN (
+                      'created','reranked','snoozed','unsnoozed',
+                      'ignored','restored','completed','priority_override')),
+    actor         TEXT NOT NULL CHECK (actor IN ('agent','user')),
+    before_json   TEXT,
+    after_json    TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_obl ON events(obligation_id, ts);
+-- Policy generator reads this: user corrections only.
+CREATE INDEX IF NOT EXISTS idx_events_corrections ON events(actor, event_type, ts);
+
+
+-- ---------------------------------------------------------------------------
+-- 4) cursors — per (source, scope) watermark, advanced in the SAME transaction
+--    as the rows it covers. Crash leaves either both or neither.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS cursors (
+    source     TEXT NOT NULL,
+    scope      TEXT NOT NULL,
+    cursor     TEXT NOT NULL,
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    PRIMARY KEY (source, scope)
+);
+

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/schema.sql
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/schema.sql
@@ -68,6 +68,14 @@ CREATE TABLE IF NOT EXISTS items (
     -- question. The row survives either way, because obligations and events
     -- hang off `source_id` and removing it would break the audit trail.
     deleted_at    TEXT,
+    -- The message's own identity, as opposed to its position in a folder.
+    --
+    -- Needed to tell a deletion from a move: the delta query reports both
+    -- identically and the per-folder id changes when a message moves, so
+    -- this is the only thing that survives to ask about. Kept on the row
+    -- rather than in a bounded map beside it — a map that evicts turns an
+    -- older message being filed away into a deletion, and clears its body.
+    internet_message_id TEXT,
     permalink   TEXT,                       -- link back to the source system
 
     -- Normalized across sources, because the judging rules ask the same

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/schema.sql
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/schema.sql
@@ -22,7 +22,7 @@ CREATE TABLE IF NOT EXISTS meta (
     key   TEXT PRIMARY KEY,
     value TEXT NOT NULL
 );
-INSERT OR IGNORE INTO meta(key, value) VALUES ('schema_version', '3');
+INSERT OR IGNORE INTO meta(key, value) VALUES ('schema_version', '4');
 
 
 -- ---------------------------------------------------------------------------
@@ -54,13 +54,20 @@ CREATE TABLE IF NOT EXISTS items (
     -- string they happen to be displayed as. Nullable: rows collected before
     -- this column existed have none, and a collector that cannot supply one
     -- is not a reason to refuse the message.
-    sender_key  TEXT,                       -- display name or address
+    sender_key  TEXT,                       -- address or user id, never a name
     subject     TEXT,                       -- NULL for slack
     body        TEXT,
     -- Set when the retention pass clears `body`, and never otherwise. It is
     -- what tells a cleared message from one that never carried text: both
     -- leave `body` NULL, and only one of them is a message somebody sent.
     body_cleared_at TEXT,
+    -- Set when the source says the message is gone. Distinct from
+    -- `body_cleared_at`, which records this recipe ageing the text out on its
+    -- own schedule: one is the person deleting something, the other is us
+    -- forgetting it, and a report that conflates them answers the wrong
+    -- question. The row survives either way, because obligations and events
+    -- hang off `source_id` and removing it would break the audit trail.
+    deleted_at    TEXT,
     permalink   TEXT,                       -- link back to the source system
 
     -- Normalized across sources, because the judging rules ask the same

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_durability.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_durability.py
@@ -685,7 +685,8 @@ class TestTheDocumentedTestCountIsTheRealOne(unittest.TestCase):
     terminal is a claim, so it gets an assertion like any other.
     """
 
-    WORDS = {"nine": 9, "ten": 10, "eleven": 11, "twelve": 12}
+    WORDS = {"nine": 9, "ten": 10, "eleven": 11, "twelve": 12,
+             "thirteen": 13, "fourteen": 14, "fifteen": 15}
 
     def _documented(self):
         readme = (HERE.parents[1] / "README.md").read_text(encoding="utf-8")

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_ingest_graph.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_ingest_graph.py
@@ -505,18 +505,34 @@ class TestTheMailboxIdentityIsChecked(CollectorCase):
         self.assertIn("/delta?", "".join(self.graph.calls),
                       "did not start a fresh round for the new mailbox")
 
-    def test_a_changed_mailbox_forgets_the_old_message_identities(self):
-        """They answer "moved or deleted" for messages in a mailbox nobody is
-        reading any more."""
+    def test_a_changed_mailbox_does_not_answer_removals_from_the_old_one(self):
+        """Message identities used to live in a map beside the cursor, and
+        the map had to be discarded with it. They now live on the row, where
+        the question is which mailbox a row belongs to.
+
+        Graph ids are per-mailbox, so a removal reported by the new mailbox
+        names an id the store has never seen. That is the `unknown` case: no
+        row is tombstoned, and the old mailbox's messages are left exactly as
+        they were rather than being resolved against a different inbox.
+        """
         self.serve([{"value": [message("m1")],
                      "@odata.deltaLink": "http://x/final"}])
         self.run_main()
-        self.assertTrue(self.state().get("message_ids"))
 
         self.graph.identity = {"mail": "someone.else@example.com"}
-        self.graph.queue({"value": [], "@odata.deltaLink": "http://x/f2"})
-        self.run_main()
-        self.assertNotIn("m1", self.state().get("message_ids", {}))
+        self.graph.queue({"value": [removed("other-mailbox-id")],
+                          "@odata.deltaLink": "http://x/f2"})
+        self.graph.still_present = False
+        before = self.graph.identity_lookups
+        self.assertEqual(self.run_main(), 0)
+
+        # No request was made, because there was nothing to ask about.
+        self.assertEqual(self.graph.identity_lookups, before)
+        # rows() is (source_id, sender, body, deleted_at, body_cleared_at)
+        self.assertEqual([r[0] for r in self.rows()], ["m1"])
+        self.assertIsNone(self.rows()[0][3],
+                          "a row was tombstoned by another mailbox's removal")
+        self.assertEqual(self.report()["unresolved_removals"], 1)
 
     def test_the_placeholder_staying_the_same_does_not_hide_it(self):
         """The credential is byte-identical across the change; only the
@@ -834,6 +850,60 @@ class TestFailuresCarryTheirDiagnosisInTheExitCode(CollectorCase):
         self.assertEqual(code, ingest_graph.EXIT_RATE_LIMIT)
         self.assertLessEqual(sum(waits),
                              ingest_graph.MAX_TOTAL_BACKOFF_SECONDS)
+
+    def test_a_removal_with_no_identity_is_not_read_as_a_deletion(self):
+        """The case that cleared a body without contacting Graph at all.
+
+        Identities used to live in a map capped at five thousand entries that
+        evicted oldest-first, so filing away an older message produced a
+        removal with nothing to ask about — and the absence was read as a
+        deletion. A row collected before the column existed is the same
+        situation, and is the one that survives the map being gone.
+        """
+        self.serve([{"value": [message("m1")],
+                     "@odata.deltaLink": "http://x/final"}])
+        self.run_main()
+        # Exactly a v3 row: collected, but with no identity of its own.
+        with sqlite3.connect(self.db) as conn:
+            conn.execute("UPDATE items SET internet_message_id = NULL")
+
+        self.graph.queue({"value": [removed("m1")],
+                          "@odata.deltaLink": "http://x/final2"})
+        before = self.graph.identity_lookups
+        self.assertEqual(self.run_main(), 0)
+
+        self.assertEqual(self.graph.identity_lookups, before,
+                         "asked Graph a question it had no id for")
+        self.assertIsNone(self.rows()[0][3],
+                          "tombstoned a message it could not ask about")
+        self.assertIsNotNone(self.rows()[0][2], "cleared the body anyway")
+        self.assertEqual(self.report()["unresolved_removals"], 1)
+
+    def test_an_identity_learned_earlier_in_the_same_round_answers(self):
+        """A message collected on one page and removed on a later page of the
+        same round. The rows are written before the removals are resolved, so
+        the question can be answered without waiting for the next tick."""
+        self.serve([
+            {"value": [message("m1")], "@odata.nextLink": "http://x/p2"},
+            {"value": [removed("m1")], "@odata.deltaLink": "http://x/final"},
+        ])
+        self.graph.still_present = False
+        self.assertEqual(self.run_main(), 0)
+        self.assertEqual(self.graph.identity_lookups, 1,
+                         "the identity from the first page was not available")
+        self.assertIsNotNone(self.rows()[0][3])
+        self.assertEqual(self.report()["unresolved_removals"], 0)
+
+    def test_a_message_moved_in_the_same_round_is_not_a_deletion(self):
+        """The other half: same arrangement, and the mailbox still has it."""
+        self.serve([
+            {"value": [message("m1")], "@odata.nextLink": "http://x/p2"},
+            {"value": [removed("m1")], "@odata.deltaLink": "http://x/final"},
+        ])
+        self.graph.still_present = True
+        self.assertEqual(self.run_main(), 0)
+        self.assertIsNone(self.rows()[0][3])
+        self.assertEqual(self.report()["moved"], 1)
 
     def test_a_failed_removal_lookup_does_not_let_the_round_advance(self):
         """A removal is reported once.

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_ingest_graph.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_ingest_graph.py
@@ -23,6 +23,7 @@ import io
 import json
 import os
 import shutil
+import subprocess
 import sqlite3
 import sys
 import tempfile
@@ -58,12 +59,20 @@ def message(mid, *, when="2026-08-20T09:00:00Z", sender="Dana Okoro",
         "parentFolderId": "inbox",
         "conversationId": "c1",
         "webLink": "https://outlook.example/" + mid,
+        "internetMessageId": "<%s@example.com>" % mid,
     }
 
 
-def removed(mid, reason="deleted"):
-    """What a delta page carries for something that is gone."""
-    return {"id": mid, "@removed": {"reason": reason}}
+def removed(mid):
+    """What a delta page carries for something that left the folder.
+
+    Always `deleted`, whether the message was deleted or filed elsewhere —
+    measured against the live service, where moving one to Archive produces
+    exactly this. An earlier version of these tests invented a `changed`
+    reason for a move; no such value exists, so the collector's handling of
+    moves was asserted against a payload Graph never sends.
+    """
+    return {"id": mid, "@removed": {"reason": "deleted"}}
 
 
 class FakeGraph:
@@ -77,6 +86,12 @@ class FakeGraph:
         self.headers_seen: list[str] = []
         self.identity = {"mail": ME, "displayName": "Avery"}
         self.status_for_next = None
+        # Whether a message that left the folder is still somewhere in the
+        # mailbox. `True` is a move, `False` is a deletion — the service tells
+        # them apart no other way.
+        self.still_present = False
+        self.identity_lookups = 0
+        self.rate_limit_forever = False
         outer = self
 
         class Handler(BaseHTTPRequestHandler):
@@ -90,6 +105,22 @@ class FakeGraph:
 
                 if parsed.path.endswith("/me"):
                     return outer._send(self, 200, outer.identity)
+
+                if parsed.path.endswith("/messages") and "filter" in self.path:
+                    # The "is it still in the mailbox" question, asked by
+                    # `internetMessageId` when something leaves the folder.
+                    outer.identity_lookups += 1
+                    hits = [{"id": "elsewhere"}] if outer.still_present else []
+                    return outer._send(self, 200, {"value": hits})
+
+                if outer.rate_limit_forever:
+                    body = json.dumps({"error": {"code": "throttled"}}).encode()
+                    self.send_response(429)
+                    self.send_header("Retry-After", "1")
+                    self.send_header("Content-Length", str(len(body)))
+                    self.end_headers()
+                    self.wfile.write(body)
+                    return
 
                 if outer.status_for_next is not None:
                     code = outer.status_for_next
@@ -274,16 +305,42 @@ class TestDeletionIsReconciled(CollectorCase):
         self.run_main()
         self.assertEqual(self.rows()[0][1], "Dana Okoro")
 
-    def test_a_move_is_not_a_deletion(self):
-        """`@removed` carries a reason, and `changed` means it left the scope
-        being synchronised — filing something is not deleting it."""
+    def test_a_message_filed_elsewhere_is_not_a_deletion(self):
+        """Graph reports a move out of the folder exactly as it reports a
+        deletion, and the per-folder id changes so it cannot answer either.
+        What survives a move is `internetMessageId`; if the mailbox still
+        holds it, the message was filed rather than deleted."""
         self.stored()
-        self.graph.queue({"value": [removed("m1", reason="changed")],
+        self.graph.still_present = True
+        self.graph.queue({"value": [removed("m1")],
                           "@odata.deltaLink": "http://x/final2"})
         self.run_main()
         row = self.rows()[0]
-        self.assertIsNone(row[3], "a moved message was tombstoned")
-        self.assertIsNotNone(row[2], "a moved message lost its body")
+        self.assertIsNone(row[3], "a filed message was tombstoned")
+        self.assertIsNotNone(row[2], "a filed message lost its body")
+        self.assertEqual(self.report()["moved"], 1)
+        self.assertEqual(self.report()["removed"], 0)
+
+    def test_the_question_is_actually_asked(self):
+        """Without the lookup the two cases are indistinguishable, so a test
+        that never sees the request is not testing the distinction."""
+        self.stored()
+        self.graph.still_present = True
+        before = self.graph.identity_lookups
+        self.graph.queue({"value": [removed("m1")],
+                          "@odata.deltaLink": "http://x/final2"})
+        self.run_main()
+        self.assertGreater(self.graph.identity_lookups, before)
+
+    def test_a_message_gone_from_the_mailbox_is_a_deletion(self):
+        self.stored()
+        self.graph.still_present = False
+        self.graph.queue({"value": [removed("m1")],
+                          "@odata.deltaLink": "http://x/final2"})
+        self.run_main()
+        row = self.rows()[0]
+        self.assertIsNotNone(row[3])
+        self.assertIsNone(row[2])
 
     def test_the_report_counts_removals(self):
         self.stored()
@@ -373,6 +430,200 @@ class TestTheCursorIsTheWatermark(CollectorCase):
         self.assertEqual(self.run_main(), ingest_graph.EXIT_OK)
         self.assertTrue(self.report().get("resynchronised"))
         self.assertIn("m2", [r[0] for r in self.rows()])
+
+
+class TestTheMailboxIdentityIsChecked(CollectorCase):
+    """Inside the sandbox the credential is a placeholder the gateway
+    substitutes, and it does not change when the token behind it does."""
+
+    def test_a_changed_mailbox_discards_the_previous_cursor(self):
+        """The cursor is the thing that must not carry over.
+
+        Asserting that the recorded address changed proves nothing: it is
+        written on every run regardless. What matters is that a cursor issued
+        for one mailbox is not used to ask another what has changed.
+        """
+        self.serve([{"value": [message("m1")],
+                     "@odata.deltaLink": "http://x/first-mailbox"}])
+        self.run_main()
+        first_cursor = self.state()["delta"]
+        self.assertIn("first-mailbox", first_cursor)
+
+        self.graph.identity = {"mail": "someone.else@example.com",
+                               "displayName": "Someone Else"}
+        self.graph.calls.clear()
+        self.graph.queue({"value": [message("m2")],
+                          "@odata.deltaLink": "http://x/second-mailbox"})
+        self.run_main()
+
+        followed = [c for c in self.graph.calls if "first-mailbox" in c]
+        self.assertEqual(followed, [],
+                         "asked the new mailbox what changed since the old "
+                         "one's cursor")
+        self.assertIn("/delta?", "".join(self.graph.calls),
+                      "did not start a fresh round for the new mailbox")
+
+    def test_a_changed_mailbox_forgets_the_old_message_identities(self):
+        """They answer "moved or deleted" for messages in a mailbox nobody is
+        reading any more."""
+        self.serve([{"value": [message("m1")],
+                     "@odata.deltaLink": "http://x/final"}])
+        self.run_main()
+        self.assertTrue(self.state().get("message_ids"))
+
+        self.graph.identity = {"mail": "someone.else@example.com"}
+        self.graph.queue({"value": [], "@odata.deltaLink": "http://x/f2"})
+        self.run_main()
+        self.assertNotIn("m1", self.state().get("message_ids", {}))
+
+    def test_the_placeholder_staying_the_same_does_not_hide_it(self):
+        """The credential is byte-identical across the change; only the
+        mailbox differs, so only the mailbox can be compared."""
+        self.serve([{"value": [], "@odata.deltaLink": "http://x/final"}])
+        self.run_main()
+        before = os.environ["MS_GRAPH_ACCESS_TOKEN"]
+        self.graph.identity = {"mail": "other@example.com"}
+        self.graph.queue({"value": [], "@odata.deltaLink": "http://x/f2"})
+        self.run_main()
+        self.assertEqual(os.environ["MS_GRAPH_ACCESS_TOKEN"], before)
+        self.assertEqual(self.state()["identity"]["address"],
+                         "other@example.com")
+
+    def test_the_same_mailbox_keeps_its_cursor(self):
+        """Re-checking must not become re-synchronising every tick."""
+        self.serve([{"value": [], "@odata.deltaLink": "http://x/final"}])
+        self.run_main()
+        first = self.state()["delta"]
+        self.graph.queue({"value": [], "@odata.deltaLink": "http://x/final"})
+        self.run_main()
+        self.assertEqual(self.state()["delta"], first)
+
+
+class TestTheScopesAreTheOnesUsed(CollectorCase):
+    """A setup that depends on a permission it does not request is a setup
+    that works for whoever already had it."""
+
+    RECIPE = HERE.parents[1]
+
+    def scopes_requested(self):
+        """The `SCOPES=` line, not the whole file.
+
+        Searching the file finds the comment explaining why `User.Read` is
+        needed, which stays true whether or not the flow asks for it — so the
+        first version of this passed with the scope deleted.
+        """
+        setup = (self.RECIPE / "scripts" / "setup-graph.sh").read_text(
+            encoding="utf-8")
+        line = [l for l in setup.splitlines() if l.startswith("SCOPES=")]
+        self.assertEqual(len(line), 1, "expected exactly one SCOPES= line")
+        return line[0]
+
+    def test_user_read_is_requested_because_me_is_read(self):
+        collector = (HERE / "ingest_graph.py").read_text(encoding="utf-8")
+        self.assertIn("/me?", collector)
+        self.assertIn("User.Read", self.scopes_requested())
+
+    def test_the_profile_refreshes_with_named_scopes(self):
+        """`.default` returns whatever the client already has, which is more
+        than this needs and grows as an administrator grants more."""
+        profile = (self.RECIPE / "providers" / "graph-user.yaml").read_text(
+            encoding="utf-8")
+        # Asserted on the scope list rather than on the file, because the file
+        # names `.default` in the comment explaining why it is not used —
+        # which is worth keeping and is not a use of it.
+        block = profile.split("scopes:", 1)[1].split("material:", 1)[0]
+        self.assertNotIn(".default", block)
+        self.assertIn("Mail.Read", block)
+        self.assertIn("User.Read", block)
+        self.assertIn("offline_access", block)
+
+    def test_the_setup_and_the_profile_ask_for_the_same_thing(self):
+        requested = self.scopes_requested()
+        profile = (self.RECIPE / "providers" / "graph-user.yaml").read_text(
+            encoding="utf-8")
+        block = profile.split("scopes:", 1)[1].split("material:", 1)[0]
+        for scope in ("Mail.Read", "User.Read", "offline_access"):
+            self.assertIn(scope, requested, scope)
+            self.assertIn(scope, block, scope)
+
+
+class TestTheGraphSetupRefusesAnIncompleteProvider(unittest.TestCase):
+    """A provider that attaches cleanly and stops within the hour is worse
+    than one that refuses: the setup reports success and the failure arrives
+    later, unattended."""
+
+    RECIPE = HERE.parents[1]
+    SCRIPT = RECIPE / "scripts" / "setup-graph.sh"
+
+    def fake_openshell(self, folder, *, refresh_ok=True, strategy="oauth2_refresh_token"):
+        stub = folder / "openshell"
+        status = (f"STRATEGY {strategy} STATUS refreshed"
+                  if refresh_ok else "")
+        rc = "0" if refresh_ok else "1"
+        profile = json.dumps({
+            "id": "memory-driven-cos-graph-user",
+            "endpoints": [{"host": "graph.microsoft.com", "port": 443,
+                           "protocol": "rest", "access": "read-only",
+                           "enforcement": "enforce"}],
+            "credentials": [{"env_vars": ["MS_GRAPH_ACCESS_TOKEN"]}],
+            "binaries": ["/usr/bin/python3"]})
+        stub.write_text(f"""#!/usr/bin/env bash
+case "$1 $2" in
+  "sandbox provider") cat <<'LIST'
+NAME  TYPE  CREDENTIAL_KEYS
+mdcos-graph  memory-driven-cos-graph-user  1
+LIST
+  ;;
+  "provider get") printf 'Type: memory-driven-cos-graph-user\nCredential keys: MS_GRAPH_ACCESS_TOKEN\n' ;;
+  "provider refresh") printf '%s\n' {status!r}; exit {rc} ;;
+  "provider profile") cat <<'JSON'
+{profile}
+JSON
+  ;;
+  *) exit 0 ;;
+esac
+""", encoding="utf-8")
+        stub.chmod(0o755)
+        uname = folder / "uname"
+        uname.write_text("#!/usr/bin/env bash\necho Linux\n", encoding="utf-8")
+        uname.chmod(0o755)
+        return folder
+
+    def run_setup(self, folder):
+        return subprocess.run(
+            ["bash", str(self.SCRIPT)], capture_output=True, text=True,
+            stdin=subprocess.DEVNULL, cwd=str(self.RECIPE),
+            env={"PATH": f"{folder}:{os.environ['PATH']}",
+                 "HOME": str(folder), "OPENSHELL_SANDBOX": "",
+                 "SANDBOX_STORAGE_PATH": str(folder),
+                 "STORE_ENCRYPTION_ACKNOWLEDGED": "1"})
+
+    def test_a_provider_with_refresh_is_reusable(self):
+        with tempfile.TemporaryDirectory() as folder:
+            folder = Path(folder)
+            self.fake_openshell(folder)
+            proc = self.run_setup(folder)
+        self.assertIn("Nothing to do", proc.stdout)
+
+    def test_a_provider_without_refresh_is_refused(self):
+        with tempfile.TemporaryDirectory() as folder:
+            folder = Path(folder)
+            self.fake_openshell(folder, refresh_ok=False)
+            proc = self.run_setup(folder)
+        out = proc.stdout + proc.stderr
+        self.assertNotIn("Nothing to do", out,
+                         "reported a finished setup for a credential that "
+                         "would expire within the hour")
+        self.assertIn("refresh", out)
+
+    def test_a_provider_with_the_wrong_strategy_is_refused(self):
+        with tempfile.TemporaryDirectory() as folder:
+            folder = Path(folder)
+            self.fake_openshell(folder, strategy="static")
+            proc = self.run_setup(folder)
+        out = proc.stdout + proc.stderr
+        self.assertNotIn("Nothing to do", out)
+        self.assertIn("rotation", out)
 
 
 class TestTheFirstRoundIsBounded(CollectorCase):
@@ -471,10 +722,29 @@ class TestFailuresCarryTheirDiagnosisInTheExitCode(CollectorCase):
         self.graph.identity = {"displayName": "App"}
         self.assertEqual(self.run_main(), ingest_graph.EXIT_SCOPE)
 
-    def test_rate_limiting_has_its_own_code(self):
+    def test_an_unrecognised_status_is_the_general_code(self):
+        """This test used to be named for rate limiting and sent a 500."""
         self.serve([{"value": [], "@odata.deltaLink": "http://x/final"}])
         self.graph.status_for_next = 500
         self.assertEqual(self.run_main(), ingest_graph.EXIT_OTHER)
+
+    def test_relentless_throttling_ends_the_tick(self):
+        """A `Retry-After` inside the per-wait bound, over and over, is a loop
+        with no exit: the page budget counts successful responses and a cron
+        pre-step has no timeout of its own. Reproduced at review as 9,248
+        retries still going."""
+        self.serve([{"value": [], "@odata.deltaLink": "http://x/final"}])
+        self.graph.rate_limit_forever = True
+        ingest_graph.MAX_TOTAL_BACKOFF_SECONDS = 3
+        try:
+            self.assertEqual(self.run_main(), ingest_graph.EXIT_RATE_LIMIT)
+        finally:
+            ingest_graph.MAX_TOTAL_BACKOFF_SECONDS = 120
+
+    def test_the_throttling_bound_is_a_total_not_a_per_wait(self):
+        """Each individual wait was already bounded; the sum was not."""
+        self.assertLessEqual(ingest_graph.MAX_BACKOFF_SECONDS,
+                             ingest_graph.MAX_TOTAL_BACKOFF_SECONDS)
 
     def test_something_unrecognised_in_the_variable_is_refused(self):
         os.environ["MS_GRAPH_ACCESS_TOKEN"] = "not-a-token"

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_ingest_graph.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_ingest_graph.py
@@ -29,6 +29,7 @@ import sys
 import tempfile
 import threading
 import unittest
+import unittest.mock
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
@@ -92,6 +93,15 @@ class FakeGraph:
         self.still_present = False
         self.identity_lookups = 0
         self.rate_limit_forever = False
+        # The removal lookup answers before the rate-limit branch, so it needs
+        # knobs of its own to be made slow or made to fail.
+        self.rate_limit_lookups = False
+        self.lookup_status = None
+        # Throttle each request this many times, then let it through. Unlike
+        # `rate_limit_forever` this lets a tick make several requests, which
+        # is the only way a per-request bound and a per-tick one differ.
+        self.throttle_per_request = 0
+        self.throttled_since_success = 0
         outer = self
 
         class Handler(BaseHTTPRequestHandler):
@@ -110,10 +120,25 @@ class FakeGraph:
                     # The "is it still in the mailbox" question, asked by
                     # `internetMessageId` when something leaves the folder.
                     outer.identity_lookups += 1
+                    if outer.lookup_status is not None:
+                        return outer._send(self, outer.lookup_status,
+                                           {"error": {"code": "x"}})
+                    if outer.rate_limit_lookups:
+                        body = json.dumps(
+                            {"error": {"code": "throttled"}}).encode()
+                        self.send_response(429)
+                        self.send_header("Retry-After", "1")
+                        self.send_header("Content-Length", str(len(body)))
+                        self.end_headers()
+                        self.wfile.write(body)
+                        return
                     hits = [{"id": "elsewhere"}] if outer.still_present else []
                     return outer._send(self, 200, {"value": hits})
 
-                if outer.rate_limit_forever:
+                throttling = outer.rate_limit_forever or (
+                    outer.throttled_since_success < outer.throttle_per_request)
+                if throttling:
+                    outer.throttled_since_success += 1
                     body = json.dumps({"error": {"code": "throttled"}}).encode()
                     self.send_response(429)
                     self.send_header("Retry-After", "1")
@@ -121,6 +146,7 @@ class FakeGraph:
                     self.end_headers()
                     self.wfile.write(body)
                     return
+                outer.throttled_since_success = 0
 
                 if outer.status_for_next is not None:
                     code = outer.status_for_next
@@ -213,6 +239,22 @@ class CollectorCase(unittest.TestCase):
             code = ingest_graph.main(args or [])
         self.stdout = buffer.getvalue()
         return code
+
+    def run_main_recording_waits(self, args=None):
+        """Run a tick, recording every sleep it asks for instead of taking it.
+
+        Taking them would make this test wait out the real budget, which is
+        two minutes by design. What is under test is the arithmetic across
+        requests, and that is visible without the waiting.
+        """
+        recorded: list[float] = []
+        real_sleep = ingest_graph.time.sleep
+        ingest_graph.time.sleep = recorded.append
+        try:
+            code = self.run_main(args)
+        finally:
+            ingest_graph.time.sleep = real_sleep
+        return code, recorded
 
     def report(self):
         return json.loads(self.stdout)
@@ -741,10 +783,99 @@ class TestFailuresCarryTheirDiagnosisInTheExitCode(CollectorCase):
         finally:
             ingest_graph.MAX_TOTAL_BACKOFF_SECONDS = 120
 
-    def test_the_throttling_bound_is_a_total_not_a_per_wait(self):
-        """Each individual wait was already bounded; the sum was not."""
-        self.assertLessEqual(ingest_graph.MAX_BACKOFF_SECONDS,
+    def test_the_waiting_bound_belongs_to_the_tick_not_the_request(self):
+        """The bound is what one run may spend waiting, in total.
+
+        Held per request it multiplied by the number of requests: a page
+        budget of ten turned a two-minute ceiling into twenty minutes in
+        `sleep`. Comparing the two constants — which is what this test used to
+        do — could not see that, and stayed green throughout.
+
+        Several pages, each throttled for a while and then served, so the
+        tick makes more than one request — which is the only arrangement in
+        which a per-request bound and a per-tick one differ at all. Each
+        request stays inside the per-request bound; together they do not.
+        """
+        self.serve([{"value": [message("m%d" % n)],
+                     "@odata.nextLink": "http://x/p%d" % n}
+                    for n in range(4)])
+        # Four requests at 40 seconds each: none of them alone exceeds the
+        # two-minute bound, and the four together exceed it by a third.
+        self.graph.throttle_per_request = 40
+        code, waits = self.run_main_recording_waits()
+        self.assertEqual(code, ingest_graph.EXIT_RATE_LIMIT)
+        self.assertLessEqual(sum(waits),
                              ingest_graph.MAX_TOTAL_BACKOFF_SECONDS)
+        # More than one request really was throttled, or the bound above is
+        # met by a tick that only ever made one.
+        self.assertGreater(len(waits), 40)
+
+    def test_the_budget_already_spent_is_not_refunded_by_a_new_request(self):
+        """The unit under the end-to-end test, stated directly."""
+        budget = ingest_graph.Budget(seconds=3)
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(unittest.mock.patch.object(
+                ingest_graph.time, "sleep", lambda s: None))
+            budget.spend(2)
+            with self.assertRaises(ingest_graph.GraphError) as caught:
+                budget.spend(2)
+        self.assertEqual(caught.exception.kind, "rate_limit")
+
+    def test_throttling_during_a_removal_lookup_is_bounded_too(self):
+        """The lookup is a Graph request like any other, and it is the one
+        made most often when something has been deleted."""
+        self.serve([{"value": [message("m1")],
+                     "@odata.deltaLink": "http://x/final"}])
+        self.run_main()
+        self.graph.queue({"value": [removed("m1")],
+                          "@odata.deltaLink": "http://x/final2"})
+        self.graph.rate_limit_lookups = True
+        code, waits = self.run_main_recording_waits()
+        self.assertEqual(code, ingest_graph.EXIT_RATE_LIMIT)
+        self.assertLessEqual(sum(waits),
+                             ingest_graph.MAX_TOTAL_BACKOFF_SECONDS)
+
+    def test_a_failed_removal_lookup_does_not_let_the_round_advance(self):
+        """A removal is reported once.
+
+        Reading a failed lookup as "it moved" finishes the round, advances the
+        cursor past the page that carried the removal, and nothing ever asks
+        again — the message stays in the store as though it were never
+        deleted. So the round has to stop instead.
+        """
+        self.serve([{"value": [message("m1")],
+                     "@odata.deltaLink": "http://x/final"}])
+        self.run_main()
+        before = self.state().get("delta")
+
+        self.graph.queue({"value": [removed("m1")],
+                          "@odata.deltaLink": "http://x/moved-on"})
+        self.graph.lookup_status = 500
+        self.assertEqual(self.run_main(), ingest_graph.EXIT_OTHER)
+        self.assertEqual(self.state().get("delta"), before,
+                         "the cursor advanced past an unresolved removal")
+        # rows() is (source_id, sender, body, deleted_at, body_cleared_at)
+        self.assertIsNone(self.rows()[0][3],
+                          "a message was tombstoned on a failed lookup")
+
+        # And the next tick, with the service answering, resolves it.
+        self.graph.lookup_status = None
+        self.graph.still_present = False
+        self.graph.queue({"value": [removed("m1")],
+                          "@odata.deltaLink": "http://x/final3"})
+        self.assertEqual(self.run_main(), 0)
+        self.assertIsNotNone(self.rows()[0][3])
+
+    def test_a_failed_removal_lookup_keeps_the_reason_it_failed(self):
+        """The exit code still has to say what went wrong; a credential that
+        expired mid-round is not the same operator problem as a timeout."""
+        self.serve([{"value": [message("m1")],
+                     "@odata.deltaLink": "http://x/final"}])
+        self.run_main()
+        self.graph.queue({"value": [removed("m1")],
+                          "@odata.deltaLink": "http://x/final2"})
+        self.graph.lookup_status = 401
+        self.assertEqual(self.run_main(), ingest_graph.EXIT_CREDENTIAL)
 
     def test_something_unrecognised_in_the_variable_is_refused(self):
         os.environ["MS_GRAPH_ACCESS_TOKEN"] = "not-a-token"

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_ingest_graph.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_ingest_graph.py
@@ -1,0 +1,516 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The Graph collector, against a stand-in Graph.
+
+These run the real module against a local HTTP server that answers the way
+Microsoft Graph does, including the parts that only matter when something goes
+wrong: an expired delta cursor, a page that arrives without a cursor of any
+kind, a removal that is a move rather than a deletion. Those are exactly the
+paths a test that reads the source cannot see.
+
+The delta protocol is what most of this is about. A cursor is opaque and is
+only issued when a round completes, so several properties this collector needs
+— a partial crawl not advancing the watermark, an interrupted round resuming
+rather than restarting — are properties of how the cursor is handled rather
+than of arithmetic anybody could check by reading.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import shutil
+import sqlite3
+import sys
+import tempfile
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+HERE = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(HERE))
+
+import ingest_graph  # noqa: E402
+
+SCHEMA = (HERE / "schema.sql").read_text(encoding="utf-8")
+
+ME = "avery@example.com"
+PLACEHOLDER = "openshell:resolve:env:v1_MS_GRAPH_ACCESS_TOKEN"
+
+
+def message(mid, *, when="2026-08-20T09:00:00Z", sender="Dana Okoro",
+            address="dana@example.com", subject="about the cutover",
+            body="the window is Thursday"):
+    return {
+        "id": mid,
+        "receivedDateTime": when,
+        "subject": subject,
+        "body": {"contentType": "text", "content": body},
+        "from": {"emailAddress": {"name": sender, "address": address}},
+        "toRecipients": [{"emailAddress": {"address": ME}}],
+        "ccRecipients": [],
+        "isRead": False,
+        "parentFolderId": "inbox",
+        "conversationId": "c1",
+        "webLink": "https://outlook.example/" + mid,
+    }
+
+
+def removed(mid, reason="deleted"):
+    """What a delta page carries for something that is gone."""
+    return {"id": mid, "@removed": {"reason": reason}}
+
+
+class FakeGraph:
+    """A Graph that answers from a script, and records what it was asked."""
+
+    def __init__(self, pages):
+        # `pages` is a list of dicts, served in order for successive delta
+        # requests. Anything else is answered from `identity`.
+        self.pages = list(pages)
+        self.calls: list[str] = []
+        self.headers_seen: list[str] = []
+        self.identity = {"mail": ME, "displayName": "Avery"}
+        self.status_for_next = None
+        outer = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, *a):  # noqa: A003
+                pass
+
+            def do_GET(self):  # noqa: N802
+                parsed = urlparse(self.path)
+                outer.calls.append(self.path)
+                outer.headers_seen.append(self.headers.get("Authorization", ""))
+
+                if parsed.path.endswith("/me"):
+                    return outer._send(self, 200, outer.identity)
+
+                if outer.status_for_next is not None:
+                    code = outer.status_for_next
+                    outer.status_for_next = None
+                    return outer._send(self, code, {"error": {"code": "x"}})
+
+                if outer.pages:
+                    return outer._send(self, 200, outer.pages.pop(0))
+                return outer._send(self, 200, {"value": [],
+                                               "@odata.deltaLink": outer.url
+                                               + "delta-final"})
+
+        self.server = HTTPServer(("127.0.0.1", 0), Handler)
+        self.port = self.server.server_port
+        threading.Thread(target=self.server.serve_forever, daemon=True).start()
+
+    @staticmethod
+    def _send(handler, status, payload):
+        body = json.dumps(payload).encode()
+        handler.send_response(status)
+        handler.send_header("Content-Type", "application/json")
+        handler.send_header("Content-Length", str(len(body)))
+        handler.end_headers()
+        handler.wfile.write(body)
+
+    def queue(self, *pages):
+        """Add pages for later rounds, on the same server.
+
+        Stopping one stand-in and starting another leaves the saved cursor
+        pointing at a dead address, which hangs rather than failing — so the
+        whole of a multi-round test runs against one server.
+        """
+        self.pages.extend(json.loads(
+            json.dumps(list(pages)).replace("http://x/", self.url + "/")))
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self.port}/v1.0"
+
+    def stop(self):
+        self.server.shutdown()
+
+    def delta_requests(self):
+        return [c for c in self.calls if "/delta" in c or "delta-" in c]
+
+
+class CollectorCase(unittest.TestCase):
+    def setUp(self):
+        self.home = tempfile.mkdtemp()
+        Path(self.home, "distribution.yaml").write_text("id: t\n",
+                                                        encoding="utf-8")
+        Path(self.home, "workspace", "ledger").mkdir(parents=True)
+        self.db = Path(self.home) / "workspace" / "ledger" / "state.db"
+        with sqlite3.connect(self.db) as conn:
+            conn.executescript(SCHEMA)
+        os.environ["HERMES_HOME"] = self.home
+        os.environ["MS_GRAPH_ACCESS_TOKEN"] = PLACEHOLDER
+        self.graph = None
+        self._api = ingest_graph.API
+
+    def tearDown(self):
+        if self.graph:
+            self.graph.stop()
+        ingest_graph.API = self._api
+        for name in ("MS_GRAPH_ACCESS_TOKEN", "GRAPH_BACKFILL_DAYS"):
+            os.environ.pop(name, None)
+        shutil.rmtree(self.home, ignore_errors=True)
+
+    def serve(self, pages):
+        """Start a stand-in Graph and point the collector at it.
+
+        Links in the scripted pages are written as `http://x/…` and rewritten
+        to this server's address here. A cursor pointing at a host that does
+        not exist is not a cursor — the collector would follow it, fail to
+        connect, and the test would be measuring the fake rather than the
+        code.
+        """
+        self.graph = FakeGraph(pages)
+        ingest_graph.API = self.graph.url
+        rewritten = json.loads(
+            json.dumps(self.graph.pages).replace("http://x/",
+                                                 self.graph.url + "/"))
+        self.graph.pages = rewritten
+        return self.graph
+
+    def run_main(self, args=None):
+        """Call the collector without its stdout landing in the test report."""
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            code = ingest_graph.main(args or [])
+        self.stdout = buffer.getvalue()
+        return code
+
+    def report(self):
+        return json.loads(self.stdout)
+
+    def rows(self):
+        with sqlite3.connect(self.db) as conn:
+            return conn.execute(
+                "SELECT source_id, sender, body, deleted_at, body_cleared_at"
+                "  FROM items ORDER BY source_id").fetchall()
+
+    def state(self):
+        return ingest_graph.read_state()
+
+
+class TestAFetchWritesRowsTheNormalizerMade(CollectorCase):
+    def test_messages_reach_the_store(self):
+        self.serve([{"value": [message("m1"), message("m2")],
+                     "@odata.deltaLink": "http://x/final"}])
+        self.assertEqual(self.run_main(), ingest_graph.EXIT_OK)
+        self.assertEqual([r[0] for r in self.rows()], ["m1", "m2"])
+
+    def test_the_row_is_what_the_normalizer_makes(self):
+        self.serve([{"value": [message("m1")],
+                     "@odata.deltaLink": "http://x/final"}])
+        self.run_main()
+        row = self.rows()[0]
+        self.assertEqual(row[1], "Dana Okoro")
+        self.assertIn("Thursday", row[2])
+
+    def test_a_second_run_is_idempotent(self):
+        self.serve([{"value": [message("m1")],
+                     "@odata.deltaLink": "http://x/final"},
+                    {"value": [message("m1")],
+                     "@odata.deltaLink": "http://x/final"}])
+        self.run_main()
+        self.run_main()
+        self.assertEqual(len([r for r in self.rows() if r[0] == "m1"]), 1)
+
+    def test_the_report_says_what_it_did(self):
+        self.serve([{"value": [message("m1")],
+                     "@odata.deltaLink": "http://x/final"}])
+        self.run_main()
+        found = self.report()
+        self.assertEqual(found["added"], 1)
+        self.assertTrue(found["complete"])
+        self.assertTrue(found["synchronised"])
+
+
+class TestDeletionIsReconciled(CollectorCase):
+    """#122 decision 4: Graph reports deletions, so they are acted on at once
+    rather than waiting for the retention pass."""
+
+    def stored(self, mid="m1"):
+        """One message in the store, and the stand-in still running."""
+        self.serve([{"value": [message(mid)],
+                     "@odata.deltaLink": "http://x/final"}])
+        self.run_main()
+
+    def test_a_deleted_message_is_tombstoned(self):
+        self.stored()
+        self.graph.queue({"value": [removed("m1")],
+                          "@odata.deltaLink": "http://x/final2"})
+        self.run_main()
+        row = self.rows()[0]
+        self.assertIsNotNone(row[3], "deleted_at was not set")
+
+    def test_its_body_goes_at_once(self):
+        """Not at the next retention pass: the person said what they want."""
+        self.stored()
+        self.graph.queue({"value": [removed("m1")],
+                          "@odata.deltaLink": "http://x/final2"})
+        self.run_main()
+        row = self.rows()[0]
+        self.assertIsNone(row[2], "the body survived a deletion")
+        self.assertIsNotNone(row[4])
+
+    def test_the_row_survives(self):
+        """Obligations and events hang off `source_id`; deleting the row would
+        break the audit trail that explains why something was ranked."""
+        self.stored()
+        self.graph.queue({"value": [removed("m1")],
+                          "@odata.deltaLink": "http://x/final2"})
+        self.run_main()
+        self.assertEqual([r[0] for r in self.rows()], ["m1"])
+
+    def test_metadata_survives_the_tombstone(self):
+        self.stored()
+        self.graph.queue({"value": [removed("m1")],
+                          "@odata.deltaLink": "http://x/final2"})
+        self.run_main()
+        self.assertEqual(self.rows()[0][1], "Dana Okoro")
+
+    def test_a_move_is_not_a_deletion(self):
+        """`@removed` carries a reason, and `changed` means it left the scope
+        being synchronised — filing something is not deleting it."""
+        self.stored()
+        self.graph.queue({"value": [removed("m1", reason="changed")],
+                          "@odata.deltaLink": "http://x/final2"})
+        self.run_main()
+        row = self.rows()[0]
+        self.assertIsNone(row[3], "a moved message was tombstoned")
+        self.assertIsNotNone(row[2], "a moved message lost its body")
+
+    def test_the_report_counts_removals(self):
+        self.stored()
+        self.graph.queue({"value": [removed("m1")],
+                          "@odata.deltaLink": "http://x/final2"})
+        self.run_main()
+        self.assertEqual(self.report()["removed"], 1)
+
+    def test_tombstoning_twice_counts_once(self):
+        """A repeated delta page must not keep rewriting the timestamp."""
+        self.stored()
+        self.graph.queue({"value": [removed("m1")],
+                          "@odata.deltaLink": "http://x/f2"},
+                         {"value": [removed("m1")],
+                          "@odata.deltaLink": "http://x/f3"})
+        self.run_main()
+        first = self.rows()[0][3]
+        self.run_main()
+        self.assertEqual(self.rows()[0][3], first)
+        self.assertEqual(self.report()["removed"], 0)
+
+
+class TestTheCursorIsTheWatermark(CollectorCase):
+    """A delta cursor is only issued when a round completes, so a partial
+    crawl cannot advance it — the property is the protocol's, not this
+    module's, and that is the reason for using it."""
+
+    def test_a_completed_round_stores_a_delta_cursor(self):
+        self.serve([{"value": [message("m1")],
+                     "@odata.deltaLink": "http://x/final"}])
+        self.run_main()
+        self.assertIn("delta", self.state())
+        self.assertNotIn("next", self.state())
+
+    def test_an_interrupted_round_stores_the_page_instead(self):
+        pages = [{"value": [message(f"m{i}")],
+                  "@odata.nextLink": f"http://x/page{i + 1}"}
+                 for i in range(ingest_graph.REQUEST_BUDGET + 2)]
+        self.serve(pages)
+        self.run_main()
+        self.assertIn("next", self.state())
+        self.assertNotIn("delta", self.state(),
+                         "a partial crawl recorded a synchronisation point")
+        self.assertFalse(self.report()["complete"])
+
+    def test_the_next_tick_resumes_rather_than_restarting(self):
+        pages = [{"value": [message(f"m{i}")],
+                  "@odata.nextLink": f"http://x/page{i + 1}"}
+                 for i in range(ingest_graph.REQUEST_BUDGET + 2)]
+        pages.append({"value": [message("last")],
+                      "@odata.deltaLink": "http://x/final"})
+        self.serve(pages)
+        self.run_main()
+        resumed_from = self.state()["next"]
+        self.run_main()
+        self.assertIn(resumed_from.rsplit("/", 1)[-1],
+                      "".join(self.graph.calls),
+                      "the second tick did not continue from the saved page")
+        self.assertTrue(self.report()["resumed"])
+
+    def test_rows_from_an_interrupted_round_are_kept(self):
+        """Partial progress is still progress; the rows are idempotent."""
+        pages = [{"value": [message(f"m{i}")],
+                  "@odata.nextLink": f"http://x/page{i + 1}"}
+                 for i in range(ingest_graph.REQUEST_BUDGET + 2)]
+        self.serve(pages)
+        self.run_main()
+        self.assertTrue(self.rows())
+
+    def test_a_page_with_neither_link_does_not_record_a_position(self):
+        """Graph gave nothing to resume from, so there is nothing to save."""
+        self.serve([{"value": [message("m1")]}])
+        self.run_main()
+        self.assertNotIn("next", self.state())
+        self.assertNotIn("delta", self.state())
+        self.assertFalse(self.report()["complete"])
+
+    def test_an_expired_cursor_starts_a_fresh_round(self):
+        """Graph expires an unused cursor with 410, and the recovery is a new
+        round rather than a failed run."""
+        self.serve([{"value": [message("m1")],
+                     "@odata.deltaLink": "http://x/final"}])
+        self.run_main()
+        self.graph.queue({"value": [message("m2")],
+                          "@odata.deltaLink": "http://x/final2"})
+        self.graph.status_for_next = 410
+        self.assertEqual(self.run_main(), ingest_graph.EXIT_OK)
+        self.assertTrue(self.report().get("resynchronised"))
+        self.assertIn("m2", [r[0] for r in self.rows()])
+
+
+class TestTheFirstRoundIsBounded(CollectorCase):
+    def test_the_window_reaches_the_request(self):
+        self.serve([{"value": [], "@odata.deltaLink": "http://x/final"}])
+        os.environ["GRAPH_BACKFILL_DAYS"] = "14"
+        self.run_main()
+        asked = [c for c in self.graph.calls if "/delta" in c][0]
+        self.assertIn("receivedDateTime+ge", asked.replace("%20", "+")
+                      .replace("%3E", ">").replace("+ge+", "+ge+"))
+
+    def test_the_default_window_is_the_one_the_docs_state(self):
+        self.assertEqual(ingest_graph.BACKFILL_DAYS, 7)
+
+    def test_the_report_says_which_window_was_used(self):
+        self.serve([{"value": [], "@odata.deltaLink": "http://x/final"}])
+        os.environ["GRAPH_BACKFILL_DAYS"] = "30"
+        self.run_main()
+        self.assertEqual(self.report()["backfill_days"], 30)
+
+    def test_a_window_that_synchronises_nothing_is_refused(self):
+        for bad in ("0", "-1", "abc",
+                    str(ingest_graph.MAX_BACKFILL_DAYS + 1)):
+            os.environ["GRAPH_BACKFILL_DAYS"] = bad
+            with self.assertRaises(SystemExit):
+                ingest_graph.bounded_days("GRAPH_BACKFILL_DAYS",
+                                          ingest_graph.BACKFILL_DAYS)
+
+    def test_the_window_applies_only_to_the_first_round(self):
+        """The cursor carries no filter, so later rounds report every change —
+        including an older message being deleted. Choosing seven days is
+        choosing where to start, not choosing to be told less afterwards."""
+        self.serve([{"value": [message("m1")],
+                     "@odata.deltaLink": "http://x/final"},
+                    {"value": [], "@odata.deltaLink": "http://x/final2"}])
+        os.environ["GRAPH_BACKFILL_DAYS"] = "7"
+        self.run_main()
+        self.graph.calls.clear()
+        self.run_main()
+        for call in self.graph.calls:
+            self.assertNotIn("receivedDateTime", call,
+                             "a later round re-applied the first window")
+
+
+class TestTheCredentialIsNeverEchoed(CollectorCase):
+    SECRET = "openshell:resolve:env:v9_DO_NOT_PRINT_THIS"
+
+    def test_it_is_not_in_the_report(self):
+        os.environ["MS_GRAPH_ACCESS_TOKEN"] = self.SECRET
+        self.serve([{"value": [message("m1")],
+                     "@odata.deltaLink": "http://x/final"}])
+        self.run_main()
+        self.assertNotIn("DO_NOT_PRINT_THIS", self.stdout)
+
+    def test_it_is_not_in_the_saved_state(self):
+        """The identity cache is keyed on a digest, not on the token."""
+        os.environ["MS_GRAPH_ACCESS_TOKEN"] = self.SECRET
+        self.serve([{"value": [], "@odata.deltaLink": "http://x/final"}])
+        self.run_main()
+        self.assertNotIn("DO_NOT_PRINT_THIS",
+                         json.dumps(self.state()))
+
+    def test_it_does_reach_the_service(self):
+        """The point is that it is not echoed, not that it is unused."""
+        os.environ["MS_GRAPH_ACCESS_TOKEN"] = self.SECRET
+        self.serve([{"value": [], "@odata.deltaLink": "http://x/final"}])
+        self.run_main()
+        self.assertTrue(any(self.SECRET in h for h in self.graph.headers_seen))
+
+
+class TestFailuresCarryTheirDiagnosisInTheExitCode(CollectorCase):
+    def test_never_configured_is_free(self):
+        """This file exists long before most people connect a mailbox; if an
+        absent credential were a failure the wake gate would never fire."""
+        os.environ.pop("MS_GRAPH_ACCESS_TOKEN", None)
+        self.assertEqual(self.run_main(), ingest_graph.EXIT_OK)
+        self.assertTrue(json.loads(self.stdout)["unconfigured"])
+
+    def test_a_credential_that_disappeared_is_a_failure(self):
+        """A detached provider empties the variable, which then looks exactly
+        like never having set one up."""
+        self.serve([{"value": [], "@odata.deltaLink": "http://x/final"}])
+        self.run_main()
+        os.environ.pop("MS_GRAPH_ACCESS_TOKEN", None)
+        self.assertEqual(self.run_main(), ingest_graph.EXIT_CREDENTIAL)
+
+    def test_a_refused_credential_says_so(self):
+        self.serve([{"value": [], "@odata.deltaLink": "http://x/final"}])
+        self.graph.status_for_next = 401
+        self.assertEqual(self.run_main(), ingest_graph.EXIT_CREDENTIAL)
+
+    def test_an_application_token_is_a_scope_failure(self):
+        """No mailbox address means it is not a delegated token, and the
+        recipe reads the signed-in mailbox."""
+        self.serve([{"value": [], "@odata.deltaLink": "http://x/final"}])
+        self.graph.identity = {"displayName": "App"}
+        self.assertEqual(self.run_main(), ingest_graph.EXIT_SCOPE)
+
+    def test_rate_limiting_has_its_own_code(self):
+        self.serve([{"value": [], "@odata.deltaLink": "http://x/final"}])
+        self.graph.status_for_next = 500
+        self.assertEqual(self.run_main(), ingest_graph.EXIT_OTHER)
+
+    def test_something_unrecognised_in_the_variable_is_refused(self):
+        os.environ["MS_GRAPH_ACCESS_TOKEN"] = "not-a-token"
+        self.assertEqual(self.run_main(), ingest_graph.EXIT_CREDENTIAL)
+
+
+class TestTheExclusionRulesApply(CollectorCase):
+    """Applied in `insert_items`, so this collector inherits them — asserted
+    by driving it against a rule rather than by reading the call chain."""
+
+    def rule(self, **kinds):
+        Path(self.home, "workspace", "exclusions.json").write_text(
+            json.dumps(kinds), encoding="utf-8")
+
+    def test_an_excluded_domain_never_reaches_the_store(self):
+        self.rule(domains=["agency.example"])
+        self.serve([{"value": [message("m1", sender="Recruiter",
+                                       address="r@agency.example")],
+                     "@odata.deltaLink": "http://x/final"}])
+        self.run_main()
+        self.assertEqual(self.rows(), [])
+
+    def test_an_excluded_address_never_reaches_the_store(self):
+        self.rule(senders=["dana@example.com"])
+        self.serve([{"value": [message("m1")],
+                     "@odata.deltaLink": "http://x/final"}])
+        self.run_main()
+        self.assertEqual(self.rows(), [])
+
+    def test_everything_else_still_arrives(self):
+        self.rule(domains=["agency.example"])
+        self.serve([{"value": [message("keep")],
+                     "@odata.deltaLink": "http://x/final"}])
+        self.run_main()
+        self.assertEqual([r[0] for r in self.rows()], ["keep"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_migration.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_migration.py
@@ -132,6 +132,38 @@ class TestMigration(unittest.TestCase):
         # identify anybody.
         self.assertIsNone(row[2])
 
+    def test_a_real_v3_store_upgrades_to_the_current_version(self):
+        """Exercise v4 against the exact schema that #140 shipped."""
+        artifact = HERE / "schema-v3.sql"
+        self.assertTrue(artifact.exists(), "the v3 schema artifact is missing")
+        path = Path(tempfile.mkdtemp()) / "v3.db"
+        with sqlite3.connect(path) as c:
+            c.executescript(artifact.read_text(encoding="utf-8"))
+            c.execute("INSERT INTO items(source_id, source, scope, event_at,"
+                      " sender, sender_key, body, state) VALUES"
+                      " ('m1','email','inbox','2026-08-01T00:00:00Z',"
+                      "  'Dana Okoro','dana@example.com','kept','pending')")
+            self.assertEqual(current_version(c), 3)
+            columns = {row[1] for row in c.execute("PRAGMA table_info(items)")}
+            self.assertIn("sender_key", columns)
+            self.assertNotIn("deleted_at", columns,
+                             "the frozen v3 schema contains a v4 column")
+            self.assertNotIn("internet_message_id", columns,
+                             "the frozen v3 schema contains a v4 column")
+
+        with sqlite3.connect(path) as c:
+            self.assertEqual(migrate(c), [4])
+            self.assertEqual(current_version(c), SCHEMA_VERSION)
+            columns = {row[1] for row in c.execute("PRAGMA table_info(items)")}
+            row = c.execute("SELECT sender, sender_key, body, deleted_at,"
+                            " internet_message_id FROM items"
+                            " WHERE source_id='m1'").fetchone()
+        self.assertIn("deleted_at", columns)
+        self.assertIn("internet_message_id", columns)
+        self.assertEqual(row[:3], ("Dana Okoro", "dana@example.com", "kept"))
+        self.assertIsNone(row[3], "an existing row was marked deleted")
+        self.assertIsNone(row[4], "a missing identity was invented")
+
     def test_migrating_an_already_migrated_store_is_not_an_error(self):
         """Two runs happen — a retried job, an interrupted upgrade. An ALTER
         that only works once turns the second into a crash loop."""
@@ -153,6 +185,13 @@ class TestMigration(unittest.TestCase):
         self.assertIn("body_cleared_at", artifact)
         self.assertNotIn("sender_key", artifact)
 
+    def test_the_v3_artifact_is_never_quietly_edited(self):
+        artifact = (HERE / "schema-v3.sql").read_text(encoding="utf-8")
+        self.assertIn("'schema_version', '3'", artifact)
+        self.assertIn("sender_key", artifact)
+        self.assertNotIn("deleted_at", artifact)
+        self.assertNotIn("internet_message_id", artifact)
+
     def test_the_v1_artifact_is_never_quietly_edited(self):
         """It is frozen: a schema change goes in schema.sql and a migration."""
         artifact = (HERE / "schema-v1.sql").read_text(encoding="utf-8")
@@ -168,8 +207,9 @@ class TestMigration(unittest.TestCase):
         # one arrived once by a bad merge and broke opening a real store.
         #
         # `deleted_at` was that column and is no longer speculative — it ships
-        # with the Graph collector, whose delta query reports deletions, and
-        # the migration that adds it is tested against the frozen v2 schema.
+        # with the Graph collector, whose removal reconciliation distinguishes
+        # moves from deletions, and its migration is tested against the frozen
+        # v3 schema that immediately preceded it.
         # The rule it stood for still holds; the example moved on.
         self.assertIn("deleted_at", columns)
         self.assertNotIn("thread_participants", columns)

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_migration.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_migration.py
@@ -416,8 +416,11 @@ class TestVersionGuardOnTheRealPath(unittest.TestCase):
             columns = {r[1] for r in c.execute("PRAGMA table_info(items)")}
             row = c.execute("SELECT sender, body, deleted_at FROM items"
                             " WHERE source_id='m1'").fetchone()
-        self.assertEqual(int(version), 3)
+        self.assertEqual(int(version), SCHEMA_VERSION)
         self.assertIn("deleted_at", columns)
+        self.assertIn("internet_message_id", columns)
+        # v3 ran too, on the way past: a real v2 store takes the whole chain.
+        self.assertIn("sender_key", columns)
         self.assertEqual(row[0], "Dana")
         self.assertEqual(row[1], "b")
         self.assertIsNone(row[2], "an existing row was marked deleted")

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_migration.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_migration.py
@@ -62,7 +62,8 @@ class TestMigration(unittest.TestCase):
                              "the artifact is not really v1")
 
         with sqlite3.connect(path) as c:
-            self.assertEqual(migrate(c), [2, 3])
+            # v1 -> v4 now, so all three steps run in order.
+            self.assertEqual(migrate(c), [2, 3, 4])
             self.assertEqual(current_version(c), SCHEMA_VERSION)
             columns = {row[1] for row in c.execute("PRAGMA table_info(items)")}
             self.assertIn("body_cleared_at", columns)
@@ -103,10 +104,11 @@ class TestMigration(unittest.TestCase):
                              "the artifact is not really v2")
 
         with sqlite3.connect(path) as c:
-            self.assertEqual(migrate(c), [3])
+            self.assertEqual(migrate(c), [3, 4])
             self.assertEqual(current_version(c), SCHEMA_VERSION)
             columns = {row[1] for row in c.execute("PRAGMA table_info(items)")}
             self.assertIn("sender_key", columns)
+            self.assertIn("deleted_at", columns)
 
     def test_the_v2_upgrade_keeps_the_messages_it_already_held(self):
         """A person's history is the point of the column. Losing the messages
@@ -142,7 +144,7 @@ class TestMigration(unittest.TestCase):
         with sqlite3.connect(path) as c:
             c.execute("UPDATE meta SET value='2' WHERE key='schema_version'")
         with sqlite3.connect(path) as c:
-            self.assertEqual(migrate(c), [3])
+            self.assertEqual(migrate(c), [3, 4])
             self.assertEqual(current_version(c), SCHEMA_VERSION)
 
     def test_the_v2_artifact_is_never_quietly_edited(self):
@@ -163,8 +165,14 @@ class TestMigration(unittest.TestCase):
         with sqlite3.connect(p) as c:
             columns = {r[1] for r in c.execute("PRAGMA table_info(items)")}
         # Columns belonging to phases that have not shipped must not be here:
-        # one of them arrived by a bad merge and broke opening a real store.
-        self.assertNotIn("deleted_at", columns)
+        # one arrived once by a bad merge and broke opening a real store.
+        #
+        # `deleted_at` was that column and is no longer speculative — it ships
+        # with the Graph collector, whose delta query reports deletions, and
+        # the migration that adds it is tested against the frozen v2 schema.
+        # The rule it stood for still holds; the example moved on.
+        self.assertIn("deleted_at", columns)
+        self.assertNotIn("thread_participants", columns)
         with sqlite3.connect(p) as c:
             self.assertEqual(migrate(c), [])
 
@@ -352,6 +360,7 @@ class TestVersionGuardOnTheRealPath(unittest.TestCase):
         self.assertEqual(int(version), SCHEMA_VERSION)
         self.assertIn("body_cleared_at", columns)
         self.assertIn("sender_key", columns)
+        self.assertIn("deleted_at", columns)
 
     def test_the_check_flag_reports_without_changing(self):
         v1 = (HERE / "schema-v1.sql").read_text(encoding="utf-8")
@@ -382,6 +391,42 @@ class TestVersionGuardOnTheRealPath(unittest.TestCase):
             module = (HERE / "migrate.py").read_text(encoding="utf-8")
             self.assertIn('if __name__ == "__main__"', module,
                           "the docs name a command this module cannot run")
+
+    def test_a_real_v2_store_gains_the_tombstone_column(self):
+        """Tested against the v2 schema as it shipped, not against the current
+        one with a column removed — that is a state nobody ever had."""
+        v2 = (HERE / "schema-v2.sql").read_text(encoding="utf-8")
+        with sqlite3.connect(self.db) as c:
+            c.executescript("DROP TABLE IF EXISTS items;"
+                            "DROP TABLE IF EXISTS obligations;"
+                            "DROP TABLE IF EXISTS events;"
+                            "DROP TABLE IF EXISTS cursors;"
+                            "DROP TABLE IF EXISTS meta;")
+            c.executescript(v2)
+            c.execute("INSERT INTO items(source_id, source, scope, event_at,"
+                      " sender, subject, body, state)"
+                      " VALUES ('m1','email','inbox','2026-01-01T00:00:00.000Z',"
+                      "         'Dana','s','b','pending')")
+
+        self._db.ensure_store()
+
+        with sqlite3.connect(self.db) as c:
+            version = c.execute(
+                "SELECT value FROM meta WHERE key='schema_version'").fetchone()[0]
+            columns = {r[1] for r in c.execute("PRAGMA table_info(items)")}
+            row = c.execute("SELECT sender, body, deleted_at FROM items"
+                            " WHERE source_id='m1'").fetchone()
+        self.assertEqual(int(version), 3)
+        self.assertIn("deleted_at", columns)
+        self.assertEqual(row[0], "Dana")
+        self.assertEqual(row[1], "b")
+        self.assertIsNone(row[2], "an existing row was marked deleted")
+
+    def test_the_v2_artifact_is_never_quietly_edited(self):
+        artifact = (HERE / "schema-v2.sql").read_text(encoding="utf-8")
+        self.assertIn("'schema_version', '2'", artifact)
+        self.assertNotIn("deleted_at", artifact,
+                         "the frozen v2 schema has grown a v3 column")
 
     def test_an_older_store_is_migrated_rather_than_refused(self):
         """The guard is one-sided: behind is upgraded, ahead is refused."""

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_selectors.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_selectors.py
@@ -1214,7 +1214,7 @@ esac
         out = self.refuses_policy({"binaries": []}, "unbounded by binary")
         self.assertIn("binary", out)
 
-    VALIDATOR = RECIPE / "scripts" / "validate-slack-profile.sh"
+    VALIDATOR = RECIPE / "scripts" / "validate-provider-profile.sh"
 
     def validate(self, policy):
         """Run the shipped validator against a profile with one field bent.
@@ -1232,7 +1232,8 @@ esac
                 capture_output=True, text=True,
                 env={"PATH": f"{folder}:{os.environ['PATH']}",
                      "HOME": str(folder),
-                     "USABLE_KEY": "SLACK_USER_TOKEN"})
+                     "USABLE_KEY": "SLACK_USER_TOKEN",
+                     "WANT_HOST": "slack.com"})
         return proc.returncode, proc.stdout + proc.stderr
 
     def test_the_expected_profile_passes(self):
@@ -1312,12 +1313,21 @@ esac
                       "the acknowledged path should reach the reuse branch")
 
     def test_an_unconfirmed_prerequisite_aborts(self):
-        code = "\n".join(line for line in self.SCRIPT.read_text().splitlines()
-                         if not line.lstrip().startswith("#"))
-        window = code[code.find("STORE_ENCRYPTION_ACKNOWLEDGED"):
-                      code.find("sandbox provider attach")]
-        self.assertIn("exit 1", window,
-                      "an unconfirmed prerequisite must abort, not warn")
+        """Run it rather than search the source for `exit 1`.
+
+        The previous form looked between two strings in `setup-slack.sh`. The
+        gate has since moved into a file both setup flows source, so the
+        search window emptied and the test passed on nothing — the same shape
+        of failure that let the reuse-path bypass ship.
+        """
+        with tempfile.TemporaryDirectory() as folder:
+            folder = Path(folder)
+            self.fake_openshell(folder)
+            proc = self.run_setup(folder, {
+                "SANDBOX_STORAGE_PATH": str(folder)})
+        self.assertNotEqual(proc.returncode, 0,
+                            "an unconfirmed prerequisite must abort, not warn")
+        self.assertNotIn("Nothing to do", proc.stdout)
 
     def test_the_docs_point_at_the_page(self):
         for name in ("README.md", "docs/set-up-slack.md"):

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_selectors.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_selectors.py
@@ -146,7 +146,7 @@ class TestSchedulerIntegrationContract(unittest.TestCase):
     registration script. Neither was covered, and one of them was already
     false — the script looked jobs up with `cron list --json`, a flag the CLI
     does not have, so the lookup always came back empty and every run created
-    another copy of all five jobs.
+    another copy of all seven jobs.
     """
 
     RECIPE = HERE.parents[1]
@@ -502,7 +502,7 @@ class TestTheInstallerRefusesTheWrongPlatform(unittest.TestCase):
     """Documentation that says "Linux only" and code that installs anywhere.
 
     The README states the scheduled path does not work on macOS, and the
-    scripts installed and registered five jobs there regardless — producing
+    scripts installed and registered seven jobs there regardless — producing
     exactly the model-without-skill calls the same document warns about. A
     warning nothing enforces is not a warning.
     """
@@ -696,7 +696,7 @@ class TestTheInstallerCarriesSettingsNotSecrets(unittest.TestCase):
         self.assertNotEqual(register, -1, "installer no longer registers jobs")
         self.assertLess(check, register,
                         "the check must precede registration, or the exit "
-                        "leaves five jobs scheduled against a dead profile")
+                        "leaves seven jobs scheduled against a dead profile")
 
     def test_an_unresolvable_model_exits_non_zero(self):
         """The check has to end the run, not merely print a complaint."""
@@ -858,7 +858,7 @@ class TestAFailedTransferStopsTheInstall(unittest.TestCase):
     `false && echo` is a no-op, not an abort. So a profile could take
     `model.default`, silently drop `model.provider` and `model.base_url`, pass
     the model check — which only asks about `model.default` — pass the
-    credential check, and get all five jobs registered against whatever route
+    credential check, and get all seven jobs registered against whatever route
     it had left.
 
     Exit status alone is also not proof the value landed, so each carried

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/providers/graph-user.yaml
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/providers/graph-user.yaml
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# The gateway holds the Microsoft Graph credential and refreshes it; the
+# sandbox receives only a placeholder, substituted at egress.
+#
+# This is the arrangement #122 decision 1 settled on. The alternative
+# considered there was MSAL-managed renewal with an encrypted token cache,
+# which makes a recipe self-contained at the cost of the refresh token living
+# inside the sandbox — where an encrypted cache is a mitigation rather than a
+# boundary. Gateway-held keeps it out entirely, and the cost is a dependency on
+# a running gateway, which this recipe already has.
+#
+# Delegated access only. `Mail.Read` covers the signed-in mailbox and nothing
+# else, and `offline_access` is what lets the gateway keep renewing without
+# asking again. An application permission would read every mailbox in the
+# tenant, which is not what a personal assistant needs and not what the
+# collector checks for — it refuses a token whose `/me` has no address, which
+# is what an application token looks like.
+id: memory-driven-cos-graph-user
+resource_version: 1
+display_name: Memory-Driven Chief of Staff — Microsoft Graph mailbox
+description: >-
+  Read-only delegated mailbox access, for the scheduled intake collector.
+  Gateway-held credential, renewed through the Microsoft identity platform.
+category: messaging
+credentials:
+  - name: graph_access_token
+    description: Microsoft Graph delegated access token
+    env_vars: [MS_GRAPH_ACCESS_TOKEN]
+    required: true
+    auth_style: bearer
+    header_name: authorization
+    refresh:
+      strategy: oauth2_refresh_token
+      token_url: https://login.microsoftonline.com/common/oauth2/v2.0/token
+      scopes: [https://graph.microsoft.com/.default]
+      # An hour is the Microsoft identity platform's usual access-token
+      # lifetime; renew ten minutes early so a tick starting near the boundary
+      # does not race the expiry.
+      refresh_before_seconds: 600
+      max_lifetime_seconds: 3600
+      material:
+        - name: tenant_id
+          description: Microsoft Entra tenant id
+          required: true
+        - name: client_id
+          description: Microsoft Entra application client id
+          required: true
+        - name: refresh_token
+          description: Delegated refresh token from the device-code flow
+          required: true
+          secret: true
+endpoints:
+  # One host, and read-only: this recipe never writes to a mailbox. It does not
+  # mark a message read, move it, or reply — the source is an input. The scan
+  # in tests/test_durability.py enforces the same property in the code; this
+  # enforces it at the egress boundary, where a future mistake would otherwise
+  # reach the network before any test ran.
+  #
+  # `login.microsoftonline.com` is deliberately absent. The gateway performs
+  # the token exchange, so the sandbox never talks to the identity platform;
+  # declaring it here would widen the boundary for a call the collector does
+  # not make.
+  - host: graph.microsoft.com
+    port: 443
+    protocol: rest
+    access: read-only
+    enforcement: enforce
+# The collector is a Python cron pre-step and needs nothing else.
+binaries:
+  - /usr/bin/python3
+  - /opt/hermes/.venv/bin/python

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/providers/graph-user.yaml
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/providers/graph-user.yaml
@@ -11,9 +11,12 @@
 # boundary. Gateway-held keeps it out entirely, and the cost is a dependency on
 # a running gateway, which this recipe already has.
 #
-# Delegated access only. `Mail.Read` covers the signed-in mailbox and nothing
-# else, and `offline_access` is what lets the gateway keep renewing without
-# asking again. An application permission would read every mailbox in the
+# Delegated access only, and exactly three permissions. `Mail.Read` covers the
+# signed-in mailbox and nothing else. `User.Read` is what makes `/me` readable,
+# which the collector needs to know whose mailbox this is — a message that
+# names the user is a different thing from one that copies them, and the
+# addressing field says which. `offline_access` lets the gateway keep renewing
+# without asking again. An application permission would read every mailbox in the
 # tenant, which is not what a personal assistant needs and not what the
 # collector checks for — it refuses a token whose `/me` has no address, which
 # is what an application token looks like.
@@ -34,7 +37,22 @@ credentials:
     refresh:
       strategy: oauth2_refresh_token
       token_url: https://login.microsoftonline.com/common/oauth2/v2.0/token
-      scopes: [https://graph.microsoft.com/.default]
+      # The exact permissions, not `.default`.
+      #
+      # `.default` asks for everything already granted to this client for
+      # this user, which on a client registered for other purposes is more
+      # than this recipe needs — and it would grow silently as an
+      # administrator granted more. Naming them keeps the credential the
+      # gateway holds no wider than the boundary declared below.
+      #
+      # `User.Read` is here because the collector reads `/me` to learn which
+      # mailbox it is looking at, which decides whether a message addressed
+      # the user or merely copied them. Microsoft documents it as the
+      # least-privileged permission for that endpoint.
+      scopes:
+        - https://graph.microsoft.com/Mail.Read
+        - https://graph.microsoft.com/User.Read
+        - offline_access
       # An hour is the Microsoft identity platform's usual access-token
       # lifetime; renew ten minutes early so a tick starting near the boundary
       # does not race the expiry.

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/install.sh
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/install.sh
@@ -78,7 +78,7 @@ echo "2/3  Carrying over the model settings"
 # as the left operand of `&&` — `false && echo` is a no-op, not an abort — so
 # writing this as `config set … && echo …` swallowed the failure. A profile
 # that took `model.default` and silently dropped `provider` and `base_url`
-# passed both checks below and got all six jobs registered, pointed at
+# passed both checks below and got all seven jobs registered, pointed at
 # whatever route it had left.
 carried=()
 for key in model.default model.provider model.base_url; do

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/register-jobs.sh
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/register-jobs.sh
@@ -59,7 +59,7 @@ fi
 # steadier than parsing that table, and it is a read.
 #
 # Without this the script cannot tell an existing job from a missing one, and
-# every run creates another copy of all six.
+# every run creates another copy of all seven.
 job_id_for() {
   local name="$1" store="$PROFILE_HOME/cron/jobs.json"
   [[ -f "$store" ]] || return 0

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/require-encrypted-storage.sh
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/require-encrypted-storage.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# The storage prerequisite, in one place for every connector.
+#
+# Decision 5 on #122 gates real message bodies on encryption at rest, and it is
+# the same question whichever source is being connected. A second copy would be
+# a second thing to keep in step, and the one nobody edited would go on
+# approving what the other refused.
+#
+# Sourced by the setup scripts; runnable on its own to check a machine before
+# connecting anything:
+#
+#     SANDBOX_STORAGE_PATH=/var/lib/docker \
+#         bash scripts/require-encrypted-storage.sh
+
+# The storage prerequisite, checked before anything is inspected or
+# attached.
+#
+# It used to sit after the reuse early-exit, which meant a run that
+# found a usable provider printed "Nothing to do" and exited 0 without
+# ever checking it — reported as a successful setup on a machine whose
+# store had never been looked at. The check belongs before the branch,
+# because it is a property of the machine rather than of the run.
+require_encrypted_storage() {
+  # Attaching this provider is the moment real message bodies start landing in
+  # the store, and the prerequisite is that they land on an encrypted volume.
+  # Owner-only permissions are not that: they stop another account reading the
+  # file on a running system and do nothing for a disk that is lost, imaged, or
+  # backed up.
+  #
+  # Which volume is the whole question, and it is not one this script can guess.
+  # `HERMES_HOME` inside a sandbox is an overlay with no block device behind it,
+  # so encryption is unobservable from in there. On the host it depends on the
+  # driver: Docker keeps sandbox storage under its data-root, a VM keeps it in a
+  # disk image, Kubernetes in a volume — none of which is reliably `$HOME`. An
+  # earlier version inspected `$HOME` and would have approved the wrong volume on
+  # every one of those.
+  #
+  # So the path is asserted rather than inferred. `SANDBOX_STORAGE_PATH` names
+  # where this sandbox's storage actually lives; the script then verifies *that*
+  # path, which is a real check rather than a plausible one.
+  storage_path="${SANDBOX_STORAGE_PATH:-}"
+  if [[ -z "$storage_path" ]]; then
+    echo "     where this sandbox's storage lives is not something this script"
+    echo "     can determine — it differs by driver, and guessing would mean"
+    echo "     checking the wrong volume."
+    echo ""
+    echo "Find it, then re-run with it named. For the Docker driver:"
+    echo "  docker info --format '{{.DockerRootDir}}'"
+    echo ""
+    echo "  SANDBOX_STORAGE_PATH=<path> bash scripts/setup-slack.sh"
+    echo ""
+    echo "docs/encrypted-storage.md explains what to look for and why."
+    exit 1
+  fi
+  if [[ ! -e "$storage_path" ]]; then
+    echo "SANDBOX_STORAGE_PATH does not exist: $storage_path" >&2
+    exit 1
+  fi
+
+  encrypted="unknown"
+  if command -v findmnt >/dev/null 2>&1 && command -v lsblk >/dev/null 2>&1; then
+    source_dev="$(findmnt -no SOURCE --target "$storage_path" 2>/dev/null || true)"
+    if [[ -n "$source_dev" ]]; then
+      if lsblk -no TYPE "$source_dev" 2>/dev/null | grep -q crypt; then
+        encrypted="yes"
+      else
+        encrypted="no"
+      fi
+    fi
+  fi
+
+  case "$encrypted" in
+    yes)
+      echo "     $storage_path is on an encrypted volume" ;;
+    no)
+      echo "     $storage_path does NOT appear to be on an encrypted volume" ;;
+    *)
+      echo "     could not determine whether $storage_path is encrypted" ;;
+  esac
+
+  if [[ "$encrypted" != "yes" ]]; then
+    echo ""
+    echo "This recipe stores message subjects, senders and bodies once a"
+    echo "connector is attached. See docs/encrypted-storage.md."
+    echo ""
+    if [[ "${STORE_ENCRYPTION_ACKNOWLEDGED:-0}" == "1" ]]; then
+      echo "     STORE_ENCRYPTION_ACKNOWLEDGED=1 — continuing."
+    else
+      read -r -p "Type 'encrypted' to confirm the prerequisite is met: " ACK
+      if [[ "$ACK" != "encrypted" ]]; then
+        echo "Not confirmed. Nothing has been configured." >&2
+        exit 1
+      fi
+    fi
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  require_encrypted_storage
+fi

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/require-encrypted-storage.sh
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/require-encrypted-storage.sh
@@ -50,7 +50,7 @@ require_encrypted_storage() {
     echo "Find it, then re-run with it named. For the Docker driver:"
     echo "  docker info --format '{{.DockerRootDir}}'"
     echo ""
-    echo "  SANDBOX_STORAGE_PATH=<path> bash scripts/setup-slack.sh"
+    echo "  SANDBOX_STORAGE_PATH=<path> bash ${SETUP_SCRIPT:-scripts/setup-slack.sh}"
     echo ""
     echo "docs/encrypted-storage.md explains what to look for and why."
     exit 1

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/require-linux.sh
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/require-linux.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# The platform prerequisite, in one place for every connector.
+#
+# `register-jobs.sh` refuses to run anywhere but Linux, so a machine that
+# cannot register the jobs cannot run the recipe on a schedule. Connecting a
+# source there costs the user a real authorization — a Slack install, or an
+# Entra consent — for a scheduler that will never exist. Checking first is
+# cheap; the consent is not, and it is granted in a browser to a tenant an
+# administrator may have to be asked about.
+#
+# This lived in setup-slack.sh alone, which is why setup-graph.sh happily ran
+# the entire device-code flow on macOS.
+require_linux() {
+  local kernel
+  kernel="$(uname -s)"
+  if [[ "$kernel" != "Linux" ]]; then
+    echo "The scheduled path is Linux only; detected $kernel." >&2
+    echo "The fixture walkthrough needs no credential and runs anywhere." >&2
+    exit 1
+  fi
+}

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/setup-graph.sh
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/setup-graph.sh
@@ -32,7 +32,12 @@ WANT_HOST="graph.microsoft.com"
 # own application passes its ids rather than editing this file.
 CLIENT_ID="${GRAPH_CLIENT_ID:-}"
 TENANT_ID="${GRAPH_TENANT_ID:-common}"
-SCOPES="offline_access https://graph.microsoft.com/Mail.Read"
+# Exactly what the collector uses. `User.Read` is not incidental: it is
+# what makes `/me` readable, and `/me` is how the collector learns which
+# mailbox it is reading — which decides whether a message addressed the
+# user or copied them. Requesting `Mail.Read` alone produced a setup that
+# depended on a permission it never asked for.
+SCOPES="offline_access https://graph.microsoft.com/Mail.Read https://graph.microsoft.com/User.Read"
 
 if ! command -v openshell >/dev/null 2>&1; then
   if [[ -n "${OPENSHELL_SANDBOX:-}" ]]; then
@@ -86,6 +91,20 @@ while read -r name; do
     fi
     if ! validate_profile "$type"; then
       echo "     '$name' does not carry this recipe's endpoint policy" >&2
+      exit 1
+    fi
+    # And that something renews it. A provider with the right key, the right
+    # type and the right policy but no refresh chain attaches cleanly and
+    # stops within the hour — reported here as "nothing to do", which is the
+    # least useful moment to be told nothing.
+    if ! status="$(openshell provider refresh status "$name" \
+        --credential-key "$USABLE_KEY" 2>&1)"; then
+      echo "     '$name' has no refresh configured; its credential would" >&2
+      echo "     expire within the hour. Re-run with FORCE_REAUTH=1." >&2
+      exit 1
+    fi
+    if ! printf '%s' "$status" | grep -q "oauth2_refresh_token"; then
+      echo "     '$name' is not configured for token rotation" >&2
       exit 1
     fi
     reusable="$name"

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/setup-graph.sh
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/setup-graph.sh
@@ -25,6 +25,9 @@ PROFILE_YAML="$RECIPE_ROOT/providers/graph-user.yaml"
 PROVIDER="${GRAPH_PROVIDER_NAME:-memory-driven-cos-graph}"
 SANDBOX="${OPENSHELL_SANDBOX_NAME:-${SANDBOX_NAME:-hermes}}"
 USABLE_KEY="MS_GRAPH_ACCESS_TOKEN"
+# Named for the shared helpers, so their error paths tell the user to re-run
+# the script they actually ran.
+SETUP_SCRIPT="scripts/setup-graph.sh"
 WANT_HOST="graph.microsoft.com"
 
 # Microsoft's own public client id for the device-code flow, and the tenant
@@ -38,6 +41,12 @@ TENANT_ID="${GRAPH_TENANT_ID:-common}"
 # user or copied them. Requesting `Mail.Read` alone produced a setup that
 # depended on a permission it never asked for.
 SCOPES="offline_access https://graph.microsoft.com/Mail.Read https://graph.microsoft.com/User.Read"
+
+# First, and before the device-code flow: an Entra consent granted on a
+# machine that cannot register the jobs is a consent spent for nothing, and
+# it is granted in a browser to a tenant an administrator may have to approve.
+. "$HERE/require-linux.sh"
+require_linux
 
 if ! command -v openshell >/dev/null 2>&1; then
   if [[ -n "${OPENSHELL_SANDBOX:-}" ]]; then

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/setup-graph.sh
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/setup-graph.sh
@@ -1,0 +1,305 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Connect a mailbox, so the scheduled intake can read it.
+#
+# Runs on the host, not in the sandbox: it talks to `openshell`, which is where
+# the credential is registered and refreshed. `install.sh` is the opposite —
+# that one talks to `hermes` and belongs in the sandbox.
+#
+# The device-code flow is used rather than a redirect. There is no browser on a
+# server and no port to redirect to, and the code is shown on this terminal
+# while the sign-in happens on whatever machine the operator already trusts.
+# What comes back is a refresh token, which is handed to the gateway and never
+# written into the sandbox.
+#
+#     SANDBOX_STORAGE_PATH=/var/lib/docker bash scripts/setup-graph.sh
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RECIPE_ROOT="$(dirname "$HERE")"
+PROFILE_ID="memory-driven-cos-graph-user"
+PROFILE_YAML="$RECIPE_ROOT/providers/graph-user.yaml"
+PROVIDER="${GRAPH_PROVIDER_NAME:-memory-driven-cos-graph}"
+SANDBOX="${OPENSHELL_SANDBOX_NAME:-${SANDBOX_NAME:-hermes}}"
+USABLE_KEY="MS_GRAPH_ACCESS_TOKEN"
+WANT_HOST="graph.microsoft.com"
+
+# Microsoft's own public client id for the device-code flow, and the tenant
+# most people want. Both are overridable: an organisation that registers its
+# own application passes its ids rather than editing this file.
+CLIENT_ID="${GRAPH_CLIENT_ID:-}"
+TENANT_ID="${GRAPH_TENANT_ID:-common}"
+SCOPES="offline_access https://graph.microsoft.com/Mail.Read"
+
+if ! command -v openshell >/dev/null 2>&1; then
+  if [[ -n "${OPENSHELL_SANDBOX:-}" ]]; then
+    echo "This is running inside the sandbox, where openshell is not." >&2
+    echo "" >&2
+    echo "Unlike install.sh, this step belongs on the host. From there:" >&2
+    echo "  cd <this recipe> && bash scripts/setup-graph.sh" >&2
+    exit 1
+  fi
+  echo "openshell is not on PATH, and this is not a NemoClaw sandbox." >&2
+  echo "This recipe's mailbox credential is held and refreshed by the" >&2
+  echo "OpenShell gateway, so there is no supported path without it." >&2
+  exit 1
+fi
+command -v python3 >/dev/null 2>&1 || {
+  echo "python3 is required to complete the device-code flow." >&2
+  exit 1
+}
+
+# The storage prerequisite, shared by every connector.
+# shellcheck source=scripts/require-encrypted-storage.sh
+. "$HERE/require-encrypted-storage.sh"
+# Field-by-field profile validation, shared by every connector.
+# shellcheck source=scripts/validate-provider-profile.sh
+. "$HERE/validate-provider-profile.sh"
+
+echo "1/6  Storage encryption"
+require_encrypted_storage
+
+echo "2/6  Looking for a mailbox credential this sandbox can already read"
+if ! attached="$(openshell sandbox provider list "$SANDBOX" 2>&1)"; then
+  echo "Could not list providers on sandbox '$SANDBOX'." >&2
+  echo "Check the name with: openshell sandbox list" >&2
+  exit 1
+fi
+
+reusable=""
+while read -r name; do
+  [[ -z "$name" ]] && continue
+  keys="$(openshell provider get "$name" 2>/dev/null \
+    | sed -n 's/.*Credential keys:[[:space:]]*//p' || true)"
+  if [[ "$keys" == *"$USABLE_KEY"* ]]; then
+    type="$(openshell provider get "$name" 2>/dev/null \
+      | sed 's/\x1b\[[0-9;]*m//g' \
+      | sed -n 's/^[[:space:]]*Type:[[:space:]]*//p')"
+    if [[ "$type" != "$PROFILE_ID" ]]; then
+      echo "     '$name' exposes $USABLE_KEY but is type '$type', not" >&2
+      echo "     '$PROFILE_ID'; refusing to reuse it. Remove it, or set" >&2
+      echo "     GRAPH_PROVIDER_NAME to a different name." >&2
+      exit 1
+    fi
+    if ! validate_profile "$type"; then
+      echo "     '$name' does not carry this recipe's endpoint policy" >&2
+      exit 1
+    fi
+    reusable="$name"
+    break
+  fi
+done < <(printf '%s\n' "$attached" \
+         | sed 's/\x1b\[[0-9;]*m//g' \
+         | awk 'NR > 1 && NF { print $1 }')
+
+if [[ -n "$reusable" ]]; then
+  echo "     reusing attached provider '$reusable' (type and policy verified)"
+  if [[ "${FORCE_REAUTH:-0}" != "1" ]]; then
+    echo ""
+    echo "Nothing to do. To replace its credential — after revoking consent,"
+    echo "or if the refresh chain was broken — re-run with:"
+    echo "  FORCE_REAUTH=1 bash scripts/setup-graph.sh"
+    exit 0
+  fi
+  echo "     FORCE_REAUTH=1, so its credential will be replaced"
+  PROVIDER="$reusable"
+else
+  echo "     none attached that exposes $USABLE_KEY"
+fi
+
+echo "3/6  Application registration"
+if [[ -z "$CLIENT_ID" ]]; then
+  echo ""
+  echo "This needs an Entra application with delegated Mail.Read and"
+  echo "offline_access, and public-client (device code) flow enabled."
+  echo "docs/set-up-graph.md walks through registering one."
+  echo ""
+  echo "Then re-run with its ids:"
+  echo "  GRAPH_CLIENT_ID=<id> GRAPH_TENANT_ID=<tenant> \\"
+  echo "      SANDBOX_STORAGE_PATH=<path> bash scripts/setup-graph.sh"
+  exit 1
+fi
+echo "     client $CLIENT_ID in tenant $TENANT_ID"
+
+echo "4/6  Sign in"
+# The device-code flow in two calls. The secret never appears in argv, where
+# `ps` would show it; the refresh token comes back on stdout and is consumed by
+# the next step through the environment.
+if ! DEVICE="$(CLIENT_ID="$CLIENT_ID" TENANT_ID="$TENANT_ID" SCOPES="$SCOPES" \
+    python3 - <<'PY'
+import json, os, sys, urllib.parse, urllib.request
+
+body = urllib.parse.urlencode({
+    "client_id": os.environ["CLIENT_ID"],
+    "scope": os.environ["SCOPES"],
+}).encode()
+url = ("https://login.microsoftonline.com/%s/oauth2/v2.0/devicecode"
+       % os.environ["TENANT_ID"])
+try:
+    with urllib.request.urlopen(urllib.request.Request(url, data=body),
+                                timeout=30) as response:
+        payload = json.loads(response.read().decode())
+except Exception as exc:  # noqa: BLE001
+    print(f"could not start the device-code flow: {type(exc).__name__}",
+          file=sys.stderr)
+    raise SystemExit(1)
+
+print(payload["device_code"])
+print(payload["user_code"], file=sys.stderr)
+print(payload["verification_uri"], file=sys.stderr)
+PY
+)"; then
+  echo "Sign-in could not be started. Nothing has been configured." >&2
+  exit 1
+fi
+
+echo ""
+echo "Open the address printed above on any machine you trust, and enter the"
+echo "code. This terminal waits; nothing is stored until it completes."
+echo ""
+
+if ! REFRESH_TOKEN="$(CLIENT_ID="$CLIENT_ID" TENANT_ID="$TENANT_ID" \
+    DEVICE_CODE="$DEVICE" python3 - <<'PY'
+import json, os, sys, time, urllib.error, urllib.parse, urllib.request
+
+url = ("https://login.microsoftonline.com/%s/oauth2/v2.0/token"
+       % os.environ["TENANT_ID"])
+body = urllib.parse.urlencode({
+    "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+    "client_id": os.environ["CLIENT_ID"],
+    "device_code": os.environ["DEVICE_CODE"],
+}).encode()
+
+deadline = time.time() + 600
+while time.time() < deadline:
+    try:
+        with urllib.request.urlopen(urllib.request.Request(url, data=body),
+                                    timeout=30) as response:
+            payload = json.loads(response.read().decode())
+        break
+    except urllib.error.HTTPError as exc:
+        detail = json.loads(exc.read().decode() or "{}")
+        error = detail.get("error")
+        if error == "authorization_pending":
+            time.sleep(5)
+            continue
+        if error == "slow_down":
+            time.sleep(10)
+            continue
+        print(f"sign-in failed: {error or exc.code}", file=sys.stderr)
+        raise SystemExit(1)
+    except Exception as exc:  # noqa: BLE001
+        print(f"could not reach the identity platform: {type(exc).__name__}",
+              file=sys.stderr)
+        raise SystemExit(1)
+else:
+    print("sign-in timed out", file=sys.stderr)
+    raise SystemExit(1)
+
+# By name, and only this one. The response also carries an access token, which
+# expires within the hour; configuring that as the refresh material would give
+# a provider that works today and stops tomorrow, reporting healthy throughout.
+refresh = payload.get("refresh_token")
+if not refresh:
+    print("the sign-in returned no refresh token; check that offline_access "
+          "is among the application's delegated permissions", file=sys.stderr)
+    raise SystemExit(1)
+print(refresh)
+PY
+)"; then
+  echo "Nothing has been configured." >&2
+  exit 1
+fi
+echo "     signed in; the refresh token stays on this host"
+
+echo "5/6  Registering the provider"
+# Delete-then-import, because import rejects an existing id rather than
+# upserting. A profile in use by a live sandbox cannot be deleted, so on a
+# re-run the delete is a no-op and the import collides — which is fine, it is
+# already registered. What is not fine is suppressing both and carrying on:
+# that leaves whatever was registered before in force, including an older
+# endpoint policy, and the provider is then created against it.
+openshell provider profile delete "$PROFILE_ID" >/dev/null 2>&1 || true
+import_out="$(openshell provider profile import --file "$PROFILE_YAML" 2>&1 ||
+true)"
+if ! openshell provider profile export "$PROFILE_ID" >/dev/null 2>&1; then
+  echo "Provider profile '$PROFILE_ID' is not registered." >&2
+  printf '%s\n' "$import_out" >&2
+  exit 1
+fi
+if ! validate_profile "$PROFILE_ID"; then
+  echo "The registered '$PROFILE_ID' profile is not the one this recipe" >&2
+  echo "describes. An older profile is still in force; delete it and re-run:"
+  >&2
+  echo "  openshell provider profile delete $PROFILE_ID" >&2
+  exit 1
+fi
+
+if openshell provider get "$PROVIDER" >/dev/null 2>&1; then
+  if ! openshell provider update "$PROVIDER" >/dev/null 2>&1; then
+    echo "Could not update provider '$PROVIDER'." >&2
+    exit 1
+  fi
+  echo "     updated provider '$PROVIDER'"
+else
+  if ! openshell provider create --name "$PROVIDER" --type "$PROFILE_ID" \
+        --runtime-credentials >/dev/null 2>&1; then
+    echo "Could not create provider '$PROVIDER'." >&2
+    exit 1
+  fi
+  echo "     created provider '$PROVIDER'"
+fi
+
+if ! GRAPH_REFRESH_TOKEN="$REFRESH_TOKEN" openshell provider refresh configure \
+    "$PROVIDER" --credential-key "$USABLE_KEY" \
+    --strategy oauth2-refresh-token \
+    --material "tenant_id=$TENANT_ID" \
+    --material "client_id=$CLIENT_ID" \
+    --secret-material-env refresh_token=GRAPH_REFRESH_TOKEN >/dev/null 2>&1;
+    then
+  echo "Could not configure refresh on '$PROVIDER'." >&2
+  echo "Nothing renews the credential, so it would stop within the hour." >&2
+  exit 1
+fi
+unset REFRESH_TOKEN
+echo "     refresh configured; the gateway owns renewal from here"
+
+echo "6/6  Attaching to sandbox '$SANDBOX'"
+if ! openshell sandbox provider attach "$SANDBOX" "$PROVIDER" >/dev/null 2>&1;
+then
+  echo "Could not attach. Attach it by hand with:" >&2
+  echo "  openshell sandbox provider attach $SANDBOX $PROVIDER" >&2
+  exit 1
+fi
+
+cat <<EOF
+
+Connected. The collector reads the mailbox on the intake schedule.
+
+The first synchronisation is bounded to a window you choose — seven days by
+default. Set it before the first run, in the profile's environment file so the
+scheduled job sees it too:
+
+  ENV=\$(hermes -p <profile> config env-path)
+  echo 'GRAPH_BACKFILL_DAYS=14' >> "\$ENV"
+
+Seven, fourteen and thirty are the usual answers; any number of days from 1 to
+3650 works. The window decides where the first round starts and nothing else:
+once the baseline exists, every later change in the folder is reported,
+including an older message being deleted.
+
+Check it by running the collector once, inside the sandbox:
+
+  python3 <profile home>/scripts/ingest_graph.py
+
+To revoke: remove consent for the application in your Microsoft account, then
+
+  openshell sandbox provider detach $SANDBOX $PROVIDER
+  openshell provider delete $PROVIDER
+
+That ends collection. It does not remove what was already collected — see
+docs/data-lifecycle.md for export and reset.
+EOF

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/setup-slack.sh
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/setup-slack.sh
@@ -21,15 +21,7 @@ set -euo pipefail
 
 # Same reason as install.sh: every shipped skill declares `platforms: [linux]`,
 # so the scheduled path this credential feeds does not run anywhere else.
-require_linux() {
-  local kernel
-  kernel="$(uname -s)"
-  if [[ "$kernel" != "Linux" ]]; then
-    echo "The scheduled path is Linux only; detected $kernel." >&2
-    echo "The fixture walkthrough needs no credential and runs anywhere." >&2
-    exit 1
-  fi
-}
+. "$(dirname "${BASH_SOURCE[0]}")/require-linux.sh"
 require_linux
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -71,6 +63,7 @@ command -v python3 >/dev/null 2>&1 || {
 # mismatch stops the run rather than being worked around.
 # The storage prerequisite, shared by every connector.
 # shellcheck source=scripts/require-encrypted-storage.sh
+SETUP_SCRIPT="scripts/setup-slack.sh"
 . "$(dirname "${BASH_SOURCE[0]}")/require-encrypted-storage.sh"
 
 # Field-by-field profile validation, shared by both paths.

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/setup-slack.sh
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/setup-slack.sh
@@ -69,92 +69,14 @@ command -v python3 >/dev/null 2>&1 || {
 # and one with no refresh configured will simply expire in twelve hours. Both
 # would attach cleanly and fail later, quietly. So the state is validated and a
 # mismatch stops the run rather than being worked around.
-# The storage prerequisite, checked before anything is inspected or
-# attached.
-#
-# It used to sit after the reuse early-exit, which meant a run that
-# found a usable provider printed "Nothing to do" and exited 0 without
-# ever checking it — reported as a successful setup on a machine whose
-# store had never been looked at. The check belongs before the branch,
-# because it is a property of the machine rather than of the run.
-require_encrypted_storage() {
-  # Attaching this provider is the moment real message bodies start landing in
-  # the store, and the prerequisite is that they land on an encrypted volume.
-  # Owner-only permissions are not that: they stop another account reading the
-  # file on a running system and do nothing for a disk that is lost, imaged, or
-  # backed up.
-  #
-  # Which volume is the whole question, and it is not one this script can guess.
-  # `HERMES_HOME` inside a sandbox is an overlay with no block device behind it,
-  # so encryption is unobservable from in there. On the host it depends on the
-  # driver: Docker keeps sandbox storage under its data-root, a VM keeps it in a
-  # disk image, Kubernetes in a volume — none of which is reliably `$HOME`. An
-  # earlier version inspected `$HOME` and would have approved the wrong volume on
-  # every one of those.
-  #
-  # So the path is asserted rather than inferred. `SANDBOX_STORAGE_PATH` names
-  # where this sandbox's storage actually lives; the script then verifies *that*
-  # path, which is a real check rather than a plausible one.
-  storage_path="${SANDBOX_STORAGE_PATH:-}"
-  if [[ -z "$storage_path" ]]; then
-    echo "     where this sandbox's storage lives is not something this script"
-    echo "     can determine — it differs by driver, and guessing would mean"
-    echo "     checking the wrong volume."
-    echo ""
-    echo "Find it, then re-run with it named. For the Docker driver:"
-    echo "  docker info --format '{{.DockerRootDir}}'"
-    echo ""
-    echo "  SANDBOX_STORAGE_PATH=<path> bash scripts/setup-slack.sh"
-    echo ""
-    echo "docs/encrypted-storage.md explains what to look for and why."
-    exit 1
-  fi
-  if [[ ! -e "$storage_path" ]]; then
-    echo "SANDBOX_STORAGE_PATH does not exist: $storage_path" >&2
-    exit 1
-  fi
-
-  encrypted="unknown"
-  if command -v findmnt >/dev/null 2>&1 && command -v lsblk >/dev/null 2>&1; then
-    source_dev="$(findmnt -no SOURCE --target "$storage_path" 2>/dev/null || true)"
-    if [[ -n "$source_dev" ]]; then
-      if lsblk -no TYPE "$source_dev" 2>/dev/null | grep -q crypt; then
-        encrypted="yes"
-      else
-        encrypted="no"
-      fi
-    fi
-  fi
-
-  case "$encrypted" in
-    yes)
-      echo "     $storage_path is on an encrypted volume" ;;
-    no)
-      echo "     $storage_path does NOT appear to be on an encrypted volume" ;;
-    *)
-      echo "     could not determine whether $storage_path is encrypted" ;;
-  esac
-
-  if [[ "$encrypted" != "yes" ]]; then
-    echo ""
-    echo "This recipe stores message subjects, senders and bodies once a"
-    echo "connector is attached. See docs/encrypted-storage.md."
-    echo ""
-    if [[ "${STORE_ENCRYPTION_ACKNOWLEDGED:-0}" == "1" ]]; then
-      echo "     STORE_ENCRYPTION_ACKNOWLEDGED=1 — continuing."
-    else
-      read -r -p "Type 'encrypted' to confirm the prerequisite is met: " ACK
-      if [[ "$ACK" != "encrypted" ]]; then
-        echo "Not confirmed. Nothing has been configured." >&2
-        exit 1
-      fi
-    fi
-  fi
-}
+# The storage prerequisite, shared by every connector.
+# shellcheck source=scripts/require-encrypted-storage.sh
+. "$(dirname "${BASH_SOURCE[0]}")/require-encrypted-storage.sh"
 
 # Field-by-field profile validation, shared by both paths.
-# shellcheck source=scripts/validate-slack-profile.sh
-. "$(dirname "${BASH_SOURCE[0]}")/validate-slack-profile.sh"
+# shellcheck source=scripts/validate-provider-profile.sh
+WANT_HOST="slack.com"
+. "$(dirname "${BASH_SOURCE[0]}")/validate-provider-profile.sh"
 
 validate_provider() {
   local name="$1" detail

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/validate-provider-profile.sh
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/validate-provider-profile.sh
@@ -4,6 +4,11 @@
 #
 # Validate a registered provider profile, field by field.
 #
+# One file for every connector rather than one per connector. A second copy of
+# a check like this is a copy that drifts: the one nobody edited keeps passing
+# a profile the other would refuse, and the difference surfaces as a boundary
+# that was narrower in one setup flow than the other.
+#
 # Its own file because two paths need it — reusing an attached provider and
 # creating a fresh one — and because the setup script cannot be driven this
 # far in a test: step 5 exchanges an authorization code against Slack, so a
@@ -11,7 +16,8 @@
 # Sourced by `setup-slack.sh`; invoked directly by the tests and by anybody
 # who wants to check what is registered:
 #
-#     USABLE_KEY=SLACK_USER_TOKEN bash scripts/validate-slack-profile.sh <id>
+#     WANT_HOST=slack.com USABLE_KEY=SLACK_USER_TOKEN \
+#         bash scripts/validate-provider-profile.sh <id>
 
 # The registered profile, checked field by field rather than by looking for
 # strings anywhere in a rendered blob.
@@ -30,10 +36,13 @@ validate_profile() {
     echo "     could not export provider profile '$id'" >&2
     return 1
   fi
-  PROFILE_JSON="$exported" USABLE_KEY="$USABLE_KEY" python3 - <<'PYCHECK'
+  PROFILE_JSON="$exported" USABLE_KEY="$USABLE_KEY" \
+  WANT_HOST="$WANT_HOST" WANT_PORT="${WANT_PORT:-443}" \
+  python3 - <<'PYCHECK'
 import json, os, sys
 
-want_host, want_port = "slack.com", 443
+want_host = os.environ["WANT_HOST"]
+want_port = int(os.environ.get("WANT_PORT", "443"))
 try:
     profile = json.loads(os.environ["PROFILE_JSON"])
 except json.JSONDecodeError as exc:
@@ -80,6 +89,7 @@ PYCHECK
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-  USABLE_KEY="${USABLE_KEY:-SLACK_USER_TOKEN}"
+  : "${WANT_HOST:?WANT_HOST is required}"
+  : "${USABLE_KEY:?USABLE_KEY is required}"
   validate_profile "$1"
 fi


### PR DESCRIPTION
## Related Issue

Related: #122

## Description

The third connector phase, and the one that can keep the stronger deletion guarantee. Slack offers no way to learn that a message was removed — its absence from a bounded read cannot be told apart from it lying outside the window — so Slack content ages out on the retention pass. Microsoft Graph delta reports that a message left the tracked folder. The collector then looks up its immutable `internetMessageId`: a match in another folder is a move, while no match is treated as a deletion.

**Deletion is reconciled rather than waited out.** A message deleted at the source is tombstoned on the next synchronisation and its body cleared at once. The row stays: obligations and events hang off `source_id`, and removing it would break the record of why something was ranked. `deleted_at` and `body_cleared_at` are separate columns because one is the person deleting and the other is this recipe ageing text out on its own schedule. The removal-tracking columns, `deleted_at` and `internet_message_id`, are schema v4, migrated in place and tested against `schema-v3.sql`, the frozen schema shipped in #140.

**The delta cursor is the watermark, which removes a class of bug rather than fixing one.** A cursor is opaque and only issued when a round completes, so it cannot be constructed from a message this run happened to see. "Only a complete crawl may advance the watermark" is enforced by the protocol rather than by remembering to write it correctly — the rule the Slack collector needed three rounds to get right. An interrupted round saves its page link and resumes; an expired cursor is a fresh round rather than a failed run.

**The first synchronisation is bounded to a window the operator chooses.** Seven days by default, `GRAPH_BACKFILL_DAYS` for 1 to 3650, through the same validator the other bounded settings use. I checked against the live service that the delta endpoint accepts a `receivedDateTime` filter on the initial request; without that the choice would have been between synchronising a whole mailbox and not learning about deletions at all. The window decides where the round starts and nothing else — the cursor carries no filter, so once the baseline exists every later change is reported, including an older message being deleted.

**Two shared pieces extracted rather than copied.** The storage-encryption gate and the field-by-field profile validation now live in `require-encrypted-storage.sh` and `validate-provider-profile.sh`, sourced by both setup flows. A second copy of a security gate is a copy that drifts. The validator is parameterised by host and credential key; `setup-slack.sh` passes `slack.com` and behaves as before.

Extracting the gate broke a test in a way worth naming: `test_an_unconfirmed_prerequisite_aborts` searched `setup-slack.sh` between two strings for `exit 1`, the window emptied when the gate moved, and it passed on nothing — the same shape that let the reuse-path bypass ship. It runs the script now.

## Verification

- [x] `python3 scripts/check_license_headers.py --check` — 569 files
- [x] `python3 scripts/check_label_taxonomy.py --check` — not applicable, no governance metadata changed
- [x] `git diff --check`
- [x] Recipe suite: 564 tests across thirteen files, `OK`
- [x] Against a real mailbox on Linux under Hermes 0.19.0: a seven-day first round synchronised 50 messages across 6 pages and stored a cursor; the next tick added nothing and stayed synchronised; moving a message to Deleted Items and re-running produced `removed: 1` with the row and metadata intact, the body gone, and both timestamps set
- [x] Confirmed against the live service that `messages/delta` accepts a `receivedDateTime` filter on the initial request and that the resulting cursor carries none
- [x] Each behaviour checked by reverting it and confirming the assertions turn red — move-is-not-deletion, immediate body clearing, partial crawls not advancing, resumption, the window bound, expired-cursor recovery

## Documentation Writer Review

- [x] Documentation writer review completed for the final changes
- Result: `docs-updated`
- Evidence or justification: `docs/set-up-graph.md` — new, covering the application registration, device-code sign-in, window choice and revocation; `README.md` — both collectors in the file map and the test table, and the Graph deletion sentence moved from future to present tense now that something implements it.
- Reviewer: @rebelle5868
- [x] Changed user-facing text follows the writing guide and controlled-word list.
- [x] A public contributor can understand the changed text without internal company context.
- [x] I reviewed any agent-generated text before submission.

## Release And Compliance

- [x] No secrets or credentials are included, including API keys, access tokens, passwords, local `.env` files, private certificates, or token caches.
- [x] No nonpublic project names, environment names, hostnames, URLs, ticket identifiers, workspace paths, logs, screenshots, or configuration values are included.
- [x] Third-party dependency changes are reflected in `THIRD-PARTY-NOTICES` — none; standard library only.
- [x] Public content uses sanitized examples and placeholders instead of private values.
- [x] I added my DCO sign-off declaration to this pull request description.

Signed-off-by: Xuan Wu <xuwu@nvidia.com>

