### PR TITLE
feat(memory-driven-chief-of-staff): join a person's identities on the user's word

### DIFF
--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -83,10 +83,12 @@ those two apart.
 | `profile/scripts/memory_check.py` | Invariant detection over the memory, deterministic |
 | `profile/scripts/preferences.py` | Correction counting against a fixed threshold |
 | `profile/scripts/apply_decisions.py` | Applies model decisions; the model returns an envelope and never writes SQL |
-| `profile/scripts/migrate.py` | Schema versioning, forward-only. At v2: adds `body_cleared_at` to a v1 store in place, without touching what it holds |
+| `profile/scripts/migrate.py` | Schema versioning, forward-only, v1 through v5. Each step is idempotent; v5 rebuilds `items` to trade a hardcoded source list for a foreign key, and refuses rather than completing if the copy would lose a row |
 | `profile/scripts/normalize.py` | Source payloads to store rows, kept separate from the network calls |
 | `profile/scripts/_db.py` | Connection and transaction boundary |
 | `profile/scripts/correct.py` | The user's writer: pins, ignores, and the only source of `actor='user'` events |
+| `profile/scripts/identity.py` | Which identities are one person: pairwise answers, resolved with a disjoint set |
+| `profile/scripts/link_identity.py` | The user's other writer, and the only thing that answers "are these the same person?" |
 | `profile/scripts/load_fixtures.py` | Replays the fixtures through the real ingest path |
 | `profile/scripts/walkthrough.py` | The fixture walkthrough, end to end, with no credentials and no model |
 | `profile/scripts/select_intake.py` | The intake job's pre-step: what to judge, and whether to wake the model at all |
@@ -248,7 +250,7 @@ cd ../..
 test "$fail" -eq 0
 ```
 
-Expected result: every file ends with `OK`, the thirteen files report 564 tests in
+Expected result: every file ends with `OK`, the fourteen files report 589 tests in
 total, and the last line is `failed=0`. Do not use `|| break` here; a `for`
 loop reports the status of its last command, so a failing test would still
 leave the loop exiting `0`.
@@ -264,6 +266,7 @@ leave the loop exiting `0`.
 | Writer behavior, audit trail, caps across batches, correction idempotency, correction state transitions, displaced-row audit | `tests/test_apply_decisions.py` |
 | The walkthrough, and its central claims | `tests/test_walkthrough.py` |
 | Selector output, the wake gate, and the scheduler contract | `tests/test_selectors.py` |
+| Identity across connectors: composing answers, refusing to guess, and the user's command | `tests/test_identity.py` |
 | What the memory job hands the agent: who is worth a page, stable identity across namesakes and renames, quiet days costing nothing, and corrections counted once | `tests/test_select_memory.py` |
 | Retention, exclusion, export and reset | `tests/test_lifecycle.py` |
 | The Slack collector: watermarks, partial failure, scope probing, thread discovery and rotation, the credential never reaching a stream, and the lifecycle controls applying to what it writes | `tests/test_ingest_slack.py` |
@@ -640,16 +643,34 @@ Both connectors can be set up, or either one alone. They write into the same
 store and run in the same tick, independently — see [When a collector
 fails](#when-a-collector-fails) for what happens when one of them cannot.
 
-**A person gets a page per source they reach you from.** Slack identifies
-people by user id and mail by address; nothing links them, and nothing should
-on the evidence available — a shared display name is not evidence, and the
-reason this recipe keeps a stable identity per sender at all is that guessing
-from a name puts two people on one page. So a colleague who writes from two
-places holds a page for each, and the selector reports them together under
-`shared_display_name` so the agent can say as much on both. That is a
-per-source split, not a Slack-and-mail one: a third connector would add a
-third page for the same person. Linking identities on the user's word rather
-than on a name is not in this change.
+**A person is a set of identities, and only the user says which.** Slack
+identifies people by user id, mail by address, and a third connector will do
+it a third way; nothing in the data links them, because a shared display name
+is not evidence and the reason this recipe keeps a stable identity per sender
+at all is that guessing from a name puts two people on one page.
+
+So the memory job proposes and never decides. When identities share a handle
+— stronger, because a handle is unique within its own source — or a display
+name, they are reported as `identity_candidates` and each still gets its own
+page. The user answers whenever they get to it:
+
+```bash
+python3 profile/scripts/link_identity.py same slack:U01DANA email:dana@example.com
+```
+
+and the next run writes one page holding the whole history. **Nothing waits
+for that answer.** The job records what it noticed and exits; an unanswered
+question costs nothing, and a nightly job whose completion depends on when
+somebody read a message is a job that does not complete.
+
+Answers are stored pairwise and composed, so confirming two pairs joins three
+identities without a third question, and a fourth connector is one more pair
+rather than a new shape. A rejection is recorded as durably as a
+confirmation, so a candidate the user has dismissed is not proposed again on
+every run. When answers stop agreeing with each other — two identities
+answered as different people, joined anyway by other confirmations since —
+that is reported as `identity_conflicts` and nothing is changed, because
+neither answer is knowably the wrong one.
 
 ### When a collector fails
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -250,7 +250,7 @@ cd ../..
 test "$fail" -eq 0
 ```
 
-Expected result: every file ends with `OK`, the fourteen files report 602 tests in
+Expected result: every file ends with `OK`, the fourteen files report 603 tests in
 total, and the last line is `failed=0`. Do not use `|| break` here; a `for`
 loop reports the status of its last command, so a failing test would still
 leave the loop exiting `0`.
@@ -719,6 +719,16 @@ repository `.gitignore` covers it, so it never appears in `git status`. Remove
 it as well if you want the checkout byte-for-byte as you found it.
 
 ## Known limitations
+
+**A page keeps the name it was created with, even when the reason for that
+name goes away.** Two people who present the same display name each get a
+name ending in a digest, because neither can be given the readable one
+without deciding between them. If the user later confirms that two such
+identities are one person, that person is no longer ambiguous and could hold
+the readable name — but the page they already have keeps its digest. Renaming
+would mean rewriting the index entry and every link that points at it, which
+is a real risk taken for an appearance, and a page name that moves is how
+history gets lost. It is cosmetic and it is permanent.
 
 - Under the builtin scheduler the jobs fire only while a gateway is serving
   this profile, and registering them starts nothing. `hermes cron tick` runs

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -250,7 +250,7 @@ cd ../..
 test "$fail" -eq 0
 ```
 
-Expected result: every file ends with `OK`, the fourteen files report 599 tests in
+Expected result: every file ends with `OK`, the fourteen files report 602 tests in
 total, and the last line is `failed=0`. Do not use `|| break` here; a `for`
 loop reports the status of its last command, so a failing test would still
 leave the loop exiting `0`.

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -250,7 +250,7 @@ cd ../..
 test "$fail" -eq 0
 ```
 
-Expected result: every file ends with `OK`, the fourteen files report 589 tests in
+Expected result: every file ends with `OK`, the fourteen files report 591 tests in
 total, and the last line is `failed=0`. Do not use `|| break` here; a `for`
 loop reports the status of its last command, so a failing test would still
 leave the loop exiting `0`.

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -250,7 +250,7 @@ cd ../..
 test "$fail" -eq 0
 ```
 
-Expected result: every file ends with `OK`, the fourteen files report 591 tests in
+Expected result: every file ends with `OK`, the fourteen files report 599 tests in
 total, and the last line is `failed=0`. Do not use `|| break` here; a `for`
 loop reports the status of its last command, so a failing test would still
 leave the loop exiting `0`.
@@ -658,8 +658,11 @@ page. The user answers whenever they get to it:
 python3 profile/scripts/link_identity.py same slack:U01DANA email:dana@example.com
 ```
 
-and the next run writes one page holding the whole history. **Nothing waits
-for that answer.** The job records what it noticed and exits; an unanswered
+and the next run reports them as one person. If each identity had already
+been written up, that run also names the other pages as `merge_into_slug`, so
+the agent folds them into one and removes what it emptied — a page nobody
+merged is history attributed to nobody, and it will not surface again on its
+own. **Nothing waits for that answer.** The job records what it noticed and exits; an unanswered
 question costs nothing, and a nightly job whose completion depends on when
 somebody read a message is a job that does not complete.
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/fixtures/memory/people/dana_okoro.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/fixtures/memory/people/dana_okoro.md
@@ -1,6 +1,7 @@
 ---
 name: Dana Okoro
-source_key: dana.okoro@example.com
+identities:
+  - email:dana.okoro@example.com
 email: dana.okoro@example.com
 role: Finance systems lead
 relationship: Owns the billing systems this person is migrating. Every cutover decision needs her sign-off.

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/fixtures/memory/people/sam_ruiz.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/fixtures/memory/people/sam_ruiz.md
@@ -1,6 +1,7 @@
 ---
 name: Sam Ruiz
-source_key: sam.ruiz@example.com
+identities:
+  - email:sam.ruiz@example.com
 email: sam.ruiz@example.com
 role: Platform engineer
 relationship: Collaborator on the onboarding revamp; occasional reviewer on migration work.

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/schema.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/schema.md
@@ -71,7 +71,9 @@ from somebody's inbox promotes work they never chose — the same failure
 ```yaml
 ---
 name: Full Name
-source_key: person@example.com     # the address or user id this page is about
+identities:                        # every account this person writes from
+  - email:person@example.com
+  - slack:U01EXAMPLE
 email: person@example.com          # optional
 role: Job title or function
 relationship: How they relate to the user, 1-2 sentences
@@ -85,14 +87,31 @@ status: active | departing | departed   # optional, default active
 **Sections, in order:** Relationship · Communication Style · Key Context ·
 Projects (linked) · Recent Interactions.
 
-**`source_key` is what makes the page durable, and it is not the same field
-as `email`.** `email` is contact information a reader might use; `source_key`
-is the identity the selector matches on, copied verbatim from what it hands
-over. Without it a page is found only by its filename, so the day a second
+**`identities` is what makes the page durable, and it is not the same field
+as `email`.** `email` is contact information a reader might use; `identities`
+is what the selector matches on, copied verbatim from what it hands over.
+Without it a page is found only by its filename, so the day a second
 `Sam Ruiz` appears the pages have to be renamed to tell them apart — and a
 renamed page is a page whose history was lost. With it, whoever was there
-first keeps their name and the newcomer gets a new one. Never edit it to tidy
-it up: an address that no longer matches the store is the same as no page.
+first keeps their name and the newcomer gets a new one. Never edit an entry
+to tidy it up: a value that no longer matches the store is the same as no
+page.
+
+**It is a list because a person is not one account.** Each entry is
+`source:key` — the connector that collected it, then the identity that
+connector gave. A colleague who writes from Slack and from mail has two
+entries; a third connector adds a third, and nothing about the page's shape
+changes. Split on the *first* colon only: a key may contain colons of its
+own.
+
+**Only the user adds an entry, and only through
+`profile/scripts/link_identity.py`.** A matching display name is not
+evidence — the reason the store keeps a stable identity at all is that
+guessing from a name puts two people on one page. A matching handle is a
+reason to *ask*, which the memory job does by reporting
+`identity_candidates`; it is never a reason to write. Pages written before
+the list existed carry a single `source_key:` and are read as a list of one;
+they are not rewritten, because the page belongs to the user.
 
 **Importance is about working proximity, not seniority.**
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/_db.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/_db.py
@@ -117,6 +117,12 @@ def ensure_store(schema_sql: Path | None = None) -> Path:
 
     with contextlib.closing(sqlite3.connect(path, isolation_level=None)) as conn:
         conn.execute(f"PRAGMA busy_timeout = {BUSY_TIMEOUT_MS}")
+        # `sources` is a foreign key, not a CHECK, so that adding a
+        # connector is an INSERT rather than a table rebuild. The cost is
+        # that SQLite enforces foreign keys per connection: unset, the
+        # constraint is inert. Every connection this code opens for writing
+        # sets it, here and in `write_txn`.
+        conn.execute("PRAGMA foreign_keys = ON")
         # Check the version before the baseline DDL, not after. `CREATE TABLE
         # IF NOT EXISTS` is idempotent against our own schema but not against
         # someone else's: a store from a later version that dropped a table we

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/identity.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/identity.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Who is one person, across however many places they write from.
+
+A person is a set of identities, not one. `sender_key` gives a stable
+identity per source; this module is what joins them, and what refuses to.
+
+The rules, in the order they matter:
+
+1. **An identity is a `(source, key)` pair, never a bare key.** Two sources
+   can mint the same string — a chat id and a login can collide, and nothing
+   stops them — and merging two people because their opaque ids matched would
+   be silent and unrecoverable. The store already carries `source` beside
+   `sender_key`; this module is where the pair is treated as one value.
+
+2. **Only the user joins identities.** No display name, no matching handle,
+   no heuristic. The whole reason the store keeps a stable identity is that
+   guessing from a name puts two people on one page, and a guess dressed up
+   as a confident link is worse than the split it replaced.
+
+3. **Answers compose.** Links are stored pairwise and resolved with a
+   disjoint set, so confirming A~B and B~C makes A~C true without asking
+   again, and the fourth identity is one more pair rather than a new shape.
+   Nothing here counts to two.
+
+4. **A dismissed candidate stays dismissed.** Rejections are recorded, not
+   just absences of confirmation, so the next run does not re-propose what
+   the user has already answered. An unresolved question re-asked nightly is
+   how a job that should be idle wakes the agent every night forever.
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from typing import Iterable, NamedTuple
+
+# A source name appears before the first colon in an identity's text form, so
+# it may not contain one. Keys may: a Teams id looks like `29:1a2b…`.
+SOURCE = re.compile(r"^[a-z0-9_]+$")
+
+
+class Identity(NamedTuple):
+    """One account, in one system."""
+
+    source: str
+    key: str
+
+    def __str__(self) -> str:
+        return f"{self.source}:{self.key}"
+
+
+def parse(text: str) -> Identity:
+    """`slack:U01DANA` -> Identity('slack', 'U01DANA').
+
+    Split on the *first* colon only. A key may contain colons — a Teams
+    conversation id is `29:1a2b…` — and splitting on the last, or on all of
+    them, silently truncates the identity of every such account to something
+    that matches nobody.
+    """
+    source, _, key = (text or "").partition(":")
+    if not key or not SOURCE.match(source):
+        raise ValueError(
+            f"{text!r} is not an identity; expected `<source>:<key>` with a "
+            "source of lowercase letters, digits or underscores")
+    return Identity(source, key)
+
+
+def _ordered(a: Identity, b: Identity) -> tuple[Identity, Identity]:
+    """The pair in the order the table stores it.
+
+    One row per pair, smaller side left, so `(A,B)` and `(B,A)` cannot both
+    exist and disagree about the same question. The database enforces it too;
+    this is where the ordering is applied rather than discovered.
+    """
+    return (a, b) if a < b else (b, a)
+
+
+def record(conn: sqlite3.Connection, a: Identity, b: Identity,
+           status: str) -> None:
+    """Write the user's answer about one pair, replacing any earlier one.
+
+    Replacing rather than refusing: people change their minds, and a stored
+    answer that cannot be corrected is worse than no answer, because the
+    candidate never comes back to be asked again.
+    """
+    if status not in ("confirmed", "rejected"):
+        raise ValueError(f"{status!r} is not confirmed or rejected")
+    if a == b:
+        raise ValueError("an identity is already itself")
+    left, right = _ordered(a, b)
+    conn.execute(
+        "INSERT INTO identity_links(left_source, left_key, right_source,"
+        "                           right_key, status)"
+        " VALUES (?,?,?,?,?)"
+        " ON CONFLICT(left_source, left_key, right_source, right_key)"
+        "   DO UPDATE SET status = excluded.status,"
+        "                 decided_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')",
+        (left.source, left.key, right.source, right.key, status))
+
+
+def decisions(conn: sqlite3.Connection) -> dict[tuple[Identity, Identity], str]:
+    """Every answer the user has given, keyed by the ordered pair."""
+    return {
+        (Identity(ls, lk), Identity(rs, rk)): status
+        for ls, lk, rs, rk, status in conn.execute(
+            "SELECT left_source, left_key, right_source, right_key, status"
+            "  FROM identity_links")
+    }
+
+
+class Persons:
+    """Identities grouped into people, by the user's confirmations alone.
+
+    A disjoint set. Grouping is not a pairwise question — asking "are these
+    two the same" for every pair of a person's four identities is six
+    questions where three answers suffice — and a disjoint set is what turns
+    the answers given into the grouping implied.
+    """
+
+    def __init__(self, links: Iterable[tuple[Identity, Identity]] = ()):
+        self._parent: dict[Identity, Identity] = {}
+        for a, b in links:
+            self.join(a, b)
+
+    def _find(self, node: Identity) -> Identity:
+        root = self._parent.setdefault(node, node)
+        while root != self._parent[root]:
+            root = self._parent[root]
+        # Path compression, so a person with many identities does not get
+        # slower to resolve as more are linked.
+        while self._parent[node] != root:
+            self._parent[node], node = root, self._parent[node]
+        return root
+
+    def join(self, a: Identity, b: Identity) -> None:
+        ra, rb = self._find(a), self._find(b)
+        if ra != rb:
+            # Smaller root wins, so the representative of a person does not
+            # depend on the order the links were read in — which would make
+            # a page name change between runs for no reason.
+            low, high = _ordered(ra, rb)
+            self._parent[high] = low
+
+    def of(self, node: Identity) -> Identity:
+        """The identity that stands for this person.
+
+        Deterministic: the lexicographically smallest identity in the set, so
+        two runs over the same links agree, and adding an identity that sorts
+        later does not rename anybody.
+        """
+        return self._find(node)
+
+    def group(self, node: Identity) -> list[Identity]:
+        root = self._find(node)
+        return sorted(n for n in self._parent if self._find(n) == root)
+
+
+def resolve(conn: sqlite3.Connection,
+            seen: Iterable[Identity] = ()) -> Persons:
+    """Group the identities in the store by the user's confirmed links.
+
+    `seen` seeds identities that have no link at all, so a person with one
+    identity is still a person rather than an absence.
+    """
+    confirmed = [pair for pair, status in decisions(conn).items()
+                 if status == "confirmed"]
+    persons = Persons(confirmed)
+    for node in seen:
+        persons.of(node)
+    return persons
+
+
+def contradictions(conn: sqlite3.Connection) -> list[dict[str, str]]:
+    """Pairs the user rejected that their other answers have joined anyway.
+
+    Confirm A~B and B~C and A~C follows, even if A~C was rejected earlier.
+    Transitivity does not care, and neither answer is obviously the wrong
+    one: the rejection may be stale, or one of the confirmations may be a
+    mistake. So this reports the conflict instead of resolving it, and the
+    grouping keeps the confirmations — dropping them would silently split a
+    person whose other links the user did confirm.
+    """
+    answers = decisions(conn)
+    persons = Persons([p for p, s in answers.items() if s == "confirmed"])
+    found = []
+    for (a, b), status in sorted(answers.items()):
+        if status == "rejected" and persons.of(a) == persons.of(b):
+            found.append({
+                "rejected": f"{a} and {b}",
+                "joined_by": " -> ".join(str(n) for n in persons.group(a)),
+                "detail": "these were answered as different people, and other "
+                          "confirmations since have joined them anyway",
+            })
+    return found
+
+
+def candidates(rows: Iterable[tuple[Identity, str, str | None]],
+               answers: dict[tuple[Identity, Identity], str],
+               persons: Persons) -> list[dict[str, object]]:
+    """Groups of identities that may be one person, for the user to answer.
+
+    `rows` is `(identity, display_name, handle)` per identity seen in the
+    window. Two things are treated as worth asking about, in this order:
+
+    - a shared **handle** across different sources. A handle is unique within
+      its own source, so `slack:dana` and `github:dana` being the same person
+      is a real possibility, where two mail addresses whose local parts match
+      is not news — that value was derived from the key that already tells
+      them apart.
+    - a shared **display name**. Weaker, and common enough to be worth asking
+      about only because a colleague usually presents the same name
+      everywhere.
+
+    Neither is acted on. Both produce a question.
+
+    A group is proposed only when it contains identities not already joined,
+    and only when the user has not already answered every pair in it. Groups,
+    not pairs, because one question about three identities beats three.
+    """
+    by_handle: dict[str, set[Identity]] = {}
+    by_name: dict[str, set[Identity]] = {}
+    display: dict[Identity, str] = {}
+    for who, name, handle in rows:
+        display[who] = name
+        if handle:
+            by_handle.setdefault(handle.strip().casefold(), set()).add(who)
+        if name:
+            by_name.setdefault(name.strip().casefold(), set()).add(who)
+
+    # One question per set of identities, even when several signals point at
+    # the same set. Handles are considered first, so a group that shares both
+    # is reported under the stronger reason rather than twice.
+    proposals = []
+    asked: set[tuple[Identity, ...]] = set()
+    for reason, buckets in (("shared handle", by_handle),
+                            ("shared display name", by_name)):
+        for value, members in sorted(buckets.items()):
+            if len(members) < 2:
+                continue
+            if len({m.source for m in members}) < 2:
+                # One source, one namespace: two distinct keys there are two
+                # distinct accounts, and the source itself would not let them
+                # share a handle. Nothing to ask.
+                continue
+            if len({persons.of(m) for m in members}) < 2:
+                continue  # already one person
+            group = sorted(members)
+            if tuple(group) in asked:
+                continue
+            if all(answers.get(_ordered(a, b)) is not None
+                   for i, a in enumerate(group) for b in group[i + 1:]):
+                continue  # every pair already answered
+            asked.add(tuple(group))
+            proposals.append({
+                "identities": [str(m) for m in group],
+                "display_names": sorted({display.get(m) or "" for m in group}),
+                "reason": reason,
+                "value": value,
+            })
+    return proposals

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/ingest_slack.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/ingest_slack.py
@@ -535,9 +535,20 @@ def worth_judging(message: dict[str, Any], user_id: str | None) -> bool:
     return message.get("user") != user_id
 
 
