### PR TITLE
fix(memory-driven-chief-of-staff): make two setup refusals say something true

### DIFF
--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -1000,7 +1000,7 @@ cd ../..
 test "$fail" -eq 0
 ```
 
-Expected result: every file ends with `OK`, the fourteen files report 603 tests
+Expected result: every file ends with `OK`, the fourteen files report 610 tests
 in total, and the final line is `failed=0`. Do not shorten the loop with an
 early break; running every module is part of the documented check.
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_selectors.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_selectors.py
@@ -1336,6 +1336,204 @@ esac
                           f"{name} never mentions the prerequisite")
 
 
+class TestTheInstallerNamesTheKeyThatWorks(unittest.TestCase):
+    """Behind a gateway that substitutes the credential, neither answer the
+    installer gave was the right one.
+
+    A real key would be a secret written into a second config file for no
+    reason, and no key at all sends `no-key-required`, which the endpoint
+    rejects — so `ALLOW_NO_API_KEY=1` produces a profile that passes this
+    check and then fails to authenticate on every scheduled run. Measured on
+    a NemoClaw host: the working profile beside it held the rewrite marker.
+
+    The marker is a public constant, so it is echoed only when the profile
+    these settings came from is already using exactly it. A real key never
+    matches, which is the half of this that must not regress.
+    """
+
+    RECIPE = HERE.parents[1]
+    MARKER = "sk-OPENSHELL-PROXY-REWRITE"
+
+    STUB = """#!/usr/bin/env bash
+store="${STUB_STORE:?}"; profile=""
+args=(); while [ $# -gt 0 ]; do
+  case "$1" in -p) profile="$2"; shift 2;; *) args+=("$1"); shift;; esac
+done
+set -- "${args[@]}"
+case "$1 $2" in
+  "profile show") echo "Path: ${STUB_HOME}"; exit 0;;
+  "profile install") echo "Installed"; exit 0;;
+  "config get")
+      if [ -z "$profile" ]; then
+        case "$3" in
+          model.default) echo "a/model";; model.provider) echo "custom";;
+          model.base_url) echo "https://inference.local/v1";;
+          model.api_key) echo "${STUB_SOURCE_KEY}";;
+        esac
+      else
+        v=$(grep "^$profile:$3=" "$store" 2>/dev/null | tail -1 | cut -d= -f2-)
+        [ -n "$v" ] && echo "$v" || echo "Config key not set: $3"
+      fi; exit 0;;
+  "config set") echo "$profile:$3=$4" >> "$store"; exit 0;;
+  *) exit 0;;
+esac
+"""
+
+    def run_install(self, folder, source_key):
+        """Run the installer with a `hermes` that answers from a script.
+
+        Small enough to be worth having: reaching the credential branch needs
+        `profile install`, `profile show` and `config get`/`set`, and nothing
+        after it, because the branch exits.
+        """
+        for name, body in (("hermes", self.STUB),
+                           ("uname", "#!/bin/sh\necho Linux\n")):
+            path = folder / name
+            path.write_text(body, encoding="utf-8")
+            path.chmod(0o755)
+        env = dict(os.environ)
+        env["PATH"] = f"{folder}{os.pathsep}{env['PATH']}"
+        env.update({"STUB_STORE": str(folder / "cfg"),
+                    "STUB_HOME": str(folder / "home"),
+                    "STUB_SOURCE_KEY": source_key,
+                    "PROFILE_NAME": "probe"})
+        (folder / "home").mkdir(exist_ok=True)
+        return subprocess.run(
+            ["bash", str(self.RECIPE / "scripts" / "install.sh")],
+            capture_output=True, text=True, cwd=str(self.RECIPE), env=env,
+            stdin=subprocess.DEVNULL)
+
+    def test_the_marker_is_named_when_that_is_what_the_endpoint_wants(self):
+        with tempfile.TemporaryDirectory() as folder:
+            proc = self.run_install(Path(folder), self.MARKER)
+        self.assertNotEqual(proc.returncode, 0, "it must still stop")
+        self.assertIn(self.MARKER, proc.stderr)
+        self.assertIn("config set model.api_key " + self.MARKER, proc.stderr)
+
+    def test_a_real_key_is_never_echoed(self):
+        """The check is an equality against a constant precisely so that this
+        cannot happen. A message that printed the source profile's key would
+        put a live credential in a terminal and a scrollback."""
+        secret = "sk-this-would-be-a-live-credential"
+        with tempfile.TemporaryDirectory() as folder:
+            proc = self.run_install(Path(folder), secret)
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertNotIn(secret, proc.stderr + proc.stdout)
+        self.assertNotIn(self.MARKER, proc.stderr,
+                         "the gateway advice was offered where it does not"
+                         " apply")
+
+    def test_the_other_two_answers_are_still_offered(self):
+        """The marker is a third option, not a replacement: an endpoint that
+        wants a real key, and one that wants none, both still exist."""
+        with tempfile.TemporaryDirectory() as folder:
+            proc = self.run_install(Path(folder), self.MARKER)
+        self.assertIn("config set model.api_key <key>", proc.stderr)
+        self.assertIn("ALLOW_NO_API_KEY=1", proc.stderr)
+
+
+class TestTheMailboxRefusalSaysSomethingTrue(unittest.TestCase):
+    """A refusal that tells the user to do something ineffective.
+
+    On a machine where another recipe already supplies `MS_GRAPH_ACCESS_TOKEN`
+    to the same sandbox, `setup-graph.sh` refuses — correctly, because two
+    providers cannot both supply one key and this recipe's endpoint policy is
+    not the other one's. It then advised setting `GRAPH_PROVIDER_NAME` to a
+    different name, which changes nothing: the check reads the credential keys
+    of every attached provider and never consults that variable. Measured on a
+    real host, with and without it set, the output was identical.
+
+    These run the script, because the previous shape of this — reading the
+    source for the message — is what let the advice stay wrong.
+    """
+
+    RECIPE = HERE.parents[1]
+    SCRIPT = RECIPE / "scripts" / "setup-graph.sh"
+
+    def fake_openshell(self, folder):
+        """An `openshell` reporting a foreign provider holding the mail key.
+
+        `hermes-direct-outlook`, type `nemoclaw-outlook-email` — the shape a
+        machine running another Outlook recipe is actually in.
+        """
+        stub = folder / "openshell"
+        stub.write_text("""#!/usr/bin/env bash
+case "$1 $2" in
+  "sandbox provider") cat <<'LIST'
+NAME  TYPE  CREDENTIAL_KEYS
+hermes-direct-outlook  nemoclaw-outlook-email  1
+LIST
+  ;;
+  "provider get") printf 'Type: nemoclaw-outlook-email\nCredential keys: MS_GRAPH_ACCESS_TOKEN\n' ;;
+  *) exit 0 ;;
+esac
+""", encoding="utf-8")
+        stub.chmod(0o755)
+        # The scheduled path is Linux only and the script refuses elsewhere
+        # before reaching any of this. Reporting a Linux kernel is what lets
+        # the refusal under test be reached from a developer's machine; the
+        # guard itself has its own coverage above.
+        uname = folder / "uname"
+        uname.write_text("#!/bin/sh\necho Linux\n", encoding="utf-8")
+        uname.chmod(0o755)
+
+    def run_setup(self, folder, extra=None):
+        env = dict(os.environ)
+        env["PATH"] = f"{folder}{os.pathsep}{env['PATH']}"
+        env.update(extra or {})
+        return subprocess.run(
+            ["bash", str(self.SCRIPT)], capture_output=True, text=True,
+            cwd=str(self.RECIPE), env=env, stdin=subprocess.DEVNULL)
+
+    def base_env(self, folder):
+        return {"SANDBOX_STORAGE_PATH": str(folder),
+                "STORE_ENCRYPTION_ACKNOWLEDGED": "1"}
+
+    def test_the_foreign_provider_is_refused(self):
+        with tempfile.TemporaryDirectory() as folder:
+            folder = Path(folder)
+            self.fake_openshell(folder)
+            proc = self.run_setup(folder, self.base_env(folder))
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("nemoclaw-outlook-email", proc.stderr)
+
+    def test_renaming_the_provider_changes_nothing(self):
+        """The advice the message used to give. Run both ways and compare —
+        a message can only be wrong about this if the outcome is the same."""
+        outcomes = []
+        for extra in ({}, {"GRAPH_PROVIDER_NAME": "something-else"}):
+            with tempfile.TemporaryDirectory() as folder:
+                folder = Path(folder)
+                self.fake_openshell(folder)
+                env = self.base_env(folder)
+                env.update(extra)
+                proc = self.run_setup(folder, env)
+            outcomes.append((proc.returncode, "MS_GRAPH_ACCESS_TOKEN" in proc.stderr))
+        self.assertEqual(outcomes[0], outcomes[1],
+                         "renaming changed the outcome, so the old advice"
+                         " would have been right")
+        self.assertNotEqual(outcomes[0][0], 0)
+
+    def test_the_refusal_does_not_send_the_user_after_a_rename(self):
+        with tempfile.TemporaryDirectory() as folder:
+            folder = Path(folder)
+            self.fake_openshell(folder)
+            proc = self.run_setup(folder, self.base_env(folder))
+        self.assertIn("Renaming does not help", proc.stderr)
+        self.assertIn("detach", proc.stderr)
+
+    def test_the_refusal_says_the_collector_reads_it_anyway(self):
+        """The part a user has to know: refusing here stops a second
+        registration, not the reading. Inside the sandbox a credential names
+        the sandbox and the key and not the provider, so the collector cannot
+        tell which one handed it over."""
+        with tempfile.TemporaryDirectory() as folder:
+            folder = Path(folder)
+            self.fake_openshell(folder)
+            proc = self.run_setup(folder, self.base_env(folder))
+        self.assertIn("still reads", proc.stderr)
+
+
 class TestTheEncryptionGateChecksAPathItWasGiven(unittest.TestCase):
     """The four tests above read the script; none of them runs it.
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/install.sh
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/install.sh
@@ -80,6 +80,11 @@ echo "2/3  Carrying over the model settings"
 # that took `model.default` and silently dropped `provider` and `base_url`
 # passed both checks below and got all seven jobs registered, pointed at
 # whatever route it had left.
+# What a profile holds instead of a key when an OpenShell gateway substitutes
+# the credential at the boundary. A public constant, not a secret — it is only
+# ever compared against and echoed when it matches.
+GATEWAY_REWRITE_MARKER="sk-OPENSHELL-PROXY-REWRITE"
+
 carried=()
 for key in model.default model.provider model.base_url; do
   value="$(hermes config get "$key" 2>/dev/null | head -1 || true)"
@@ -150,6 +155,22 @@ if [[ -z "$credential" || "$credential" == *"not set"* ]]; then
     echo "Set one, then re-run this script:" >&2
     echo "  hermes -p $PROFILE config set model.api_key <key>" >&2
     echo "" >&2
+    # Neither of the two answers above is the right one behind a gateway that
+    # substitutes the credential at the boundary. There the profile holds a
+    # fixed rewrite marker rather than a key: a real key would be a secret
+    # written into a second config file for no reason, and no key at all
+    # sends `no-key-required`, which the endpoint rejects. The marker is a
+    # public constant, so it is echoed only when the profile these settings
+    # came from is already using exactly it — a real key never matches and
+    # is never printed.
+    source_key="$(hermes config get model.api_key 2>/dev/null | head -1 || true)"
+    if [[ "$source_key" == "$GATEWAY_REWRITE_MARKER" ]]; then
+      echo "This looks like a gateway-backed endpoint: the profile these" >&2
+      echo "settings came from holds the substitution marker rather than a" >&2
+      echo "key, and the gateway rewrites it at the boundary. Use the same:" >&2
+      echo "  hermes -p $PROFILE config set model.api_key $GATEWAY_REWRITE_MARKER" >&2
+      echo "" >&2
+    fi
     echo "If your endpoint needs no key, say so explicitly:" >&2
     echo "  ALLOW_NO_API_KEY=1 bash scripts/install.sh" >&2
     exit 1

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/setup-graph.sh
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/scripts/setup-graph.sh
@@ -94,8 +94,23 @@ while read -r name; do
       | sed -n 's/^[[:space:]]*Type:[[:space:]]*//p')"
     if [[ "$type" != "$PROFILE_ID" ]]; then
       echo "     '$name' exposes $USABLE_KEY but is type '$type', not" >&2
-      echo "     '$PROFILE_ID'; refusing to reuse it. Remove it, or set" >&2
-      echo "     GRAPH_PROVIDER_NAME to a different name." >&2
+      echo "     '$PROFILE_ID'. Refusing to reuse it: this recipe's endpoint" >&2
+      echo "     policy is read-only and that provider carries its own." >&2
+      echo "" >&2
+      echo "     Renaming does not help. Two providers cannot both supply" >&2
+      echo "     $USABLE_KEY to one sandbox, so GRAPH_PROVIDER_NAME changes" >&2
+      echo "     nothing here — the clash is the key, not the name." >&2
+      echo "" >&2
+      echo "     Either detach '$name' from this sandbox, or attach this" >&2
+      echo "     recipe to a sandbox that does not have it:" >&2
+      echo "       openshell sandbox provider detach $SANDBOX $name" >&2
+      echo "       OPENSHELL_SANDBOX_NAME=<other> bash scripts/setup-graph.sh" >&2
+      echo "" >&2
+      echo "     Until then the collector still reads $USABLE_KEY on every" >&2
+      echo "     tick and will collect mail through '$name' — this refusal" >&2
+      echo "     stops the provider being registered, not the reading. From" >&2
+      echo "     inside the sandbox a credential carries no provenance, so" >&2
+      echo "     the collector cannot tell which provider supplied it." >&2
       exit 1
     fi
     if ! validate_profile "$type"; then


### PR DESCRIPTION
## Related Issue

Related: #122

## Description

Two messages that sent the user somewhere useless, both found by installing this recipe into a fresh profile on a NemoClaw host that already runs another Outlook recipe, and following the README as written.

**`setup-graph.sh` gave advice that provably does nothing.** It refuses when another provider already supplies `MS_GRAPH_ACCESS_TOKEN` to the same sandbox — correctly, because two providers cannot both supply one key and this recipe's endpoint policy is not the other one's. It then advised setting `GRAPH_PROVIDER_NAME` to a different name. The check reads the credential keys of every attached provider and never consults that variable; run with and without it, the output is identical. The message now names the two things that do work — detach the other provider, or attach this recipe to a sandbox that does not have it — and quotes the commands.

**It also now says the part a user has to know: the refusal does not bind the collector.** Inside the sandbox a credential is a placeholder naming the sandbox and the key and nothing else, so `ingest_graph.py` cannot tell which provider handed it over. On the host I tested, refusing to register stopped a second provider and not the reading: the first intake tick collected fifty real messages through the other recipe's provider, whose profile is `access: read-write` where this recipe declares read-only. Refusing at setup and continuing at runtime is worth saying out loud rather than leaving to be discovered.

I did not try to make the collector enforce it, because on a sandboxed install it cannot. Setup runs on the host, where `openshell` is; the collector runs in the sandbox, where the profile is; `setup-graph.sh` writes nothing into the profile and has nowhere to write it. A gate that cannot see what it is gating is worse than none, so this change makes the message true instead of pretending the boundary holds. The limitation belongs in the README, which is being revised separately.

**`install.sh` offered two answers, neither of which is right behind a gateway.** A real key is a secret written into a second config file for no reason, and no key at all sends `no-key-required`, which the endpoint rejects — so `ALLOW_NO_API_KEY=1` produces a profile that passes this check and then fails to authenticate on every scheduled run. The working profile beside it held the gateway's substitution marker. That marker is a public constant, so it is now named as a third option, and only when the profile these settings came from is already using exactly it. A real key never matches the constant and is never printed, which has its own regression.

Both changes are tested by running the scripts against a stubbed `openshell`, a stubbed `hermes` and a stubbed `uname`, because the earlier shape of this — reading the source for the message — is what let the advice stay wrong in the first place. One test stays green either way by design: it compares the outcome with and without `GRAPH_PROVIDER_NAME`, which is the fact the message has to describe rather than the wording.

## Verification

- [x] `python3 scripts/check_license_headers.py --check` — 590 files
- [x] `python3 scripts/check_label_taxonomy.py --check` — not applicable, no governance metadata changed
- [x] `git diff --check`
- [x] Recipe suite: 610 tests across fourteen files, `OK`
- [x] Reproduced on a Linux NemoClaw host: with `hermes-direct-outlook` attached, `setup-graph.sh` refuses identically with and without `GRAPH_PROVIDER_NAME` set, and the intake tick afterwards collected 50 messages through that provider
- [x] Confirmed the sandbox placeholder carries no provenance: `MS_GRAPH_ACCESS_TOKEN=openshell:resolve:env:v<sandbox>_MS_GRAPH_ACCESS_TOKEN`
- [x] Confirmed on the same host that the profile which authenticates holds the gateway marker rather than a key
- [x] Each behaviour checked by reverting it — the refusal turns two red, the installer hint turns one red

## Documentation Writer Review

- [x] Documentation writer review completed for the final changes
- Result: `no-doc-change-needed`
- Evidence or justification: the only README line touched is the test count, which the suite pins. The onboarding and egress-limitation prose this work surfaced is being revised in a separate change so the two do not collide.
- Reviewer: @rebelle5868
- [x] Changed user-facing text follows the writing guide and controlled-word list.
- [x] A public contributor can understand the changed text without internal company context.
- [x] I reviewed any agent-generated text before submission.

## Release And Compliance

- [x] No secrets or credentials are included, including API keys, access tokens, passwords, local `.env` files, private certificates, or token caches.
- [x] No nonpublic project names, environment names, hostnames, URLs, ticket identifiers, workspace paths, logs, screenshots, or configuration values are included.
- [x] Third-party dependency changes are reflected in `THIRD-PARTY-NOTICES` — none; standard library only.
- [x] Public content uses sanitized examples and placeholders instead of private values.
- [x] I added my DCO sign-off declaration to this pull request description.

Signed-off-by: Xuan Wu <xuwu@nvidia.com>