-def sender_name(token: str, user_id: str | None, cache: dict[str, str | None],
-                budget: Budget) -> str | None:
-    """Resolve one display name, or give up quietly.
+def sender_name(token: str, user_id: str | None,
+                cache: dict[str, tuple[str | None, str | None]],
+                budget: Budget) -> tuple[str | None, str | None]:
+    """Resolve one sender's display name and handle, or give up quietly.
+
+    Two values, because Slack has two and they answer different questions.
+    `profile.display_name` (falling back to `real_name`) is what to show a
+    reader; `name` is the workspace handle — the `@dana` a colleague is
+    addressed by, unique within the workspace and recognisable to the user in
+    a way a `U0…` id never is. The same response carries both, so keeping the
+    second costs no request.
+
+    Neither is an identity. Both can be changed by the person they describe,
+    which is what `sender_key` is for.
 
     Slack's own guidance for a large workspace, learned the expensive way on
     one: never enumerate the member list. Names are resolved one at a time and
@@ -545,19 +556,22 @@ def sender_name(token: str, user_id: str | None, cache: dict[str, str | None],
     whole collection because one lookup was rate-limited would be worse.
     """
     if not user_id:
-        return None
+        return (None, None)
     if user_id not in cache:
         if not budget.spend():
             # A name is cosmetic; the message is not. Do not spend the last
             # call on decoration, and do not cache the miss — a later tick
             # with budget left should still be able to resolve it.
-            return None
+            return (None, None)
         try:
-            profile = call("users.info", token, user=user_id).get("user", {})
-            cache[user_id] = (profile.get("profile", {}).get("display_name")
-                              or profile.get("real_name") or None)
+            user = call("users.info", token, user=user_id).get("user", {})
+            profile = user.get("profile", {}) or {}
+            cache[user_id] = (
+                profile.get("display_name") or user.get("real_name") or None,
+                user.get("name") or None,
+            )
         except SlackError:
-            cache[user_id] = None
+            cache[user_id] = (None, None)
     return cache[user_id]
 
 
@@ -844,8 +858,9 @@ def collect(token: str, caps: dict[str, Any],
                 threads_complete = False
 
         items = [
-            slack_message_to_item(message, channel, caps["user_id"],
-                                  sender_name(token, message.get("user"), names, budget))
+            slack_message_to_item(
+                message, channel, caps["user_id"],
+                *sender_name(token, message.get("user"), names, budget))
             for message in messages + threaded
             if worth_judging(message, caps["user_id"])
         ]

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/link_identity.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/link_identity.py
@@ -80,16 +80,27 @@ def _check_sources(conn, people: list[identity.Identity]) -> None:
 
 
 def decide(texts: list[str], status: str) -> dict[str, object]:
-    """Record one answer over every pair among the named identities.
+    """Record the user's answer, pairwise.
 
-    Stored pairwise even when the user answered about a group, so a later
-    answer about one member does not have to unpick a group decision — and so
-    `different` means what it says. Confirming a group of three is three
-    pairs; rejecting one is also three, because "these are not one person"
-    does not say which of them is the odd one out, and recording only some of
-    the pairs would leave the rest to be asked again.
+    `same` takes any number, because "these are one person" is a claim about
+    every pair in the group and each of them follows from it. Confirming
+    three identities is three pairs, and a later answer about one member can
+    revise that pair without unpicking a group decision.
+
+    `different` takes exactly two, because the negative does not distribute.
+    "These three are not one person" rules out the group and says nothing
+    about which member is the odd one out — A and B may well be the same
+    colleague with C a stranger. Recording all three pairs as rejected would
+    bury the A~B link and stop it ever being proposed again, on the strength
+    of an answer the user did not give.
     """
     people = _identities(texts)
+    if status == "rejected" and len(people) != 2:
+        raise ValueError(
+            "`different` takes exactly two identities. Saying a group is not "
+            "one person does not say which member is the odd one out, and "
+            "recording every pair as rejected would bury a link the user "
+            "never denied. Answer the pairs that are actually different.")
     unknown = []
     with write_txn() as conn:
         _check_sources(conn, people)
@@ -143,7 +154,7 @@ def main(argv: list[str] | None = None) -> int:
     same = sub.add_parser("same", help="one person, several accounts")
     same.add_argument("identities", nargs="+", metavar="source:key")
 
-    diff = sub.add_parser("different", help="not the same person")
+    diff = sub.add_parser("different", help="these two are not one person")
     diff.add_argument("identities", nargs="+", metavar="source:key")
 
     shown = sub.add_parser("list", help="what has been answered so far")

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/link_identity.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/link_identity.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The user's answer to "are these the same person?".
+
+Like `correct.py`, and for the same reason: the model must not be able to
+manufacture this evidence. A display name matching, a handle matching — those
+are why a question is asked, never why it is answered. Only the user answers,
+and this is the only thing that writes an answer.
+
+    python3 link_identity.py same slack:U01DANA email:dana@example.com
+    python3 link_identity.py different slack:U01DANA email:d.okoro@example.com
+    python3 link_identity.py list [--all]
+
+Any number of identities may be named at once, because that is the shape of
+the question the memory job asks — "these three all present as Dana Okoro" —
+and answering it as three separate pairs is arithmetic the user should not
+have to do.
+
+**This is deliberately not part of any scheduled job.** The memory job writes
+its pages, records what it noticed, and exits; nothing waits for an answer,
+and an unanswered question costs nothing. Blocking a nightly job on a human
+would make the job's completion depend on when somebody happened to read a
+message, and the pages it can write without the answer are still worth
+writing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from itertools import combinations
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import identity  # noqa: E402
+from _db import ensure_store, write_txn  # noqa: E402
+
+
+def _identities(texts: list[str]) -> list[identity.Identity]:
+    seen = []
+    for text in texts:
+        who = identity.parse(text)
+        if who in seen:
+            raise ValueError(f"{who} was named twice")
+        seen.append(who)
+    if len(seen) < 2:
+        raise ValueError("name at least two identities")
+    return seen
+
+
+def _known(conn, who: identity.Identity) -> bool:
+    return conn.execute(
+        "SELECT 1 FROM items WHERE source = ? AND sender_key = ? LIMIT 1",
+        (who.source, who.key)).fetchone() is not None
+
+
+def _check_sources(conn, people: list[identity.Identity]) -> None:
+    """Refuse a source this install has never heard of.
+
+    The foreign key already refuses it, and says `FOREIGN KEY constraint
+    failed` — which tells a user who mistyped `slak:U01DANA` nothing about
+    what went wrong or what to type instead. The constraint stays; this is
+    the message.
+
+    Refusing rather than adding the source: a source appears when a connector
+    ships, and inventing one here would let a typo create a namespace that
+    silently matches nothing forever.
+    """
+    known = {row[0] for row in conn.execute("SELECT name FROM sources")}
+    missing = sorted({w.source for w in people} - known)
+    if missing:
+        raise ValueError(
+            f"no connector called {', '.join(missing)}; this install knows "
+            f"{', '.join(sorted(known))}. An identity is `<source>:<key>`, "
+            "and the source is the connector that collected it.")
+
+
+def decide(texts: list[str], status: str) -> dict[str, object]:
+    """Record one answer over every pair among the named identities.
+
+    Stored pairwise even when the user answered about a group, so a later
+    answer about one member does not have to unpick a group decision — and so
+    `different` means what it says. Confirming a group of three is three
+    pairs; rejecting one is also three, because "these are not one person"
+    does not say which of them is the odd one out, and recording only some of
+    the pairs would leave the rest to be asked again.
+    """
+    people = _identities(texts)
+    unknown = []
+    with write_txn() as conn:
+        _check_sources(conn, people)
+        for who in people:
+            if not _known(conn, who):
+                unknown.append(str(who))
+        for a, b in combinations(people, 2):
+            identity.record(conn, a, b, status)
+        conflicts = identity.contradictions(conn)
+    return {
+        "identities": [str(w) for w in people],
+        "status": status,
+        "pairs": len(list(combinations(people, 2))),
+        # Named rather than refused: an identity with no messages yet is a
+        # normal state — a colleague whose account the user knows about
+        # before the collector has seen them write.
+        "not_seen_in_the_store": unknown,
+        # Answers that no longer agree. The write is kept; see
+        # `identity.contradictions` for why neither side is dropped.
+        "conflicts": conflicts,
+    }
+
+
+def listing(everything: bool) -> dict[str, object]:
+    with write_txn() as conn:
+        answers = identity.decisions(conn)
+        persons = identity.resolve(
+            conn, [identity.Identity(s, k) for s, k in conn.execute(
+                "SELECT DISTINCT source, sender_key FROM items"
+                " WHERE sender_key IS NOT NULL")])
+        conflicts = identity.contradictions(conn)
+    groups = {}
+    for (a, b), status in answers.items():
+        if status != "confirmed":
+            continue
+        root = persons.of(a)
+        groups[str(root)] = [str(x) for x in persons.group(a)]
+    out: dict[str, object] = {"people": sorted(groups.values()),
+                              "conflicts": conflicts}
+    if everything:
+        out["rejected"] = sorted(
+            f"{a} / {b}" for (a, b), s in answers.items() if s == "rejected")
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Say which identities are the same person.")
+    sub = ap.add_subparsers(dest="command", required=True)
+
+    same = sub.add_parser("same", help="one person, several accounts")
+    same.add_argument("identities", nargs="+", metavar="source:key")
+
+    diff = sub.add_parser("different", help="not the same person")
+    diff.add_argument("identities", nargs="+", metavar="source:key")
+
+    shown = sub.add_parser("list", help="what has been answered so far")
+    shown.add_argument("--all", action="store_true",
+                       help="include the pairs answered as different people")
+
+    args = ap.parse_args(argv)
+    ensure_store()
+    try:
+        if args.command == "list":
+            report = listing(args.all)
+        else:
+            report = decide(args.identities,
+                            "confirmed" if args.command == "same"
+                            else "rejected")
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/memory_check.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/memory_check.py
@@ -330,8 +330,12 @@ def check_identity(root: Path) -> list[Finding]:
             if text_form in seen:
                 findings.append(Finding(
                     "duplicate-identity", rel,
-                    f"identity {text_form} is also on {seen[text_form]}; one "
-                    "of them is about somebody else"))
+                    f"identity {text_form} is also on {seen[text_form]}. "
+                    "Either one of them is about somebody else, or a merge "
+                    "copied the content across and left the emptied page "
+                    "behind. Only the memory job knows which: it reports the "
+                    "pages a confirmed link has joined. Do not merge and do "
+                    "not pick on what is visible here."))
                 continue
             seen[text_form] = rel
     return findings

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/memory_check.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/memory_check.py
@@ -268,19 +268,39 @@ def check_ceilings(root: Path) -> list[Finding]:
     return findings
 
 
+# A source name is what appears before the first colon of an identity, so it
+# may not contain one. Keys may: a Teams id looks like `29:1a2b`.
+IDENTITY_SOURCE = re.compile(r"^[a-z0-9_]+$")
+
+
+def _identities_of(text: str) -> list[str]:
+    """Every identity a page claims, from either spelling of the field."""
+    listed = re.search(r"^identities:\s*\n((?:\s*-\s*\S+\s*\n)+)",
+                       text, re.M)
+    if listed:
+        return [line.strip().lstrip("-").strip()
+                for line in listed.group(1).splitlines() if line.strip()]
+    single = re.search(r"^source_key:\s*(\S+)", text, re.M)
+    return [single.group(1)] if single else []
+
+
 def check_identity(root: Path) -> list[Finding]:
-    """People pages carry an identity, and no two carry the same one.
+    """People pages carry at least one identity, and no two claim the same one.
 
-    `source_key` is what the memory job matches a person on. A page without
-    one is found only by its filename, so it is renamed the day a namesake
+    `identities` is what the memory job matches a person on. A page without
+    any is found only by its filename, so it is renamed the day a namesake
     appears — and a renamed page is a page whose history was lost. Two pages
-    with the same one are worse: the job finds whichever it looks at first and
-    writes both people into it.
+    claiming one identity are worse: the job finds whichever it looks at
+    first and writes both people into it.
 
-    Neither is repaired by guessing. A missing key is reported so the page can
-    be given the value the selector hands over for that person; there is
-    nothing on the page itself that could supply it, and deriving one from the
-    name is the exact mistake the field exists to prevent.
+    Neither is repaired by guessing. A missing list is reported so the page
+    can be given the values the selector hands over; there is nothing on the
+    page itself that could supply them, and deriving one from the name is the
+    exact mistake the field exists to prevent.
+
+    A malformed entry is its own finding. `dana@example.com` without a source
+    matches nothing — the selector looks for `email:dana@example.com` — and a
+    page that matches nothing is silently orphaned rather than loudly broken.
     """
     findings: list[Finding] = []
     seen: dict[str, str] = {}
@@ -291,21 +311,29 @@ def check_identity(root: Path) -> list[Finding]:
         if text is None:
             continue
         rel = str(page.relative_to(root))
-        key = _frontmatter(text).get("source_key", "").strip()
-        if not key:
+        claimed = _identities_of(text)
+        if not claimed:
             findings.append(Finding(
                 "missing-identity", rel,
-                "no source_key; a page written now must carry the value the "
+                "no identities; a page written now must carry the values the "
                 "selector reports, and one written before the field existed "
-                "needs it supplied rather than derived from the name"))
+                "needs them supplied rather than derived from the name"))
             continue
-        if key in seen:
-            findings.append(Finding(
-                "duplicate-identity", rel,
-                f"source_key {key} is also on {seen[key]}; one of them is "
-                "about somebody else"))
-            continue
-        seen[key] = rel
+        for text_form in claimed:
+            source, _, key = text_form.partition(":")
+            if not key or not IDENTITY_SOURCE.match(source):
+                findings.append(Finding(
+                    "malformed-identity", rel,
+                    f"{text_form} is not `<source>:<key>`; it will match no "
+                    "message, so the page is orphaned rather than broken"))
+                continue
+            if text_form in seen:
+                findings.append(Finding(
+                    "duplicate-identity", rel,
+                    f"identity {text_form} is also on {seen[text_form]}; one "
+                    "of them is about somebody else"))
+                continue
+            seen[text_form] = rel
     return findings
 
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/migrate.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/migrate.py
@@ -22,7 +22,7 @@ import sqlite3
 from pathlib import Path
 from typing import Callable
 
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5
 
 # version -> callable applied to reach it. Forward only; there is no down path,
 # because a downgrade that drops a column loses data no backup can infer.
@@ -87,10 +87,147 @@ def _add_removal_tracking(conn: sqlite3.Connection) -> None:
         conn.execute("ALTER TABLE items ADD COLUMN internet_message_id TEXT")
 
 
+def _add_identity_model(conn: sqlite3.Connection) -> None:
+    """v5: a person is a set of identities, and a source is a row.
+
+    Three changes that only make sense together.
+
+    `sender_handle` records what a source calls somebody — a Slack handle, a
+    login — which is neither their identity nor their display name, and is
+    the strongest evidence a source offers that the same person appears in
+    another one.
+
+    `sources` replaces `CHECK (source IN ('email','slack'))`. That list meant
+    a third connector could not write a row until somebody shipped a schema
+    change, which is a poor thing to discover while writing the connector.
+    SQLite cannot alter a CHECK, so removing it is a table rebuild — the one
+    migration shape that can lose rows, which is why the columns are named
+    explicitly below rather than copied with `SELECT *`, and why the row
+    count is compared before and after.
+
+    `identity_links` holds the user's answers about which identities belong
+    to one person. Empty here: this migration adds somewhere to record them
+    and does not invent any.
+
+    Idempotent throughout, so an interrupted upgrade can be run again.
+    """
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(items)")}
+    if "sender_handle" not in columns:
+        conn.execute("ALTER TABLE items ADD COLUMN sender_handle TEXT")
+
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS sources (
+            name      TEXT PRIMARY KEY,
+            added_at  TEXT NOT NULL
+                      DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+        )""")
+    # Every source any row already claims, so the foreign key added below
+    # cannot orphan a message that arrived before this table existed.
+    conn.execute("INSERT OR IGNORE INTO sources(name) VALUES ('email'),('slack')")
+    conn.execute("INSERT OR IGNORE INTO sources(name)"
+                 " SELECT DISTINCT source FROM items WHERE source IS NOT NULL")
+
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS identity_links (
+            left_source   TEXT NOT NULL REFERENCES sources(name),
+            left_key      TEXT NOT NULL,
+            right_source  TEXT NOT NULL REFERENCES sources(name),
+            right_key     TEXT NOT NULL,
+            status        TEXT NOT NULL
+                          CHECK (status IN ('confirmed','rejected')),
+            decided_at    TEXT NOT NULL
+                          DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            decided_via   TEXT NOT NULL DEFAULT 'user',
+            PRIMARY KEY (left_source, left_key, right_source, right_key),
+            CHECK ((left_source, left_key) < (right_source, right_key))
+        )""")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_links_left"
+                 " ON identity_links(left_source, left_key)"
+                 " WHERE status = 'confirmed'")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_links_right"
+                 " ON identity_links(right_source, right_key)"
+                 " WHERE status = 'confirmed'")
+
+    _rebuild_items_without_the_source_check(conn)
+
+
+ITEM_COLUMNS_V5 = (
+    "source_id", "source", "scope", "thread_ref", "event_at", "sender",
+    "sender_key", "sender_handle", "subject", "body", "body_cleared_at",
+    "deleted_at", "internet_message_id", "permalink", "addressing", "unread",
+    "state", "state_at",
+)
+
+
+def _rebuild_items_without_the_source_check(conn: sqlite3.Connection) -> None:
+    """Swap `items` for one whose `source` is a foreign key, keeping rows.
+
+    Detected rather than attempted: a store that already has the foreign key
+    is left alone, so a re-run costs a `PRAGMA` and nothing else.
+
+    `PRAGMA foreign_keys` is deliberately not touched. The callers that open
+    a store for writing set it, and turning it off here would silently do
+    nothing anyway — SQLite ignores the pragma inside a transaction. The
+    order below does not need it off: nothing has a foreign key to `items`,
+    and `sources` is populated before any row is copied, so every row has a
+    parent by the time the constraint applies.
+    """
+    sql = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='items'"
+    ).fetchone()
+    if sql and "REFERENCES sources" in (sql[0] or ""):
+        return
+
+    before = conn.execute("SELECT count(*) FROM items").fetchone()[0]
+    names = ", ".join(ITEM_COLUMNS_V5)
+    conn.execute("""
+        CREATE TABLE items_v5 (
+            source_id   TEXT PRIMARY KEY,
+            source      TEXT NOT NULL REFERENCES sources(name),
+            scope       TEXT NOT NULL,
+            thread_ref  TEXT,
+            event_at    TEXT NOT NULL,
+            sender      TEXT,
+            sender_key  TEXT,
+            sender_handle TEXT,
+            subject     TEXT,
+            body        TEXT,
+            body_cleared_at TEXT,
+            deleted_at    TEXT,
+            internet_message_id TEXT,
+            permalink   TEXT,
+            addressing  TEXT
+                        CHECK (addressing IN ('direct','mentioned','broadcast')),
+            unread      INTEGER CHECK (unread IN (0,1)),
+            state       TEXT NOT NULL
+                        CHECK (state IN ('pending','judged','skipped'))
+                        DEFAULT 'pending',
+            state_at    TEXT NOT NULL
+                        DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+        )""")
+    conn.execute(f"INSERT INTO items_v5({names}) SELECT {names} FROM items")
+    after = conn.execute("SELECT count(*) FROM items_v5").fetchone()[0]
+    if after != before:
+        # The transaction is rolled back by the caller, so the old table is
+        # still there. Better to refuse an upgrade than to complete one that
+        # dropped messages.
+        raise RuntimeError(
+            f"rebuilding items would have kept {after} of {before} rows")
+
+    conn.execute("DROP TABLE items")
+    conn.execute("ALTER TABLE items_v5 RENAME TO items")
+    # Dropping the table dropped its indexes with it.
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_items_pending"
+                 " ON items(state, event_at)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_items_event_at"
+                 " ON items(event_at) WHERE body IS NOT NULL")
+
+
 MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
     2: _add_body_cleared_at,
     3: _add_sender_key,
     4: _add_removal_tracking,
+    5: _add_identity_model,
 }
 
 
@@ -183,6 +320,9 @@ def open_store(path: Path) -> sqlite3.Connection:
     """Open a store and bring it to the current schema."""
     conn = sqlite3.connect(path, isolation_level=None)
     conn.execute("PRAGMA busy_timeout = 5000")
+    # Per connection, and inert without it — see `_db.ensure_store`. Set
+    # before BEGIN: SQLite ignores this pragma inside a transaction.
+    conn.execute("PRAGMA foreign_keys = ON")
     conn.execute("BEGIN IMMEDIATE")
     try:
         migrate(conn)

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/migrate.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/migrate.py
@@ -165,12 +165,25 @@ def _rebuild_items_without_the_source_check(conn: sqlite3.Connection) -> None:
     Detected rather than attempted: a store that already has the foreign key
     is left alone, so a re-run costs a `PRAGMA` and nothing else.
 
-    `PRAGMA foreign_keys` is deliberately not touched. The callers that open
-    a store for writing set it, and turning it off here would silently do
-    nothing anyway — SQLite ignores the pragma inside a transaction. The
-    order below does not need it off: nothing has a foreign key to `items`,
-    and `sources` is populated before any row is copied, so every row has a
-    parent by the time the constraint applies.
+    **The dependants have to be carried across by hand.** `obligations.source_id`
+    references `items(source_id)` `ON DELETE CASCADE`, and with foreign keys
+    enabled SQLite performs an implicit `DELETE FROM` before dropping a table
+    — which fires that cascade and takes the obligations, and the events
+    hanging off them, with it. Measured: a v4 store with one message, one
+    obligation and one event came out of this migration with the message and
+    nothing else. The audit trail is the thing the recipe promises outlives
+    its subject, so losing it here would have been the worst possible place.
+
+    Turning the pragma off does not help: SQLite ignores
+    `PRAGMA foreign_keys` inside a transaction, and `defer_foreign_keys`
+    defers constraint *checks* rather than cascade *actions*. All three were
+    tried. The documented procedure sets the pragma before `BEGIN`, which is
+    the caller's business and not something a migration step can reach.
+
+    So the rows are saved and put back. The dependants are discovered from
+    `PRAGMA foreign_key_list` rather than named here, because a table added
+    later that references `items` would otherwise be silently emptied by this
+    same code — which is the defect above, one table further on.
     """
     sql = conn.execute(
         "SELECT sql FROM sqlite_master WHERE type='table' AND name='items'"
@@ -178,7 +191,33 @@ def _rebuild_items_without_the_source_check(conn: sqlite3.Connection) -> None:
     if sql and "REFERENCES sources" in (sql[0] or ""):
         return
 
-    before = conn.execute("SELECT count(*) FROM items").fetchone()[0]
+    # The transitive closure, not the direct dependants. `events` references
+    # `obligations`, which references `items`, so dropping `items` empties
+    # obligations by cascade and events by the cascade from *that* — and a
+    # first attempt at this saved only the direct dependants and lost the
+    # events anyway.
+    tables = [row[0] for row in conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+        "   AND name NOT LIKE 'sqlite_%'").fetchall()]
+    parents = {table: {row[2] for row in
+                       conn.execute(f"PRAGMA foreign_key_list({table})")}
+               for table in tables}
+    reached, dependants = {"items"}, []
+    growing = True
+    while growing:
+        growing = False
+        for table in tables:
+            if table not in reached and parents[table] & reached:
+                reached.add(table)
+                dependants.append(table)
+                growing = True
+
+    before = {"items": conn.execute("SELECT count(*) FROM items").fetchone()[0]}
+    for table in dependants:
+        before[table] = conn.execute(
+            f"SELECT count(*) FROM {table}").fetchone()[0]
+        conn.execute(f"CREATE TEMP TABLE _carry_{table} AS"
+                     f" SELECT * FROM {table}")
     names = ", ".join(ITEM_COLUMNS_V5)
     conn.execute("""
         CREATE TABLE items_v5 (
@@ -206,13 +245,14 @@ def _rebuild_items_without_the_source_check(conn: sqlite3.Connection) -> None:
                         DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
         )""")
     conn.execute(f"INSERT INTO items_v5({names}) SELECT {names} FROM items")
-    after = conn.execute("SELECT count(*) FROM items_v5").fetchone()[0]
-    if after != before:
+    copied = conn.execute("SELECT count(*) FROM items_v5").fetchone()[0]
+    if copied != before["items"]:
         # The transaction is rolled back by the caller, so the old table is
         # still there. Better to refuse an upgrade than to complete one that
         # dropped messages.
         raise RuntimeError(
-            f"rebuilding items would have kept {after} of {before} rows")
+            f"rebuilding items would have kept {copied} of {before['items']}"
+            " rows")
 
     conn.execute("DROP TABLE items")
     conn.execute("ALTER TABLE items_v5 RENAME TO items")
@@ -221,6 +261,19 @@ def _rebuild_items_without_the_source_check(conn: sqlite3.Connection) -> None:
                  " ON items(state, event_at)")
     conn.execute("CREATE INDEX IF NOT EXISTS idx_items_event_at"
                  " ON items(event_at) WHERE body IS NOT NULL")
+
+    for table in dependants:
+        conn.execute(f"INSERT INTO {table} SELECT * FROM _carry_{table}")
+        conn.execute(f"DROP TABLE _carry_{table}")
+
+    # Every affected table, not only the one being rebuilt. Counting `items`
+    # alone is what let the cascade through unnoticed.
+    for table, count in before.items():
+        now = conn.execute(f"SELECT count(*) FROM {table}").fetchone()[0]
+        if now != count:
+            raise RuntimeError(
+                f"rebuilding items would have left {table} with {now} of "
+                f"{count} rows")
 
 
 MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/normalize.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/normalize.py
@@ -96,6 +96,15 @@ def graph_message_to_item(msg: dict[str, Any], user_address: str) -> dict[str, A
         # The stable half. `sender` is the display name when there is one,
         # which two different people can share; the address is theirs.
         "sender_key": _address_of(msg.get("from")) or None,
+        # Mail has no handle of its own — Graph gives a sender a name and an
+        # address and nothing else — so this is *derived* from the address
+        # rather than stated by the source. Said plainly because it changes
+        # what it is worth as evidence: a handle matching another mail
+        # identity's proves nothing new, since both come from the key that
+        # already distinguishes them. Matching a handle from a different
+        # source is a different matter.
+        "sender_handle": (_address_of(msg.get("from")) or "").split("@")[0]
+                         or None,
         "subject": msg.get("subject"),
         "body": body.get("content"),
         "permalink": msg.get("webLink"),
@@ -113,6 +122,7 @@ def slack_message_to_item(
     channel: dict[str, Any],
     user_id: str,
     sender_name: str | None = None,
+    sender_handle: str | None = None,
 ) -> dict[str, Any]:
     """One Slack message -> one `items` row.
 
@@ -147,6 +157,10 @@ def slack_message_to_item(
         # The stable half, for the same reason: a display name is something
         # its owner can change, and two people can choose the same one.
         "sender_key": msg.get("user") or None,
+        # Stated by the source, unlike mail's: Slack's `name` is the `@handle`
+        # a colleague is addressed by. Unique in the workspace, and the person
+        # can change it — readable, and not an identity.
+        "sender_handle": sender_handle or None,
         "subject": None,
         "body": msg.get("text"),
         "permalink": msg.get("permalink"),
@@ -158,8 +172,8 @@ def slack_message_to_item(
 
 ITEM_COLUMNS = (
     "source_id", "source", "scope", "thread_ref", "event_at",
-    "sender", "sender_key", "subject", "body", "permalink", "addressing",
-    "unread",
+    "sender", "sender_key", "sender_handle", "subject", "body", "permalink",
+    "addressing", "unread",
     # Mail only. Slack has no equivalent and leaves it NULL; the collector
     # that needs it is the one that can tell a move from a deletion.
     "internet_message_id",

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/schema-v4.sql
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/schema-v4.sql
@@ -1,3 +1,10 @@
+-- FROZEN. The v4 schema exactly as it shipped.
+--
+-- Kept so the v4 -> v5 migration is tested against the database people
+-- actually have. The v5 step rebuilds `items` to drop a CHECK constraint,
+-- which is the one migration shape that can lose rows, so the state it
+-- starts from has to be the real one.
+--
 -- Ledger store for the memory-driven chief-of-staff recipe.
 --
 -- Target runtime : SQLite bundled with Hermes 0.19.0 (the version the current
@@ -22,24 +29,7 @@ CREATE TABLE IF NOT EXISTS meta (
     key   TEXT PRIMARY KEY,
     value TEXT NOT NULL
 );
-INSERT OR IGNORE INTO meta(key, value) VALUES ('schema_version', '5');
-
-
--- ---------------------------------------------------------------------------
--- 0) sources — the systems messages can arrive from.
---
---    A table rather than a CHECK list on `items.source`. The list was
---    `CHECK (source IN ('email','slack'))`, which meant a third connector
---    could not write a single row until someone shipped a schema migration —
---    and SQLite cannot alter a CHECK, so that migration is a full table
---    rebuild. Adding a source is now an INSERT, and the foreign key still
---    refuses a typo, which is what the CHECK was actually for.
--- ---------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS sources (
-    name      TEXT PRIMARY KEY,
-    added_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
-);
-INSERT OR IGNORE INTO sources(name) VALUES ('email'), ('slack');
+INSERT OR IGNORE INTO meta(key, value) VALUES ('schema_version', '4');
 
 
 -- ---------------------------------------------------------------------------
@@ -50,7 +40,7 @@ CREATE TABLE IF NOT EXISTS items (
     -- Email: the Graph message id. Slack: "<channel_id>:<ts>", because a
     -- Slack timestamp is only unique within its channel.
     source_id   TEXT PRIMARY KEY,
-    source      TEXT NOT NULL REFERENCES sources(name),
+    source      TEXT NOT NULL CHECK (source IN ('email','slack')),
     scope       TEXT NOT NULL,              -- mail folder id / slack channel id
     thread_ref  TEXT,                       -- groups replies; NULL when standalone
     -- ISO-8601 UTC. Slack returns an epoch float and must be converted at
@@ -72,20 +62,6 @@ CREATE TABLE IF NOT EXISTS items (
     -- this column existed have none, and a collector that cannot supply one
     -- is not a reason to refuse the message.
     sender_key  TEXT,                       -- address or user id, never a name
-    -- What the person is called *by the source*, as opposed to who they are
-    -- (`sender_key`) or what they are displayed as (`sender`).
-    --
-    -- A Slack `@handle`, a GitHub login, a mail local part. Three distinct
-    -- things, and conflating any two of them loses something: the handle is
-    -- unique within its source but the person can change it, so it cannot be
-    -- an identity; the display name is neither unique nor stable; the stable
-    -- id is neither readable nor something anyone would recognise.
-    --
-    -- Kept because it is the strongest evidence a source gives for the same
-    -- person appearing in another one, and because it is what a user
-    -- recognises when asked whether two identities are the same colleague.
-    -- NULL when the source has no such concept — mail does not.
-    sender_handle TEXT,
     subject     TEXT,                       -- NULL for slack
     body        TEXT,
     -- Set when the retention pass clears `body`, and never otherwise. It is
@@ -122,52 +98,6 @@ CREATE TABLE IF NOT EXISTS items (
                 DEFAULT 'pending',
     state_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 );
-
--- ---------------------------------------------------------------------------
--- 1b) identity_links — the user's answer to "are these the same person?"
---
---    An identity is a (source, key) pair, and one person holds as many as
---    they have places to write from. Nothing in the data says which belong
---    together: a shared display name is not evidence, and guessing from one
---    is precisely the mistake `sender_key` exists to prevent. Only the user
---    can say, so only the user's answer is recorded here.
---
---    Pairs, not groups, because pairs compose. Confirming A~B and B~C makes
---    A~C true without asking a third time, and a fourth identity is one more
---    pair rather than a new shape. The grouping is a disjoint-set union over
---    the confirmed rows; see `identity.py`.
---
---    Rejections are kept for the same reason as confirmations. A candidate
---    the user has already dismissed must not be proposed again on the next
---    run — an unresolved question re-asked nightly is how a job that should
---    be idle wakes the agent forever.
---
---    Each pair is stored once, with the lexicographically smaller identity
---    on the left, so (A,B) and (B,A) cannot both exist and disagree.
--- ---------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS identity_links (
-    left_source   TEXT NOT NULL REFERENCES sources(name),
-    left_key      TEXT NOT NULL,
-    right_source  TEXT NOT NULL REFERENCES sources(name),
-    right_key     TEXT NOT NULL,
-    status        TEXT NOT NULL CHECK (status IN ('confirmed','rejected')),
-    decided_at    TEXT NOT NULL
-                  DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
-    -- How the answer was obtained. Only the user decides, but the route
-    -- matters when reading back a decision months later.
-    decided_via   TEXT NOT NULL DEFAULT 'user',
-    PRIMARY KEY (left_source, left_key, right_source, right_key),
-    -- The ordering invariant, enforced rather than remembered.
-    CHECK ((left_source, left_key) < (right_source, right_key))
-);
-
--- Resolving a person means walking every confirmed link touching an
--- identity, from either side.
-CREATE INDEX IF NOT EXISTS idx_links_left
-    ON identity_links(left_source, left_key) WHERE status = 'confirmed';
-CREATE INDEX IF NOT EXISTS idx_links_right
-    ON identity_links(right_source, right_key) WHERE status = 'confirmed';
-
 
 -- Intake selector reads this: oldest pending first.
 CREATE INDEX IF NOT EXISTS idx_items_pending ON items(state, event_at);

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/select_memory.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/select_memory.py
@@ -501,7 +501,15 @@ def evidence(conn, since: str) -> dict[str, object]:
             # to write one. Treat it as unknown, which means look.
             if recorded > today:
                 recorded = ""
-            if recorded and last and last <= recorded:
+            # A page still to be merged is work whether or not anything has
+            # been said since. The freshness rule asks "has a message arrived
+            # that this page does not account for", and a merge answers no —
+            # both pages are current, which is exactly the case where the
+            # split can sit there forever. Nothing else reports it, and no
+            # new message is required to arrive for it to still be true, so
+            # skipping here leaves the person split indefinitely and lets the
+            # wake gate sleep on it.
+            if recorded and last and last <= recorded and not extra.get(key):
                 continue
         candidates.append({
             "sender": sender,

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/select_memory.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/select_memory.py
@@ -199,8 +199,9 @@ def slug(name: str) -> str:
 
 def page_names(display: dict[object, str],
                have: dict[str, dict[str, object]],
-               members: dict[object, list[object]]) -> dict[object, str]:
-    """Person -> the page slug that person owns.
+               members: dict[object, list[object]],
+               ) -> tuple[dict[object, str], dict[object, list[str]]]:
+    """Person -> the page slug they own, and any other pages that are theirs.
 
     Two people called `Sam Ruiz` need two pages, and each needs to keep its
     own name across runs. Neither follows from the display name, so the
@@ -231,12 +232,31 @@ def page_names(display: dict[object, str],
         for text in page.get("identities") or []:
             claimed.setdefault(text, mark)
 
+    # Every page this person's identities land on, not the first one found.
+    #
+    # Before the user answers, each identity has a page of its own — that is
+    # the state the whole feature exists to resolve. Confirming the link then
+    # makes them one person with two pages, and returning one slug quietly
+    # strands the other: its history and its index entry stay on disk,
+    # belonging to nobody, while the handoff claims a single page holds
+    # everything. So all of them are returned and the extras are named for
+    # merging.
     names: dict[object, str] = {}
+    extra: dict[object, list[str]] = {}
     for person in display:
+        found = []
         for who in members.get(person, [person]):
-            if str(who) in claimed:
-                names[person] = claimed[str(who)]
-                break
+            mark = claimed.get(str(who))
+            if mark and mark not in found:
+                found.append(mark)
+        if not found:
+            continue
+        # Sorted, so which page is kept does not depend on the order the
+        # identities came back in. A keep-choice that changes between runs
+        # would move content back and forth and lose some of it each way.
+        found.sort()
+        names[person] = found[0]
+        extra[person] = found[1:]
 
     contenders: dict[str, list[object]] = {}
     for person in display:
@@ -254,7 +274,7 @@ def page_names(display: dict[object, str],
                 base not in have or not (have[base].get("identities") or []))
             names[person] = base if solo else (
                 f"{base}_{hashlib.sha256(str(person).encode()).hexdigest()[:8]}")
-    return names
+    return names, extra
 
 
 def existing_people() -> dict[str, dict[str, str]]:
@@ -443,7 +463,7 @@ def evidence(conn, since: str) -> dict[str, object]:
     have = existing_people()
     today = datetime.now(timezone.utc).date().isoformat()
 
-    names = page_names(display, have, members)
+    names, extra = page_names(display, have, members)
 
     # Namesakes still worth reporting: two people the agent cannot tell apart
     # by name get one page each, and it should say so on both rather than
@@ -485,6 +505,13 @@ def evidence(conn, since: str) -> dict[str, object]:
                 continue
         candidates.append({
             "sender": sender,
+            # Pages that belong to this person and are not the one above.
+            # Present only after a link is confirmed over identities that had
+            # each already been written up. Their content has to be folded
+            # into `slug` and the page then removed, index entry included —
+            # nothing else will do it, and left alone they are history
+            # attributed to nobody.
+            "merge_into_slug": extra.get(key) or [],
             # Every identity this person writes from, not one of them. The
             # page records the whole list, so it is still found when the
             # message that arrives next comes from a different source.

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/select_memory.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/select_memory.py
@@ -38,6 +38,7 @@ from collections import Counter
 from pathlib import Path
 from datetime import datetime, timedelta, timezone
 
+import identity
 from _db import ensure_store, write_txn
 
 # How many exchanges before somebody is worth a page.
@@ -196,50 +197,63 @@ def slug(name: str) -> str:
     return f"{cleaned}_{mark}" if cleaned else f"person_{mark}"
 
 
-def page_names(display: dict[str, str],
-               have: dict[str, dict[str, str]]) -> dict[str, str]:
-    """Stable identity -> the page slug that identity owns.
+def page_names(display: dict[object, str],
+               have: dict[str, dict[str, object]],
+               members: dict[object, list[object]]) -> dict[object, str]:
+    """Person -> the page slug that person owns.
 
     Two people called `Sam Ruiz` need two pages, and each needs to keep its
     own name across runs. Neither follows from the display name, so the
-    allocation is driven by the stable key and by what the pages on disk
-    already claim:
+    allocation is driven by identity and by what the pages on disk claim:
 
-    - A page that records this key keeps it. This is the case that makes the
-      name durable: once written, a person's page is found by who they are,
-      so a namesake appearing later cannot rename or overwrite them.
-    - Otherwise the readable slug is used when exactly one identity wants it
-      and no other identity already holds it.
-    - Otherwise every contender takes a digest of its own key. Nobody wins the
-      readable name by being processed first, because a winner picked that way
-      changes between runs, and a page name that changes is a page lost.
+    - A page that records **any** of this person's identities keeps its name.
+      That is what makes the name durable, and why it is a list: a colleague
+      whose Slack account is later confirmed to be the same person as their
+      mailbox must not be moved to a new page because the identity the page
+      happens to be found by was not the one that wrote this week.
+    - Otherwise the readable slug is used when exactly one person wants it
+      and no other person already holds it.
+    - Otherwise every contender takes a digest of its own identity. Nobody
+      wins the readable name by being processed first, because a winner
+      picked that way changes between runs, and a page name that changes is
+      a page lost.
 
-    A page with no `source_key` was written before the field existed. It is
-    treated as belonging to the sole contender for its name — the migration
-    case, and the alternative is abandoning a real page and starting a blank
-    one beside it. With two contenders it cannot be attributed to either, so
-    both take digests and the old page is left where it is.
+    A page claiming no identity at all was written before the field existed.
+    It is treated as belonging to the sole contender for its name — the
+    migration case, and the alternative is abandoning a real page and
+    starting a blank one beside it. With two contenders it cannot be
+    attributed to either, so both take digests and the old page is left where
+    it is.
     """
-    owned = {page["source_key"]: mark for mark, page in have.items()
-             if page.get("source_key")}
+    # Identity text -> the page that claims it. A page may claim several.
+    claimed: dict[str, str] = {}
+    for mark, page in have.items():
+        for text in page.get("identities") or []:
+            claimed.setdefault(text, mark)
 
-    contenders: dict[str, list[str]] = {}
-    for key in display:
-        if key in owned:
+    names: dict[object, str] = {}
+    for person in display:
+        for who in members.get(person, [person]):
+            if str(who) in claimed:
+                names[person] = claimed[str(who)]
+                break
+
+    contenders: dict[str, list[object]] = {}
+    for person in display:
+        if person in names:
             continue
-        contenders.setdefault(slug(display[key]), []).append(key)
+        contenders.setdefault(slug(display[person]), []).append(person)
 
-    names = {key: mark for key, mark in owned.items() if key in display}
-    for base, keys in contenders.items():
+    for base, people in contenders.items():
         if not base:
             base = "person"
         # Sorted so the digest set is the same whatever order the store
         # returned the senders in.
-        for key in sorted(keys):
-            solo = len(keys) == 1 and (
-                base not in have or not have[base].get("source_key"))
-            names[key] = base if solo else (
-                f"{base}_{hashlib.sha256(key.encode()).hexdigest()[:8]}")
+        for person in sorted(people, key=str):
+            solo = len(people) == 1 and (
+                base not in have or not (have[base].get("identities") or []))
+            names[person] = base if solo else (
+                f"{base}_{hashlib.sha256(str(person).encode()).hexdigest()[:8]}")
     return names
 
 
@@ -271,12 +285,30 @@ def existing_people() -> dict[str, dict[str, str]]:
             continue
         seen = re.search(r"^last_interaction:\s*(\d{4}-\d{2}-\d{2})",
                          head, re.M)
-        key = re.search(r"^source_key:\s*(\S+)", head, re.M)
         found[page.stem] = {
             "last_interaction": seen.group(1) if seen else "",
-            "source_key": key.group(1) if key else "",
+            "identities": _page_identities(head),
         }
     return found
+
+
+def _page_identities(head: str) -> list[str]:
+    """Every identity a page claims, from either spelling of the field.
+
+    `identities:` is a YAML list — a person holds as many as they have places
+    to write from, and privileging one of them as `source_key` made "which is
+    the primary" a question with no answer as soon as a third arrived. Pages
+    written before the list existed carry the single `source_key:`, which is
+    read as a list of one rather than migrated: the page is the user's, and
+    rewriting their frontmatter to suit a schema change is not this job's.
+    """
+    listed = re.search(r"^identities:\s*\n((?:\s*-\s*\S+\s*\n)+)",
+                       head, re.M)
+    if listed:
+        return [line.strip().lstrip("-").strip()
+                for line in listed.group(1).splitlines() if line.strip()]
+    single = re.search(r"^source_key:\s*(\S+)", head, re.M)
+    return [single.group(1)] if single else []
 
 
 def stale_attention() -> list[dict[str, str]]:
@@ -351,11 +383,17 @@ def evidence(conn, since: str) -> dict[str, object]:
     # name, from the old rows, and once by their address, from the new ones —
     # and got two pages that each held half their history. A display name is
     # not an identity in the fallback either.
+    #
+    # Grouped by `(source, sender_key)`, not by the key alone. Two sources can
+    # mint the same string, and merging two people because their opaque ids
+    # happened to match would be silent and unrecoverable.
     counted = conn.execute(
-        "SELECT sender_key, sender, COUNT(*), MAX(event_at)"
+        "SELECT source, sender_key, sender, sender_handle,"
+        "       COUNT(*), MAX(event_at)"
         "  FROM items"
         "  WHERE event_at >= ? AND sender IS NOT NULL AND sender_key IS NOT NULL"
-        "  GROUP BY sender_key, sender", (since,)).fetchall()
+        "  GROUP BY source, sender_key, sender, sender_handle",
+        (since,)).fetchall()
 
     # Said out loud rather than silently skipped. These are rows from before
     # the upgrade; they stop appearing as the collectors re-read their window
@@ -366,36 +404,64 @@ def evidence(conn, since: str) -> dict[str, object]:
         "  WHERE event_at >= ? AND sender IS NOT NULL AND sender_key IS NULL",
         (since,)).fetchone()[0]
 
-    counts: Counter[str] = Counter()
-    latest: dict[str, str] = {}
-    display: dict[str, str] = {}
-    for key, sender, count, last in counted:
+    # Per identity first: how much they wrote, when last, and what they are
+    # called and known as there.
+    seen: Counter[identity.Identity] = Counter()
+    last_at: dict[identity.Identity, str] = {}
+    shown: dict[identity.Identity, str] = {}
+    handles: dict[identity.Identity, str | None] = {}
+    for source, key, sender, handle, count, last in counted:
         if AUTOMATED.search(sender or ""):
             continue
-        if not key:
+        if not key or not source:
             continue
-        counts[key] += count
-        if last and last > latest.get(key, ""):
-            latest[key] = last
+        who = identity.Identity(source, key)
+        seen[who] += count
+        handles.setdefault(who, handle)
+        if last and last > last_at.get(who, ""):
+            last_at[who] = last
             # The name they go by now, not the one they used first.
-            display[key] = sender
-        display.setdefault(key, sender)
+            shown[who] = sender
+        shown.setdefault(who, sender)
+
+    # Then per person: identities the user has confirmed belong together are
+    # one correspondent with one page, however many of them there are.
+    persons = identity.resolve(conn, seen)
+    counts: Counter[identity.Identity] = Counter()
+    latest: dict[identity.Identity, str] = {}
+    display: dict[identity.Identity, str] = {}
+    members: dict[identity.Identity, list[identity.Identity]] = {}
+    for who, count in seen.items():
+        person = persons.of(who)
+        counts[person] += count
+        members.setdefault(person, persons.group(who))
+        if last_at.get(who, "") > latest.get(person, ""):
+            latest[person] = last_at[who]
+            display[person] = shown[who]
+        display.setdefault(person, shown[who])
 
     have = existing_people()
     today = datetime.now(timezone.utc).date().isoformat()
 
-    names = page_names(display, have)
+    names = page_names(display, have, members)
 
-    # Namesakes still worth reporting: they now get one page each, but the
-    # agent is writing about two people whose names it cannot tell apart, and
-    # it should say so on the page rather than leave a reader to guess.
-    by_name: dict[str, set[str]] = {}
-    for key, sender in display.items():
-        by_name.setdefault(sender, set()).add(key)
-    shared = {sender: sorted(names[key] for key in keys)
-              for sender, keys in by_name.items() if len(keys) > 1}
+    # Namesakes still worth reporting: two people the agent cannot tell apart
+    # by name get one page each, and it should say so on both rather than
+    # leave a reader to guess which colleague a page is about.
+    by_name: dict[str, set[identity.Identity]] = {}
+    for person, sender in display.items():
+        by_name.setdefault(sender, set()).add(person)
+    shared = {sender: sorted(names[p] for p in people)
+              for sender, people in by_name.items() if len(people) > 1}
+
+    # Identities that may be one person, for the user to answer later. The
+    # job does not wait for the answer and does not act without one.
+    proposals = identity.candidates(
+        [(who, shown.get(who, ""), handles.get(who)) for who in seen],
+        identity.decisions(conn), persons)
 
     candidates = []
+    group_of: dict[str, list[identity.Identity]] = {}
     for key, count in counts.most_common():
         if count < PEOPLE_THRESHOLD:
             continue
@@ -419,7 +485,10 @@ def evidence(conn, since: str) -> dict[str, object]:
                 continue
         candidates.append({
             "sender": sender,
-            "source_key": key,
+            # Every identity this person writes from, not one of them. The
+            # page records the whole list, so it is still found when the
+            # message that arrives next comes from a different source.
+            "identities": [str(i) for i in members[key]],
             "slug": mark,
             "messages": count,
             "last_interaction": last,
@@ -427,31 +496,40 @@ def evidence(conn, since: str) -> dict[str, object]:
             "page_records": (have[mark]["last_interaction"] or None)
                             if mark in have else None,
         })
+        group_of[mark] = members[key]
 
     # A person with no page at all is more valuable than one whose page is
     # merely a few bullets behind, so they go first within the bound.
     candidates.sort(key=lambda c: (c["has_page"], -c["messages"]))
     chosen = candidates[:MAX_PEOPLE]
-    wanted = {c["source_key"] for c in chosen}
+    wanted = [(c["slug"], group_of[c["slug"]]) for c in chosen]
 
     # Keyed by page slug, not by display name: two namesakes would otherwise
     # write into one entry and the second would replace the first's history.
     interactions: dict[str, list[dict[str, str]]] = {}
-    for key in wanted:
-        rows = conn.execute(
-            "SELECT source, event_at, addressing,"
-            "       substr(COALESCE(subject, body), 1, 200)"
-            "  FROM items WHERE sender_key = ?"
-            "    AND event_at >= ?"
-            "  ORDER BY event_at DESC LIMIT ?",
-            (key, since, MAX_INTERACTIONS)).fetchall()
-        interactions[names[key]] = [
+    for mark, group in wanted:
+        # One query per identity rather than a join or an IN list built from
+        # two columns: the store keeps its tables as independent silos and
+        # the number of identities a person has is small.
+        rows: list[tuple] = []
+        for who in group:
+            rows += conn.execute(
+                "SELECT source, event_at, addressing,"
+                "       substr(COALESCE(subject, body), 1, 200)"
+                "  FROM items WHERE source = ? AND sender_key = ?"
+                "    AND event_at >= ?"
+                "  ORDER BY event_at DESC LIMIT ?",
+                (who.source, who.key, since, MAX_INTERACTIONS)).fetchall()
+        rows.sort(key=lambda r: r[1] or "", reverse=True)
+        interactions[mark] = [
             {"when": (event_at or "")[:10], "source": source,
              "addressing": addressing, "text": " ".join((text or "").split())}
-            for source, event_at, addressing, text in rows]
+            for source, event_at, addressing, text in rows[:MAX_INTERACTIONS]]
 
     return {"people": chosen, "interactions": interactions,
             "shared_display_name": shared,
+            "identity_candidates": proposals,
+            "identity_conflicts": identity.contradictions(conn),
             "messages_without_identity": unkeyed}
 
 
@@ -616,6 +694,12 @@ def main() -> int:
         # Namesakes get one page each, but the agent cannot tell them apart
         # by name and should say which page is about whom.
         "shared_display_name": found["shared_display_name"],
+        # Identities that may be one person. Proposed, never acted on: the
+        # user answers these after the run, and the run does not wait.
+        "identity_candidates": found["identity_candidates"],
+        # Answers that no longer agree with each other. Reported rather than
+        # resolved, because neither side is knowably the wrong one.
+        "identity_conflicts": found["identity_conflicts"],
         # Collected before the store kept identities. Not attributed to
         # anybody, because the only thing left to attribute them by is the
         # display name that cannot identify anybody.

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_identity.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_identity.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""One person, however many places they write from.
+
+The tests that matter here are the ones that would still matter with a fourth
+and fifth connector, because that is what this module exists to survive.
+"""
+
+from __future__ import annotations
+
+import io
+import contextlib
+import os
+import shutil
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(HERE))
+
+import _db  # noqa: E402
+import identity  # noqa: E402
+import link_identity  # noqa: E402
+
+
+SLACK = identity.Identity("slack", "U01DANA")
+MAIL = identity.Identity("email", "dana@example.com")
+# A key with colons in it, because Teams ids have them and an identity that
+# round-trips through text must survive that.
+TEAMS = identity.Identity("teams", "29:1a2b:3c")
+GITHUB = identity.Identity("github", "dokoro")
+
+
+class StoreCase(unittest.TestCase):
+    def setUp(self):
+        self.home = Path(tempfile.mkdtemp())
+        os.environ["HERMES_HOME"] = str(self.home)
+        # Through `ensure_store`, not by writing the schema to a path spelled
+        # out here. The store's location is the store's business, and a test
+        # that guesses it tests a database nothing else opens.
+        self.db = _db.ensure_store()
+        with sqlite3.connect(self.db) as conn:
+            conn.execute("INSERT OR IGNORE INTO sources(name)"
+                         " VALUES ('teams'),('github')")
+
+    def tearDown(self):
+        shutil.rmtree(self.home, ignore_errors=True)
+
+    def conn(self):
+        conn = sqlite3.connect(self.db)
+        conn.execute("PRAGMA foreign_keys = ON")
+        return conn
+
+    def link(self, a, b, status="confirmed"):
+        with contextlib.closing(self.conn()) as conn:
+            identity.record(conn, a, b, status)
+            conn.commit()
+
+    def item(self, who, sender="Dana Okoro", handle=None, at="2026-08-20"):
+        with contextlib.closing(self.conn()) as conn:
+            conn.execute(
+                "INSERT INTO items(source_id, source, scope, event_at, sender,"
+                " sender_key, sender_handle, body, addressing, state) VALUES"
+                " (?,?,?,?,?,?,?,?, 'direct','pending')",
+                (f"{who}:{at}", who.source, "c", at + "T00:00:00Z", sender,
+                 who.key, handle, "b"))
+            conn.commit()
+
+
+class TestAnIdentityIsASourceAndAKey(unittest.TestCase):
+    def test_a_key_containing_colons_round_trips(self):
+        """Teams ids look like `29:1a2b`. Splitting on the last colon, or on
+        every colon, truncates every such account to something matching
+        nobody — and does it silently."""
+        self.assertEqual(identity.parse(str(TEAMS)), TEAMS)
+        self.assertEqual(identity.parse("teams:29:1a2b:3c").key, "29:1a2b:3c")
+
+    def test_text_without_a_source_is_refused(self):
+        for bad in ("U01DANA", ":key", "Slack:U1", "sla ck:U1", "slack:"):
+            with self.subTest(text=bad):
+                with self.assertRaises(ValueError):
+                    identity.parse(bad)
+
+    def test_the_same_key_from_two_sources_is_two_people(self):
+        """Nothing stops two systems minting the same string. Treating a bare
+        key as an identity would merge their owners, silently."""
+        self.assertNotEqual(identity.Identity("slack", "dana"),
+                            identity.Identity("github", "dana"))
+
+
+class TestAnswersCompose(StoreCase):
+    """The property that makes this generalize past two connectors."""
+
+    def test_confirming_two_pairs_joins_three_identities(self):
+        self.link(SLACK, MAIL)
+        self.link(MAIL, TEAMS)
+        with contextlib.closing(self.conn()) as conn:
+            persons = identity.resolve(conn, [SLACK, MAIL, TEAMS])
+        self.assertEqual(persons.group(SLACK), sorted([SLACK, MAIL, TEAMS]))
+        self.assertEqual(persons.of(SLACK), persons.of(TEAMS),
+                         "A~B and B~C did not make A~C")
+
+    def test_a_fourth_identity_is_one_more_pair(self):
+        """Not a new shape, and not a re-answer of what was already settled."""
+        self.link(SLACK, MAIL)
+        self.link(MAIL, TEAMS)
+        self.link(TEAMS, GITHUB)
+        with contextlib.closing(self.conn()) as conn:
+            persons = identity.resolve(conn, [SLACK, MAIL, TEAMS, GITHUB])
+        self.assertEqual(len(persons.group(GITHUB)), 4)
+
+    def test_the_representative_does_not_depend_on_link_order(self):
+        """It decides the page name. One that changes between runs is a page
+        lost, and link order is not stable — it is whatever the table
+        returns."""
+        forward = identity.Persons([(SLACK, MAIL), (MAIL, TEAMS)])
+        backward = identity.Persons([(TEAMS, MAIL), (MAIL, SLACK)])
+        self.assertEqual(forward.of(SLACK), backward.of(SLACK))
+        self.assertEqual(forward.of(TEAMS), backward.of(TEAMS))
+
+    def test_an_unlinked_identity_is_a_person_on_their_own(self):
+        with contextlib.closing(self.conn()) as conn:
+            persons = identity.resolve(conn, [GITHUB])
+        self.assertEqual(persons.group(GITHUB), [GITHUB])
+
+    def test_a_rejected_pair_stays_two_people(self):
+        """The direction that matters most. A rejection read as an answer of
+        any kind — or a store that groups on every row rather than on the
+        confirmed ones — merges two people the user said were different, and
+        the merge is the unrecoverable direction."""
+        self.link(SLACK, MAIL, "rejected")
+        with contextlib.closing(self.conn()) as conn:
+            persons = identity.resolve(conn, [SLACK, MAIL])
+        self.assertNotEqual(persons.of(SLACK), persons.of(MAIL))
+        self.assertEqual(persons.group(SLACK), [SLACK])
+
+    def test_a_pair_is_stored_once_whichever_way_round_it_is_given(self):
+        """Two rows for one question could disagree with each other."""
+        self.link(MAIL, SLACK)
+        self.link(SLACK, MAIL, "rejected")
+        with contextlib.closing(self.conn()) as conn:
+            rows = conn.execute("SELECT status FROM identity_links").fetchall()
+        self.assertEqual(rows, [("rejected",)])
+
+
+class TestOnlyTheUserJoinsIdentities(StoreCase):
+    def test_a_shared_handle_is_proposed_and_not_applied(self):
+        self.item(SLACK, handle="dana.okoro")
+        self.item(MAIL, handle="dana.okoro")
+        with contextlib.closing(self.conn()) as conn:
+            persons = identity.resolve(conn, [SLACK, MAIL])
+            found = identity.candidates(
+                [(SLACK, "Dana Okoro", "dana.okoro"),
+                 (MAIL, "Dana Okoro", "dana.okoro")],
+                identity.decisions(conn), persons)
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0]["reason"], "shared handle")
+        self.assertNotEqual(persons.of(SLACK), persons.of(MAIL),
+                            "a matching handle joined two identities on its own")
+
+    def test_one_question_per_group_not_one_per_signal(self):
+        """Name and handle both matching is one question, not two."""
+        with contextlib.closing(self.conn()) as conn:
+            found = identity.candidates(
+                [(SLACK, "Dana Okoro", "dana"), (MAIL, "Dana Okoro", "dana")],
+                {}, identity.Persons())
+        self.assertEqual([f["identities"] for f in found],
+                         [[str(MAIL), str(SLACK)]])
+
+    def test_two_identities_in_one_source_are_not_proposed(self):
+        """A source will not let two accounts share a handle, so a match
+        within one is not a coincidence worth asking about."""
+        other = identity.Identity("slack", "U02SAM")
+        with contextlib.closing(self.conn()) as conn:
+            found = identity.candidates(
+                [(SLACK, "Dana Okoro", "dana"), (other, "Dana Okoro", "dana")],
+                {}, identity.Persons())
+        self.assertEqual(found, [])
+
+    def test_an_answered_group_is_not_proposed_again(self):
+        """A candidate re-asked nightly is how an idle job wakes the agent
+        forever. Rejection has to be as durable as confirmation."""
+        self.link(SLACK, MAIL, "rejected")
+        with contextlib.closing(self.conn()) as conn:
+            found = identity.candidates(
+                [(SLACK, "Dana Okoro", "dana"), (MAIL, "Dana Okoro", "dana")],
+                identity.decisions(conn), identity.resolve(conn, [SLACK, MAIL]))
+        self.assertEqual(found, [])
+
+    def test_a_group_already_joined_is_not_proposed(self):
+        self.link(SLACK, MAIL)
+        with contextlib.closing(self.conn()) as conn:
+            found = identity.candidates(
+                [(SLACK, "Dana Okoro", "dana"), (MAIL, "Dana Okoro", "dana")],
+                identity.decisions(conn), identity.resolve(conn, [SLACK, MAIL]))
+        self.assertEqual(found, [])
+
+    def test_a_partly_answered_group_is_still_proposed(self):
+        """Three identities, one pair answered: the other two are still open,
+        and dropping the group would lose them."""
+        with contextlib.closing(self.conn()) as conn:
+            identity.record(conn, SLACK, MAIL, "rejected")
+            conn.commit()
+            found = identity.candidates(
+                [(SLACK, "Dana Okoro", "dana"), (MAIL, "Dana Okoro", "dana"),
+                 (TEAMS, "Dana Okoro", "dana")],
+                identity.decisions(conn), identity.resolve(conn))
+        self.assertEqual(len(found), 1)
+        self.assertEqual(len(found[0]["identities"]), 3)
+
+
+class TestAnswersThatNoLongerAgree(StoreCase):
+    def test_transitivity_overruling_a_rejection_is_reported(self):
+        self.link(SLACK, MAIL, "rejected")
+        self.link(SLACK, TEAMS)
+        self.link(TEAMS, MAIL)
+        with contextlib.closing(self.conn()) as conn:
+            conflicts = identity.contradictions(conn)
+        self.assertEqual(len(conflicts), 1)
+        self.assertIn(str(SLACK), conflicts[0]["rejected"])
+
+    def test_the_confirmations_are_kept_rather_than_dropped(self):
+        """Dropping them to honour the rejection would split a person whose
+        other links the user did confirm — a second wrong answer, silently."""
+        self.link(SLACK, MAIL, "rejected")
+        self.link(SLACK, TEAMS)
+        self.link(TEAMS, MAIL)
+        with contextlib.closing(self.conn()) as conn:
+            persons = identity.resolve(conn, [SLACK, MAIL, TEAMS])
+        self.assertEqual(len(persons.group(SLACK)), 3)
+
+    def test_a_plain_rejection_is_not_a_conflict(self):
+        self.link(SLACK, MAIL, "rejected")
+        with contextlib.closing(self.conn()) as conn:
+            self.assertEqual(identity.contradictions(conn), [])
+
+
+class TestTheUserFacingCommand(StoreCase):
+    def run_cli(self, *argv):
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            code = link_identity.main(list(argv))
+        return code, buffer.getvalue()
+
+    def test_answering_about_three_records_every_pair(self):
+        self.item(SLACK)
+        self.item(MAIL)
+        self.item(TEAMS)
+        code, out = self.run_cli("same", str(SLACK), str(MAIL), str(TEAMS))
+        self.assertEqual(code, 0)
+        self.assertIn('"pairs": 3', out)
+        with contextlib.closing(self.conn()) as conn:
+            persons = identity.resolve(conn, [SLACK, MAIL, TEAMS])
+        self.assertEqual(len(persons.group(SLACK)), 3)
+
+    def test_a_mistyped_source_is_refused_with_the_ones_that_exist(self):
+        """The foreign key already refuses it and says `FOREIGN KEY
+        constraint failed`, which tells the user nothing to act on."""
+        code, _ = self.run_cli("same", "slak:U01DANA", str(MAIL))
+        self.assertEqual(code, 2)
+        with contextlib.closing(self.conn()) as conn:
+            self.assertEqual(identity.decisions(conn), {})
+
+    def test_an_identity_with_no_messages_yet_is_named_not_refused(self):
+        self.item(SLACK)
+        code, out = self.run_cli("same", str(SLACK), str(GITHUB))
+        self.assertEqual(code, 0)
+        self.assertIn(str(GITHUB), out)
+
+    def test_naming_one_identity_is_refused(self):
+        code, _ = self.run_cli("same", str(SLACK))
+        self.assertEqual(code, 2)
+
+    def test_an_answer_can_be_changed(self):
+        """A stored answer that cannot be corrected is worse than none: the
+        candidate never comes back to be asked again."""
+        self.item(SLACK)
+        self.item(MAIL)
+        self.run_cli("same", str(SLACK), str(MAIL))
+        self.run_cli("different", str(SLACK), str(MAIL))
+        with contextlib.closing(self.conn()) as conn:
+            persons = identity.resolve(conn, [SLACK, MAIL])
+        self.assertNotEqual(persons.of(SLACK), persons.of(MAIL))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_identity.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_identity.py
@@ -271,6 +271,44 @@ class TestTheUserFacingCommand(StoreCase):
         self.assertEqual(code, 0)
         self.assertIn(str(GITHUB), out)
 
+    def test_a_group_cannot_be_answered_as_different(self):
+        """The negative does not distribute.
+
+        "These three are not one person" rules out the group and says nothing
+        about which member is the odd one out — A and B may be the same
+        colleague with C a stranger. Recording all three pairs as rejected
+        buries the A~B link and stops it ever being proposed again, on the
+        strength of an answer nobody gave.
+        """
+        self.item(SLACK)
+        self.item(MAIL)
+        self.item(TEAMS)
+        code, _ = self.run_cli("different", str(SLACK), str(MAIL), str(TEAMS))
+        self.assertEqual(code, 2)
+        with contextlib.closing(self.conn()) as conn:
+            self.assertEqual(identity.decisions(conn), {},
+                             "a group rejection was recorded pairwise")
+
+    def test_the_pair_the_user_did_deny_is_still_recorded(self):
+        """Refusing the group must not refuse the answer they can give."""
+        self.item(SLACK)
+        self.item(MAIL)
+        code, _ = self.run_cli("different", str(SLACK), str(MAIL))
+        self.assertEqual(code, 0)
+        with contextlib.closing(self.conn()) as conn:
+            persons = identity.resolve(conn, [SLACK, MAIL])
+        self.assertNotEqual(persons.of(SLACK), persons.of(MAIL))
+
+    def test_a_group_can_still_be_answered_as_the_same_person(self):
+        """`same` distributes where `different` does not: one person is a
+        claim about every pair, and each of them follows."""
+        for who in (SLACK, MAIL, TEAMS):
+            self.item(who)
+        code, _ = self.run_cli("same", str(SLACK), str(MAIL), str(TEAMS))
+        self.assertEqual(code, 0)
+        with contextlib.closing(self.conn()) as conn:
+            self.assertEqual(len(identity.decisions(conn)), 3)
+
     def test_naming_one_identity_is_refused(self):
         code, _ = self.run_cli("same", str(SLACK))
         self.assertEqual(code, 2)

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_memory_check.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_memory_check.py
@@ -195,6 +195,27 @@ class TestPersonIdentityIsChecked(unittest.TestCase):
                              "slack:U01DANA")
         self.assertEqual(check_identity(self.root), [])
 
+    def test_the_clash_does_not_say_which_page_to_delete(self):
+        """The two situations that wear this clash want opposite repairs, and
+        nothing on disk tells them apart.
+
+        A merge that copied the content across and left the emptied page
+        behind produces a page whose identities are all on another one. So
+        does a page that wrongly claims somebody else's address — and there
+        the "extra" page is the correct one. A subset test calls both a
+        leftover and sends the repair job to delete a real page. The evidence
+        that separates them is the confirmed link, which lives in the store
+        and not here, so this reports and refuses to choose.
+        """
+        self._set_identities(self.person, "email:sam.ruiz@example.com",
+                             "slack:U01SAM", "email:dana.okoro@example.com")
+        findings = check_identity(self.root)
+        self.assertEqual([f.kind for f in findings], ["duplicate-identity"])
+        detail = findings[0].detail
+        self.assertIn("somebody else", detail)
+        self.assertIn("left the emptied page behind", detail)
+        self.assertNotIn("delete", detail)
+
     def test_the_duplicate_report_does_not_depend_on_directory_order(self):
         """`glob` order is filesystem order. A finding that appears only on
         some machines is worse than no finding."""

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_memory_check.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_memory_check.py
@@ -122,12 +122,12 @@ class TestInvariants(unittest.TestCase):
 
 
 class TestPersonIdentityIsChecked(unittest.TestCase):
-    """`source_key` is what the memory job matches a person on.
+    """`identities` is what the memory job matches a person on.
 
-    Until this existed, two valid-looking people pages with no key at all —
-    and two claiming the same one — both passed `check_all()`, so the page
-    that decides who a person is was the one thing the deterministic checker
-    did not look at.
+    Until this existed, two valid-looking people pages with no identity at
+    all — and two claiming the same one — both passed `check_all()`, so the
+    field that decides who a person is was the one thing the deterministic
+    checker did not look at.
     """
 
     def setUp(self):
@@ -136,31 +136,43 @@ class TestPersonIdentityIsChecked(unittest.TestCase):
         self.person = self.root / "people" / "sam_ruiz.md"
         self.other = self.root / "people" / "dana_okoro.md"
 
-    def _drop_line(self, page, key):
-        page.write_text(re.sub(rf"^{key}:.*\n", "", page.read_text(),
-                               count=1, flags=re.M))
+    def _drop_identities(self, page):
+        page.write_text(re.sub(r"^identities:\n(?:\s*-\s*\S+\n)+", "",
+                               page.read_text(), count=1, flags=re.M))
 
-    def _set(self, page, key, value):
-        page.write_text(re.sub(rf"^{key}:.*$", f"{key}: {value}",
+    def _set_identities(self, page, *values):
+        block = "identities:\n" + "".join(f"  - {v}\n" for v in values)
+        page.write_text(re.sub(r"^identities:\n(?:\s*-\s*\S+\n)+", block,
                                page.read_text(), count=1, flags=re.M))
 
     def test_the_shipped_fixture_pages_carry_identities(self):
         self.assertEqual(check_identity(self.root), [])
 
     def test_a_page_with_no_identity_is_reported(self):
-        self._drop_line(self.person, "source_key")
+        self._drop_identities(self.person)
         findings = check_identity(self.root)
         self.assertEqual([f.kind for f in findings], ["missing-identity"])
         self.assertEqual(findings[0].path, "people/sam_ruiz.md")
 
-    def test_an_empty_identity_counts_as_missing(self):
-        """A key present but blank is the shape a half-written page has."""
-        self._set(self.person, "source_key", "")
-        self.assertEqual([f.kind for f in check_identity(self.root)],
-                         ["missing-identity"])
+    def test_a_page_from_before_the_list_still_counts_as_carrying_one(self):
+        """`source_key:` is what earlier pages have. Reporting them as
+        missing would send the repair job to rewrite pages that are fine."""
+        self._drop_identities(self.person)
+        self.person.write_text(
+            self.person.read_text().replace(
+                "name: Sam Ruiz",
+                "name: Sam Ruiz\nsource_key: email:sam.ruiz@example.com", 1))
+        self.assertEqual(check_identity(self.root), [])
+
+    def test_an_entry_with_no_source_is_reported_as_malformed(self):
+        """`dana@example.com` matches nothing — the selector looks for
+        `email:dana@example.com` — so the page is orphaned, silently."""
+        self._set_identities(self.person, "sam.ruiz@example.com")
+        findings = check_identity(self.root)
+        self.assertEqual([f.kind for f in findings], ["malformed-identity"])
 
     def test_two_pages_claiming_one_identity_are_reported(self):
-        self._set(self.person, "source_key", "dana.okoro@example.com")
+        self._set_identities(self.person, "email:dana.okoro@example.com")
         findings = check_identity(self.root)
         self.assertEqual([f.kind for f in findings], ["duplicate-identity"])
         # Both pages are named, because the finding is about the pair and
@@ -168,26 +180,31 @@ class TestPersonIdentityIsChecked(unittest.TestCase):
         self.assertIn("dana_okoro.md", findings[0].detail)
         self.assertEqual(findings[0].path, "people/sam_ruiz.md")
 
+    def test_a_duplicate_among_several_entries_is_still_caught(self):
+        """A page may claim many, and the clash can be on any of them."""
+        self._set_identities(self.person, "email:sam.ruiz@example.com",
+                             "slack:U01SAM", "email:dana.okoro@example.com")
+        self.assertIn("duplicate-identity",
+                      [f.kind for f in check_identity(self.root)])
+
+    def test_two_pages_sharing_no_identity_are_not_a_duplicate(self):
+        """Otherwise a person with several accounts would report themselves."""
+        self._set_identities(self.person, "email:sam.ruiz@example.com",
+                             "slack:U01SAM")
+        self._set_identities(self.other, "email:dana.okoro@example.com",
+                             "slack:U01DANA")
+        self.assertEqual(check_identity(self.root), [])
+
     def test_the_duplicate_report_does_not_depend_on_directory_order(self):
         """`glob` order is filesystem order. A finding that appears only on
         some machines is worse than no finding."""
-        self._set(self.other, "source_key", "sam.ruiz@example.com")
+        self._set_identities(self.other, "email:sam.ruiz@example.com")
         self.assertEqual([f.kind for f in check_identity(self.root)],
                          ["duplicate-identity"])
 
-    def test_pages_of_other_types_are_left_alone(self):
-        """Only people pages have this field; a project page is not a person
-        missing an identity."""
-        for page in self.root.rglob("*.md"):
-            if page.parent.name != "people":
-                self.assertNotIn(
-                    "missing-identity",
-                    [f.kind for f in check_identity(self.root)
-                     if f.path.endswith(page.name)])
-
     def test_check_all_runs_it(self):
         """A check that exists but is not wired in has never run."""
-        self._drop_line(self.person, "source_key")
+        self._drop_identities(self.person)
         self.assertIn("missing-identity",
                       [f.kind for f in check_all(self.root)])
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_migration.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_migration.py
@@ -180,6 +180,80 @@ class TestMigration(unittest.TestCase):
             self.assertEqual(migrate(c), [3, 4, 5])
             self.assertEqual(current_version(c), SCHEMA_VERSION)
 
+    def test_the_rebuild_keeps_the_audit_trail(self):
+        """The v5 step drops and recreates `items`.
+
+        `obligations.source_id` references it `ON DELETE CASCADE`, and with
+        foreign keys on, SQLite runs an implicit `DELETE FROM` before
+        dropping a table — which fires that cascade, and the cascade from
+        `obligations` to `events` after it. Measured before the fix: one
+        message, one obligation and one event went in; the message came out
+        alone. The audit trail is what the recipe promises outlives its
+        subject, so this is the one thing the rebuild must not cost.
+        """
+        path = Path(tempfile.mkdtemp()) / "v4.db"
+        with sqlite3.connect(path) as c:
+            c.executescript((HERE / "schema-v4.sql").read_text(encoding="utf-8"))
+            c.execute("INSERT INTO items(source_id, source, scope, event_at,"
+                      " sender, body, addressing, state) VALUES"
+                      " ('m1','email','inbox','2026-08-01T00:00:00Z','Dana',"
+                      "  'b','direct','judged')")
+            c.execute("INSERT INTO obligations(id, source_id, title, status,"
+                      " priority, global_rank)"
+                      " VALUES ('o1','m1','the cutover','open','high',1)")
+            c.execute("INSERT INTO events(obligation_id, actor, event_type)"
+                      " VALUES ('o1','user','ignored')")
+
+        with sqlite3.connect(path) as c:
+            # As `ensure_store` opens it. Without the pragma the cascade does
+            # not fire and this test cannot see the defect.
+            c.execute("PRAGMA foreign_keys = ON")
+            migrate(c)
+
+        with sqlite3.connect(path) as c:
+            self.assertEqual(
+                c.execute("SELECT id, source_id, title FROM obligations"
+                          " ORDER BY id").fetchall(),
+                [("o1", "m1", "the cutover")])
+            self.assertEqual(
+                c.execute("SELECT obligation_id, actor, event_type FROM events"
+                          " ORDER BY obligation_id").fetchall(),
+                [("o1", "user", "ignored")])
+            self.assertEqual(c.execute("PRAGMA foreign_key_check").fetchall(),
+                             [])
+
+    def test_the_rebuild_follows_the_cascade_further_than_one_table(self):
+        """`events` hangs off `obligations`, which hangs off `items`.
+
+        Saving only the tables that name `items` directly restores the
+        obligations and still loses the events — which is what a first
+        attempt at this did. The closure is what has to be carried.
+        """
+        path = Path(tempfile.mkdtemp()) / "v4.db"
+        with sqlite3.connect(path) as c:
+            c.executescript((HERE / "schema-v4.sql").read_text(encoding="utf-8"))
+            for n in range(3):
+                c.execute("INSERT INTO items(source_id, source, scope, event_at,"
+                          " sender, body, addressing, state) VALUES"
+                          " (?,'slack','c',?,?,'b','direct','judged')",
+                          (f"m{n}", f"2026-08-0{n + 1}T00:00:00Z", f"P{n}"))
+                c.execute("INSERT INTO obligations(id, source_id, title, status,"
+                          " priority, global_rank) VALUES (?,?,?,'open','high',?)",
+                          (f"o{n}", f"m{n}", f"t{n}", n + 1))
+                for actor in ("user", "agent"):
+                    c.execute("INSERT INTO events(obligation_id, actor,"
+                              " event_type) VALUES (?,?,'ignored')",
+                              (f"o{n}", actor))
+
+        with sqlite3.connect(path) as c:
+            c.execute("PRAGMA foreign_keys = ON")
+            migrate(c)
+
+        with sqlite3.connect(path) as c:
+            counts = {t: c.execute(f"SELECT count(*) FROM {t}").fetchone()[0]
+                      for t in ("items", "obligations", "events")}
+        self.assertEqual(counts, {"items": 3, "obligations": 3, "events": 6})
+
     def test_the_v2_artifact_is_never_quietly_edited(self):
         artifact = (HERE / "schema-v2.sql").read_text(encoding="utf-8")
         self.assertIn("'schema_version', '2'", artifact)

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_migration.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_migration.py
@@ -63,7 +63,7 @@ class TestMigration(unittest.TestCase):
 
         with sqlite3.connect(path) as c:
             # v1 -> v4 now, so all three steps run in order.
-            self.assertEqual(migrate(c), [2, 3, 4])
+            self.assertEqual(migrate(c), [2, 3, 4, 5])
             self.assertEqual(current_version(c), SCHEMA_VERSION)
             columns = {row[1] for row in c.execute("PRAGMA table_info(items)")}
             self.assertIn("body_cleared_at", columns)
@@ -104,7 +104,7 @@ class TestMigration(unittest.TestCase):
                              "the artifact is not really v2")
 
         with sqlite3.connect(path) as c:
-            self.assertEqual(migrate(c), [3, 4])
+            self.assertEqual(migrate(c), [3, 4, 5])
             self.assertEqual(current_version(c), SCHEMA_VERSION)
             columns = {row[1] for row in c.execute("PRAGMA table_info(items)")}
             self.assertIn("sender_key", columns)
@@ -152,7 +152,7 @@ class TestMigration(unittest.TestCase):
                              "the frozen v3 schema contains a v4 column")
 
         with sqlite3.connect(path) as c:
-            self.assertEqual(migrate(c), [4])
+            self.assertEqual(migrate(c), [4, 5])
             self.assertEqual(current_version(c), SCHEMA_VERSION)
             columns = {row[1] for row in c.execute("PRAGMA table_info(items)")}
             row = c.execute("SELECT sender, sender_key, body, deleted_at,"
@@ -160,6 +160,7 @@ class TestMigration(unittest.TestCase):
                             " WHERE source_id='m1'").fetchone()
         self.assertIn("deleted_at", columns)
         self.assertIn("internet_message_id", columns)
+        self.assertIn("sender_handle", columns)
         self.assertEqual(row[:3], ("Dana Okoro", "dana@example.com", "kept"))
         self.assertIsNone(row[3], "an existing row was marked deleted")
         self.assertIsNone(row[4], "a missing identity was invented")
@@ -176,7 +177,7 @@ class TestMigration(unittest.TestCase):
         with sqlite3.connect(path) as c:
             c.execute("UPDATE meta SET value='2' WHERE key='schema_version'")
         with sqlite3.connect(path) as c:
-            self.assertEqual(migrate(c), [3, 4])
+            self.assertEqual(migrate(c), [3, 4, 5])
             self.assertEqual(current_version(c), SCHEMA_VERSION)
 
     def test_the_v2_artifact_is_never_quietly_edited(self):

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_select_memory.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_select_memory.py
@@ -83,7 +83,7 @@ class SelectorCase(unittest.TestCase):
         return found
 
     def page(self, slug, updated=None, decay=None, kind="people",
-             last_interaction=None, source_key=None):
+             last_interaction=None, source_key=None, identities=None):
         folder = self.workspace / "memory" / kind
         folder.mkdir(parents=True, exist_ok=True)
         head = ["---"]
@@ -94,7 +94,13 @@ class SelectorCase(unittest.TestCase):
         if last_interaction:
             head.append(f"last_interaction: {last_interaction}")
         if source_key:
+            # The pre-list spelling. Kept in the helper because pages written
+            # by an earlier version still carry it, and reading them is a
+            # promise this code makes.
             head.append(f"source_key: {source_key}")
+        if identities:
+            head.append("identities:")
+            head += [f"  - {who}" for who in identities]
         head += ["---", "", "# page"]
         (folder / f"{slug}.md").write_text("\n".join(head), encoding="utf-8")
 
@@ -716,16 +722,18 @@ class TestAPersonIsWhoTheyAreNotWhatTheyAreCalled(SelectorCase):
         their display name turned up."""
         page_slug = "sam_ruiz"
         self.page(page_slug, updated="2020-01-01", last_interaction=None,
-                  source_key="sam.ruiz@example.com")
+                  source_key="email:sam.ruiz@example.com")
         for n in range(2):
             self.arrive("Sam Ruiz", "sam.ruiz@example.com", days_ago=n,
                         body=f"a{n}")
             self.arrive("Sam Ruiz", "s.ruiz@other.example", days_ago=n,
                         body=f"b{n}")
         found = self.report()
-        by_key = {p["source_key"]: p["slug"] for p in found["people"]}
-        self.assertEqual(by_key["sam.ruiz@example.com"], page_slug)
-        self.assertTrue(by_key["s.ruiz@other.example"].startswith("sam_ruiz_"))
+        by_key = {who: p["slug"] for p in found["people"]
+                  for who in p["identities"]}
+        self.assertEqual(by_key["email:sam.ruiz@example.com"], page_slug)
+        self.assertTrue(
+            by_key["email:s.ruiz@other.example"].startswith("sam_ruiz_"))
 
     def test_a_page_from_before_the_field_existed_is_not_abandoned(self):
         """Pages written by an earlier version record no identity. The sole
@@ -783,7 +791,8 @@ class TestUpgradingDoesNotSplitAPerson(SelectorCase):
                         body=f"new{n}")
         found = self.report()
         self.assertEqual(len(found["people"]), 1, found["people"])
-        self.assertEqual(found["people"][0]["source_key"], "dana@example.com")
+        self.assertEqual(found["people"][0]["identities"],
+                         ["email:dana@example.com"])
 
     def test_rows_with_no_identity_are_counted_rather_than_guessed(self):
         for n in range(2):

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_select_memory.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_select_memory.py
@@ -141,6 +141,13 @@ class SelectorCase(unittest.TestCase):
         lines = [line for line in out.splitlines() if line.strip()]
         return out, lines[-1]
 
+    def current_attention(self):
+        today = datetime.now(timezone.utc).date().isoformat()
+        self.page("current_priorities", updated=today, decay="daily",
+                  kind="attention")
+        self.page("active_threads", updated=today, decay="weekly",
+                  kind="attention")
+
     def report(self):
         """The selector's report, parsed.
 
@@ -341,13 +348,6 @@ class TestACleanInstallIsInitialised(SelectorCase):
 class TestAQuietDayCostsNothing(SelectorCase):
     """The wake gate is what makes an idle tick free, and it was never firing."""
 
-    def current_attention(self):
-        today = datetime.now(timezone.utc).date().isoformat()
-        self.page("current_priorities", updated=today, decay="daily",
-                  kind="attention")
-        self.page("active_threads", updated=today, decay="weekly",
-                  kind="attention")
-
     def test_an_unchanged_correspondent_does_not_wake_the_agent(self):
         """Two messages from last week and a page written since is not work.
         Treating it as work kept the agent awake every half hour for the
@@ -487,13 +487,6 @@ class TestOnlyTheUserSaysWhatTheyChose(SelectorCase):
 
 class TestACorrectionIsEvidenceOnce(SelectorCase):
     """It woke the writer nightly for a month over one thing done once."""
-
-    def current_attention(self):
-        today = datetime.now(timezone.utc).date().isoformat()
-        self.page("current_priorities", updated=today, decay="daily",
-                  kind="attention")
-        self.page("active_threads", updated=today, decay="weekly",
-                  kind="attention")
 
     def applied(self, event_id):
         page = self.workspace / "memory" / "attention" / "current_priorities.md"
@@ -829,6 +822,62 @@ class TestConfirmingALinkDoesNotStrandAPage(SelectorCase):
         texts = {line["text"] for line in found["interactions"][person["slug"]]}
         self.assertTrue(any(x.startswith("mail") for x in texts), texts)
         self.assertTrue(any(x.startswith("slack") for x in texts), texts)
+
+    def test_a_pending_merge_is_work_when_both_pages_are_current(self):
+        """The case the freshness rule was built to skip, and the one case it
+        must not.
+
+        That rule asks whether a message has arrived which the page does not
+        account for. A pending merge answers no — both pages are current,
+        which is exactly when the split can sit there forever, because no new
+        message is required for it to still be true. Skipped here, the person
+        stays split indefinitely and nothing ever says so.
+        """
+        self.current_attention()
+        today = datetime.now(timezone.utc).date().isoformat()
+        self.two_written_pages()
+        # Both pages record the newest interaction there is.
+        self.page("dana_by_mail", updated=today, last_interaction=today,
+                  identities=["email:dana@example.com"])
+        self.page("dana_by_slack", updated=today, last_interaction=today,
+                  identities=["slack:U01DANA"])
+        self.link("email:dana@example.com", "slack:U01DANA")
+
+        found = self.report()
+        self.assertEqual(len(found["people"]), 1,
+                         "a person with a page still to merge was skipped as"
+                         " quiet")
+        self.assertEqual(len(found["people"][0]["merge_into_slug"]), 1)
+
+    def test_the_gate_wakes_for_a_pending_merge_and_nothing_else(self):
+        """Every other input current — attention pages fresh, no corrections,
+        no message since either page was written — and the merge alone has to
+        be enough. If the gate sleeps, nothing else in the schedule reports
+        the split."""
+        self.current_attention()
+        today = datetime.now(timezone.utc).date().isoformat()
+        self.two_written_pages()
+        self.page("dana_by_mail", updated=today, last_interaction=today,
+                  identities=["email:dana@example.com"])
+        self.page("dana_by_slack", updated=today, last_interaction=today,
+                  identities=["slack:U01DANA"])
+        self.link("email:dana@example.com", "slack:U01DANA")
+
+        out, last = self.run_selector()
+        self.assertNotIn("wakeAgent", out,
+                         "the job slept on a merge nothing else will do")
+
+    def test_a_quiet_person_with_nothing_to_merge_still_costs_nothing(self):
+        """The exemption is for pending merges, not a way around the rule."""
+        self.current_attention()
+        today = datetime.now(timezone.utc).date().isoformat()
+        for n in range(2):
+            self.arrive("Dana Okoro", "dana@example.com", days_ago=n + 5,
+                        body=f"mail{n}")
+        self.page("dana_okoro", updated=today, last_interaction=today,
+                  identities=["email:dana@example.com"])
+        _, last = self.run_selector()
+        self.assertEqual(json.loads(last), {"wakeAgent": False})
 
     def test_a_person_with_one_page_has_nothing_to_merge(self):
         """The field is present and empty rather than absent, so a reader

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_select_memory.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_select_memory.py
@@ -27,6 +27,7 @@ HERE = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(HERE))
 
 import correct  # noqa: E402
+import identity  # noqa: E402
 import normalize  # noqa: E402
 import select_memory  # noqa: E402
 
@@ -745,6 +746,120 @@ class TestAPersonIsWhoTheyAreNotWhatTheyAreCalled(SelectorCase):
                         body=f"a{n}")
         found = self.report()
         self.assertEqual([p["slug"] for p in found["people"]], ["dana_okoro"])
+
+
+class TestConfirmingALinkDoesNotStrandAPage(SelectorCase):
+    """The state the feature exists to resolve, and the one it has to survive.
+
+    Before the user answers, each identity has a page of its own — both
+    written, both with history. Confirming the link makes them one person.
+    Returning one slug and saying nothing about the other leaves real content
+    and a real index entry belonging to nobody, while the handoff claims a
+    single page holds everything.
+    """
+
+    def arrive(self, name, address, *, days_ago=0, body="b"):
+        msg = {
+            "id": f"{address}:{days_ago}:{body}",
+            "receivedDateTime": iso(days_ago),
+            "from": {"emailAddress": {"name": name, "address": address}},
+            "toRecipients": [{"emailAddress": {"address": "user@example.com"}}],
+            "subject": body, "bodyPreview": body, "isRead": False,
+        }
+        with sqlite3.connect(self.db) as conn:
+            normalize.insert_items(
+                conn, [normalize.graph_message_to_item(msg, "user@example.com")])
+
+    def slack(self, name, uid, *, days_ago=0, body="b", handle=None):
+        with sqlite3.connect(self.db) as conn:
+            normalize.insert_items(conn, [normalize.slack_message_to_item(
+                {"ts": f"{1787000000 + days_ago}.000{len(body)}",
+                 "user": uid, "text": body},
+                {"id": "D01", "is_im": True}, "U0ME", name, handle)])
+
+    def link(self, *identities):
+        with sqlite3.connect(self.db) as conn:
+            for a, b in ((identities[i], identities[j])
+                         for i in range(len(identities))
+                         for j in range(i + 1, len(identities))):
+                identity.record(conn, identity.parse(a), identity.parse(b),
+                                "confirmed")
+            conn.commit()
+
+    def two_written_pages(self):
+        """A store where the agent has already written both halves up."""
+        for n in range(2):
+            self.arrive("Dana Okoro", "dana@example.com", days_ago=n,
+                        body=f"mail{n}")
+            self.slack("Dana Okoro", "U01DANA", days_ago=n, body=f"slack{n}",
+                       handle="dana")
+        self.page("dana_by_mail", updated="2026-08-01",
+                  identities=["email:dana@example.com"])
+        self.page("dana_by_slack", updated="2026-08-01",
+                  identities=["slack:U01DANA"])
+
+    def test_both_pages_are_handed_over_not_just_the_first(self):
+        self.two_written_pages()
+        self.link("email:dana@example.com", "slack:U01DANA")
+        found = self.report()
+        self.assertEqual(len(found["people"]), 1, found["people"])
+        person = found["people"][0]
+        self.assertEqual(
+            sorted([person["slug"]] + person["merge_into_slug"]),
+            ["dana_by_mail", "dana_by_slack"],
+            "a page this person owns was dropped from the handoff")
+
+    def test_the_page_that_is_kept_does_not_change_between_runs(self):
+        """A keep-choice that depends on identity order would move content
+        back and forth and lose some of it each way."""
+        self.two_written_pages()
+        self.link("email:dana@example.com", "slack:U01DANA")
+        first = self.report()["people"][0]["slug"]
+        for _ in range(3):
+            self.assertEqual(self.report()["people"][0]["slug"], first)
+
+    def test_the_kept_page_is_offered_with_the_whole_history(self):
+        """One page, and the interactions under it are both halves — which is
+        what makes the merge worth doing rather than a bookkeeping move."""
+        self.two_written_pages()
+        self.link("email:dana@example.com", "slack:U01DANA")
+        found = self.report()
+        person = found["people"][0]
+        self.assertEqual(person["messages"], 4)
+        texts = {line["text"] for line in found["interactions"][person["slug"]]}
+        self.assertTrue(any(x.startswith("mail") for x in texts), texts)
+        self.assertTrue(any(x.startswith("slack") for x in texts), texts)
+
+    def test_a_person_with_one_page_has_nothing_to_merge(self):
+        """The field is present and empty rather than absent, so a reader
+        does not have to tell "no extras" from "not reported"."""
+        for n in range(2):
+            self.arrive("Dana Okoro", "dana@example.com", days_ago=n,
+                        body=f"mail{n}")
+        self.page("dana_okoro", updated="2026-08-01",
+                  identities=["email:dana@example.com"])
+        self.assertEqual(self.report()["people"][0]["merge_into_slug"], [])
+
+    def test_three_pages_for_one_person_are_all_reported(self):
+        """Nothing here counts to two: a third connector joins the same way,
+        and its page has to be named too."""
+        for n in range(2):
+            self.arrive("Dana Okoro", "dana@example.com", days_ago=n,
+                        body=f"mail{n}")
+            self.slack("Dana Okoro", "U01DANA", days_ago=n, body=f"slack{n}")
+        self.add("Dana Okoro", days_ago=0, source="slack", body="third",
+                 key="U09OTHER")
+        self.add("Dana Okoro", days_ago=1, source="slack", body="third2",
+                 key="U09OTHER")
+        for mark, who in (("dana_by_mail", "email:dana@example.com"),
+                          ("dana_by_slack", "slack:U01DANA"),
+                          ("dana_by_other", "slack:U09OTHER")):
+            self.page(mark, updated="2026-08-01", identities=[who])
+        self.link("email:dana@example.com", "slack:U01DANA", "slack:U09OTHER")
+        person = self.report()["people"][0]
+        self.assertEqual(
+            sorted([person["slug"]] + person["merge_into_slug"]),
+            ["dana_by_mail", "dana_by_other", "dana_by_slack"])
 
 
 class TestUpgradingDoesNotSplitAPerson(SelectorCase):

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/skills/memory-repair/SKILL.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/skills/memory-repair/SKILL.md
@@ -53,8 +53,13 @@ quickly.
    that person and write it in; if the selector does not name them, leave the
    field absent and note it — a page found by the wrong identity is worse than
    one found only by its filename. For `duplicate-identity`, do not merge and
-   do not pick: two pages claiming one identity means one of them is about
-   somebody else, and only the selector's evidence can say which.
+   do not pick. Two pages claiming one identity means either that one of them
+   is about somebody else, or that a merge copied the content across and left
+   the emptied page behind — and nothing on disk tells those apart, because
+   the page that looks redundant is the correct one in the second case and
+   the victim in the first. The memory job knows: it reports the pages a
+   confirmed link has joined, under `merge_into_slug`. Leave this to that
+   job.
 5. **Decay windows.** Any page past its `decay` window is flagged as stale in
    the log. **Do not delete it and do not silently refresh the date.** A page
    marked stale is still useful; a page whose date was quietly bumped is a

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/skills/memory-writing/SKILL.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/skills/memory-writing/SKILL.md
@@ -125,6 +125,11 @@ this, and a page left behind is history attributed to nobody — it will not
 show up as a person again, because its identities now resolve to the page you
 kept.
 
+A person can appear in the handoff for this reason alone, with nothing new
+said since either page was written. That is not a mistake in the selector:
+both pages being current is exactly when a split sits there unnoticed, and no
+further message is needed for it to still be wrong. Do the merge.
+
 Merge by hand, not by concatenation. Recent Interactions is newest-first and
 has a ceiling; two lists spliced end to end are neither. Relationship and Key
 Context may disagree between the pages — say what is true now rather than

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/skills/memory-writing/SKILL.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/skills/memory-writing/SKILL.md
@@ -81,7 +81,8 @@ People pages require **all** of:
 ```yaml
 ---
 name: Full Name
-source_key: <copy `source_key` from the selector, exactly as given>
+identities:                      # copy `identities` from the selector, as given
+  - <source:key>
 role: Job title or function      # write "unknown" rather than omitting it
 relationship: How they relate to the user, 1-2 sentences
 importance: high | medium | low
@@ -90,12 +91,30 @@ interaction_frequency: daily | weekly | monthly | rare
 ---
 ```
 
-**Copy `source_key` verbatim and never invent one.** It is how the selector
-finds this page again — an address or a user id, not a name. Get it wrong and
-the page is orphaned: the next run finds nobody who matches it, writes a
-second page for the same person, and their history stays behind in the first.
-If the selector did not give you one for somebody, leave the field out rather
-than guessing.
+**Copy `identities` verbatim and never invent an entry.** It is how the
+selector finds this page again — addresses and user ids, not names. Get one
+wrong and the page is orphaned: the next run finds nobody who matches it,
+writes a second page for the same person, and their history stays behind in
+the first. If the selector gave you none for somebody, leave the field out
+rather than guessing.
+
+**Never add an entry because two identities look like the same person.** That
+decision is the user's, and `link_identity.py` is the only thing that records
+it. When the selector reports `identity_candidates`, you may raise it in
+conversation — "Dana Okoro writes from Slack and from mail; same person?" —
+and if the user says yes, run:
+
+    python3 profile/scripts/link_identity.py same slack:U01DANA email:dana@example.com
+
+Then the next run writes one page for them. **Do not wait for an answer.**
+Write the pages you can write, mention what you noticed, and finish; the
+question keeps, and a job that blocks on a human is a job that does not
+complete.
+
+`identity_conflicts` means two answers no longer agree — the user said two
+identities were different people, and other answers since have joined them
+anyway. Report it and change nothing. Only the user can say which answer was
+the wrong one.
 
 Attention pages require **all** of `type`, `updated`, **and `decay`** —
 `decay: daily` for `current_priorities.md`, `decay: weekly` for

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/skills/memory-writing/SKILL.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/skills/memory-writing/SKILL.md
@@ -106,10 +106,30 @@ and if the user says yes, run:
 
     python3 profile/scripts/link_identity.py same slack:U01DANA email:dana@example.com
 
+`same` takes any number of identities. `different` takes exactly two — "these
+three are not one person" does not say which of them is the odd one out, and
+recording every pair as denied would bury a link the user never denied. If
+they rule out a group, ask which pairs.
+
 Then the next run writes one page for them. **Do not wait for an answer.**
 Write the pages you can write, mention what you noticed, and finish; the
 question keeps, and a job that blocks on a human is a job that does not
 complete.
+
+**`merge_into_slug` means this person has pages you have to fold together.**
+It is the state right after the user confirms a link over identities that had
+each already been written up: two real pages, two histories, two index
+entries, one person. Move everything worth keeping from each named page into
+`slug`, then delete that page and remove its index entry. Nothing else does
+this, and a page left behind is history attributed to nobody — it will not
+show up as a person again, because its identities now resolve to the page you
+kept.
+
+Merge by hand, not by concatenation. Recent Interactions is newest-first and
+has a ceiling; two lists spliced end to end are neither. Relationship and Key
+Context may disagree between the pages — say what is true now rather than
+keeping both, and if they disagree about a fact rather than a wording, keep
+the one the newer evidence supports and note that it changed.
 
 `identity_conflicts` means two answers no longer agree — the user said two
 identities were different people, and other answers since have joined them


### PR DESCRIPTION
## Related Issue

Related: #122

## Description

A person is a set of identities, not one. `sender_key` from #140 gave a stable identity per source and nothing joined them, so a colleague who writes from Slack and from mail held two pages with half their history each — and neither got the readable name, because two identities contending for one slug both take a digest. That split becomes visible the moment a second connector is configured, which #142 made possible.

**Only the user joins identities, and the job never waits for the answer.** A matching display name is not evidence — guessing from one is the mistake `sender_key` exists to prevent — and a matching handle is a reason to ask rather than to write. The memory job reports `identity_candidates`, writes a page per identity as before, and exits. The user answers whenever they get to it through `link_identity.py`, which is the only thing that records an answer, for the same reason `correct.py` is the only thing that writes `actor='user'`: a system that can manufacture its own evidence will eventually believe something nobody told it. A nightly job whose completion depends on when somebody read a message is a job that does not complete.

**Answers are stored pairwise and resolved with a disjoint set, so the design does not count to two.** Confirming A~B and B~C joins three identities without a third question, and a fourth connector is one more pair rather than a new shape. Rejections are recorded as durably as confirmations, because a candidate re-proposed on every run is how an idle job wakes the agent forever. When answers stop agreeing — a rejected pair joined anyway by later confirmations — that is reported as `identity_conflicts` and nothing is changed, because neither side is knowably the wrong one.

**An identity is a `(source, key)` pair, never a bare key.** Two systems can mint the same string and merging their owners would be silent and unrecoverable. The text form splits on the first colon only, because a key may contain colons of its own — a Teams conversation id is `29:1a2b…`.

**Schema v5 makes a new connector an INSERT rather than a migration.** `CHECK (source IN ('email','slack'))` meant a third connector could not write a single row until somebody shipped a schema change, which is a poor thing to discover while writing the connector. `sources` is a table and `items.source` a foreign key; the constraint still refuses a typo, with the caveat — stated in the schema — that SQLite enforces foreign keys per connection, so every connection this code opens for writing now sets the pragma. Two did not.

**`sender_handle` records a third thing, distinct from who somebody is and from what they are displayed as.** A Slack handle, a login, a mail local part: unique within its source, changeable by its owner, and the value a user recognises when asked whether two identities are the same colleague. Slack's `users.info` already returned it beside the display name and it was being discarded, so this costs no request. For mail it is derived from the address rather than stated, which the comment says, because it changes what the value is worth as evidence.

**People pages carry `identities:` — a list.** Privileging one entry as `source_key` made "which is the primary" a question with no answer as soon as a third arrived. Pages written before the list are read as a list of one and are not rewritten; the page belongs to the user. `memory_check` gains a malformed-entry finding beside missing and duplicate, because an entry with no source matches nothing and orphans the page silently rather than breaking it loudly.

One defect is worth naming because verification found it and the tests did not. The v5 step drops and recreates `items`, and `obligations.source_id` references it `ON DELETE CASCADE` — with foreign keys enabled SQLite performs an implicit `DELETE FROM` before dropping a table, which fired that cascade and the cascade from `obligations` to `events` after it. A v4 store holding one message, one obligation and one event came out of the migration with the message alone. The row-count guard missed it because it counted `items`, the one table that survived. `PRAGMA foreign_keys = OFF` does not help, because SQLite ignores it inside a transaction and migrations run inside one; `defer_foreign_keys` defers constraint checks rather than cascade actions. Both were measured. The dependants are now carried across the rebuild, discovered as the transitive closure of `PRAGMA foreign_key_list` rather than named — a first attempt saved only the direct dependants, restored the obligations and lost every event.

## Verification

- [x] `python3 scripts/check_license_headers.py --check` — 572 files
- [x] `python3 scripts/check_label_taxonomy.py --check` — not applicable, no governance metadata changed
- [x] `git diff --check`
- [x] Recipe suite: 603 tests across fourteen files, `OK`
- [x] Both connectors end to end through the real normalizers on a fresh store: eight messages in as three mail and five Slack; before an answer, two `Dana Okoro` pages with one identity each and one `shared handle` candidate; after `link_identity.py same`, one `dana_okoro` page holding all six of her messages, no candidates and no conflicts; a Slack-only colleague unaffected throughout
- [x] A third connector, registered by `INSERT INTO sources`, wrote a row with a colon-bearing key and joined the existing candidate group as one question rather than re-asking the pair already answered
- [x] `schema-v3.sql` and `schema-v4.sql` upgraded to v5 with `items`, `obligations`, `events` and `cursors` preserved row for row and `PRAGMA foreign_key_check` clean
- [x] The offline fixture walkthrough runs clean end to end, including `memory_check` reporting zero findings and reporting one when a required field is removed on purpose
- [x] Each behaviour checked by reverting it and confirming the assertions turn red — dropping the source from an identity, resolving groups from direct pairs only, reading a rejection as an answer, and both stages of the migration defect
- [ ] Not verified against a live Hermes install; the connectors' own paths are unchanged by this PR and the store changes are exercised against the frozen schema artifacts instead

## Documentation Writer Review

- [x] Documentation writer review completed for the final changes
- Result: `docs-updated`
- Evidence or justification: `README.md` — the identity section replaces the per-source split note with the proposal-and-answer flow and the command; `profile/schema.md` — `identities` replaces `source_key` in the people-page contract, with the reason it is a list and the rule that only the user adds an entry; `profile/skills/memory-writing/SKILL.md` — how to copy the list, when to raise a candidate in conversation, and an explicit instruction not to wait for the answer.
- Reviewer: @rebelle5868
- [x] Changed user-facing text follows the writing guide and controlled-word list.
- [x] A public contributor can understand the changed text without internal company context.
- [x] I reviewed any agent-generated text before submission.

## Release And Compliance

- [x] No secrets or credentials are included, including API keys, access tokens, passwords, local `.env` files, private certificates, or token caches.
- [x] No nonpublic project names, environment names, hostnames, URLs, ticket identifiers, workspace paths, logs, screenshots, or configuration values are included.
- [x] Third-party dependency changes are reflected in `THIRD-PARTY-NOTICES` — none; standard library only.
- [x] Public content uses sanitized examples and placeholders instead of private values.
- [x] I added my DCO sign-off declaration to this pull request description.

Signed-off-by: Xuan Wu <xuwu@nvidia.com>

