### PR TITLE
docs(memory-driven-chief-of-staff): rewrite onboarding guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -372,13 +372,17 @@ Each example's root README is the single source for that example in the
 generated [Markdown catalog](examples/README.md), GitHub Pages cards, filters,
 detail pages, public `catalog.json` search index, and agent-oriented
 `llms.txt`. The build discovers example directories from the canonical
-taxonomy, derives kind and provenance from the path, and reads this exact
-opening block after any license header. Existing
-non-catalog YAML frontmatter may also precede the title and is ignored by
-catalog generation:
+taxonomy, derives kind and provenance from the path, and reads this exact table
+from the root README. Put it in a final `Catalog Metadata` section. Existing
+tables immediately after the title remain supported. Non-catalog YAML
+frontmatter may precede the title and is ignored by catalog generation:
 
 ```markdown
 # Recognizable Example Name
+
+[Explain the example and show how to run it.]
+
+## Catalog Metadata
 
 | Catalog field | Value |
 | --- | --- |
@@ -585,8 +589,9 @@ remaining validation.]
 
 - Put material credential, data-sharing, permission, cost, write, or
   destructive-action warnings before the command that triggers them.
-- Start with the exact title and catalog table, including its `Description`
-  outcome, documented in [Catalog Metadata](#catalog-metadata).
+- Start with the exact title. Put the catalog table, including its `Description`
+  outcome, in a final `Catalog Metadata` section as documented in
+  [Catalog Metadata](#catalog-metadata).
 - Use the canonical category independently from contributor or organizational
   provenance.
 - Preserve partner and community attribution.

--- a/examples/README.md
+++ b/examples/README.md
@@ -58,7 +58,7 @@ Standalone utilities that help developers build, evaluate, inspect, or operate N
 
 | Example | Industry | Description |
 | --- | --- | --- |
-| [Agent Memory Benchmark](tools/agent-memory-benchmark/README.md) | ✨ Other | Measures the memory an agent builds from synthetic email and chat by asking 186 questions on one corpus and 96 on another, then reports accuracy by question type separately from ingest and answer token costs. |
+| [Agent Memory Benchmark](tools/agent-memory-benchmark/README.md) | ✨ Other | Benchmarks memory systems on synthetic email and chat, reporting answer accuracy and token cost. |
 | [Harness Engineering Playground](tools/harness-engineering-playground/README.md) | ✨ Other | Provides an experimental loop for tuning DeepAgents harness profiles against behavioral evaluations, keeping fixes that pass verification and rolling back rejected edits. |
 
 ## Recipe Collections

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,7 @@
 
 Examples are organized first by artifact type. Reusable recipes are organized
 again by contributor provenance. Industry is an independent discovery field.
-This file is generated from the catalog metadata block at the top of each
+This file is generated from the catalog metadata table in each
 example README. Edit that README, then run
 `python3 scripts/build_catalog.py --write` from the repository root.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -58,7 +58,7 @@ Standalone utilities that help developers build, evaluate, inspect, or operate N
 
 | Example | Industry | Description |
 | --- | --- | --- |
-| [Agent Memory Benchmark](tools/agent-memory-benchmark/README.md) | ✨ Other | Benchmarks memory systems on synthetic email and chat, reporting answer accuracy and token cost. |
+| [Agent Memory Benchmark](tools/agent-memory-benchmark/README.md) | ✨ Other | Measures memory built from synthetic email and chat, asks 186 questions on one corpus and 96 on a second, and reports accuracy by question type with ingest and answer token costs. |
 | [Harness Engineering Playground](tools/harness-engineering-playground/README.md) | ✨ Other | Provides an experimental loop for tuning DeepAgents harness profiles against behavioral evaluations, keeping fixes that pass verification and rolling back rejected edits. |
 
 ## Recipe Collections

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -5,12 +5,6 @@
 
 # Memory-Driven Chief of Staff
 
-| Catalog field | Value |
-| --- | --- |
-| Description | Builds a revisable local memory from email and Slack, then ranks obligations against the user's priorities while preserving pins and ignores without changing source systems. |
-| Industry | ✨ Other |
-| Requirements | Python 3.10+ · scheduled use: Linux/WSL, Hermes 0.19+, and an inference provider API key · Slack and Microsoft Graph collectors optional |
-
 Turn NemoHermes into an attention bridge for inbound conversations. This recipe
 builds a source-backed work wiki and surfaces the decisions, replies, and
 follow-ups that require the user's attention.
@@ -1031,3 +1025,11 @@ source_connectors:
 evidence_level: integration
 license: Apache-2.0
 ```
+
+## Catalog Metadata
+
+| Catalog field | Value |
+| --- | --- |
+| Description | Builds a revisable local memory from email and Slack, then ranks obligations against the user's priorities while preserving pins and ignores without changing source systems. |
+| Industry | ✨ Other |
+| Requirements | Python 3.10+ · scheduled use: Linux/WSL, Hermes 0.19+, and an inference provider API key · Slack and Microsoft Graph collectors optional |

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -234,12 +234,6 @@ git clone https://github.com/NVIDIA/nemoclaw-community.git
 cd nemoclaw-community/examples/recipes/nvidia/memory-driven-chief-of-staff
 ```
 
-If you are already at the repository root, only run the second command.
-
-```bash
-cd examples/recipes/nvidia/memory-driven-chief-of-staff
-```
-
 ### 2. Create isolated local state and run the walkthrough
 
 ```bash

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -77,9 +77,9 @@ recipe complements Hermes memory and optional external memory providers.
 - [Quick Start](#quick-start)
 - [Install in NemoClaw](#install-in-nemoclaw)
 - [Configuration](#configuration)
+- [Connect Messaging Providers](#connect-messaging-providers)
 - [API and Module Reference](#api-and-module-reference)
 - [Scheduled Operation](#scheduled-operation)
-- [Connect Messaging Providers](#connect-messaging-providers)
 - [Data Lifecycle and Privacy](#data-lifecycle-and-privacy)
 - [Verification](#verification)
 - [Troubleshooting and FAQ](#troubleshooting-and-faq)
@@ -425,24 +425,6 @@ a temporary shell export. See [docs/data-lifecycle.md](docs/data-lifecycle.md)
 for retention and memory settings, and
 [docs/set-up-graph.md](docs/set-up-graph.md) for Outlook backfill.
 
-### Profile configuration
-
-The source of truth for installed files is `profile/distribution.yaml`.
-A conceptual target profile model block has this shape; use Hermes commands to
-set values rather than editing the file directly.
-
-```yaml
-model:
-  default: "<provider/model>"
-  provider: "<provider>"
-  base_url: "<https-endpoint>"
-  api_key: sk-OPENSHELL-PROXY-REWRITE
-```
-
-The `api_key` value above is the required non-secret routing marker for a
-NemoClaw-managed Hermes profile. OpenShell replaces it at egress; it is not a
-credential to rotate or hide.
-
 ### Public Slack channels
 
 Direct messages and group DMs are discovered automatically. Public channels
@@ -468,6 +450,168 @@ are not supported. Invalid or unknown fields fail closed.
   "channels": ["C0SALARY01", "D0PRIVATE1"]
 }
 ```
+
+## Connect Messaging Providers
+
+Slack and Microsoft Outlook are independent, optional inputs. Configure either
+one or both after installing the recipe and setting any intake exclusions.
+Each setup script requires encrypted sandbox storage and attaches a read-only
+OpenShell provider to the NemoHermes sandbox.
+
+### Profile configuration
+
+The installer has already created the target profile from
+`profile/distribution.yaml`. Its model block should have this shape:
+
+```yaml
+model:
+  default: "<provider/model>"
+  provider: "<provider>"
+  base_url: "<https-endpoint>"
+  api_key: sk-OPENSHELL-PROXY-REWRITE
+```
+
+The `api_key` value is the non-secret routing marker configured during
+installation. OpenShell replaces it at egress; it is not a credential to rotate
+or hide.
+
+Provider setup now continues on the **Linux host**.
+
+### Slack
+
+Slack setup is optional. Complete it only after placing the sandbox storage on
+an encrypted volume; owner-only permissions are access control, not encryption.
+See [docs/encrypted-storage.md](docs/encrypted-storage.md) first.
+
+Run the setup script from the recipe checkout on the **Linux host**, not inside
+the sandbox. The host has `openshell`; the sandbox has `hermes`.
+
+```bash
+export SANDBOX_STORAGE_PATH="<host-path-containing-sandbox-storage>"
+export OPENSHELL_SANDBOX_NAME="my-hermes"
+bash scripts/setup-slack.sh
+```
+
+The script imports `docs/slack_app_manifest.json`, requests user scopes, checks
+the provider type and read-only policy, configures token rotation, and attaches
+the provider to the named sandbox. The required scopes are:
+
+```yaml
+user_scopes:
+  - im:read
+  - im:history
+  - mpim:read
+  - mpim:history
+  - channels:read
+  - channels:history
+  - users:read
+```
+
+Static user tokens, bot tokens, and app tokens are refused. Attachments are not
+downloaded. Full setup and workspace-admin recovery steps are in
+[docs/set-up-slack.md](docs/set-up-slack.md).
+
+Verify the live collector from the host through the supported sandbox exec
+path. Replace both placeholders.
+
+```bash
+nemohermes my-hermes exec \
+  --workdir /sandbox/memory-driven-chief-of-staff \
+  -- env HERMES_HOME=/sandbox/.hermes/profiles/memory-driven-chief-of-staff \
+  python3 profile/scripts/ingest_slack.py --recheck
+```
+
+Collector exit codes are stable diagnostics:
+
+| Exit | Meaning |
+| --- | --- |
+| `0` | Fetch succeeded, or Slack is intentionally unconfigured |
+| `1` | Other collector error |
+| `2` | Missing/wrong credential type or unreachable API |
+| `3` | Slack rate limit |
+| `4` | Required Slack scope missing |
+
+### Microsoft Outlook
+
+Outlook intake uses the Microsoft Graph inbox delta API. Register a Microsoft
+Entra application with public-client flows enabled and delegated `Mail.Read`,
+`User.Read`, and `offline_access` permissions. Do not grant application-level
+mail permissions, which would authorize access beyond the signed-in mailbox.
+
+Run the device-code setup from the recipe checkout on the Linux host:
+
+```bash
+export SANDBOX_STORAGE_PATH="<host-path-containing-sandbox-storage>"
+export OPENSHELL_SANDBOX_NAME="my-hermes"
+export GRAPH_CLIENT_ID="<entra-application-client-id>"
+export GRAPH_TENANT_ID="<entra-directory-tenant-id>"
+bash scripts/setup-graph.sh
+```
+
+If the script reports that another attached provider already exposes
+`MS_GRAPH_ACCESS_TOKEN`, treat that as a hard stop. Detach the conflicting
+provider or use a dedicated sandbox, then rerun setup. Do not run the Graph
+collector while the credential source is ambiguous.
+
+On the supported path, the gateway stores and refreshes the delegated
+credential, and the sandbox receives only an OpenShell placeholder. Confirm
+that the attached provider has type `memory-driven-cos-graph-user` and that its
+exported profile declares `access: read-only` with `enforcement: enforce` before
+running the collector. The initial synchronization covers seven days by default
+and resumes across intake ticks when more pages remain. Configure a different
+`GRAPH_BACKFILL_DAYS` in the profile environment file before the first
+synchronization. See [docs/set-up-graph.md](docs/set-up-graph.md) for the
+application registration, provider inspection, backfill, revocation, and
+recovery steps.
+
+### Link identities across providers
+
+Slack identifies a person by user ID, while email uses an address. The recipe
+never assumes that matching display names belong to the same person. The memory
+job reports likely matches as `identity_candidates`; only the user can confirm
+or reject them.
+
+Run the identity command from the Linux host through sandbox exec:
+
+```bash
+nemohermes my-hermes exec \
+  --workdir /sandbox/memory-driven-chief-of-staff \
+  -- env HERMES_HOME=/sandbox/.hermes/profiles/memory-driven-chief-of-staff \
+  python3 profile/scripts/link_identity.py same \
+    slack:U01DANA email:dana@example.com
+```
+
+Use `different` instead of `same` to reject a match. Confirmed relationships
+compose across providers. Rejected candidates are not proposed again. If saved
+answers conflict, the recipe reports `identity_conflicts` and changes nothing.
+Existing page names remain stable after identities are linked so that index
+entries and source-backed links do not move.
+
+### Collector failures
+
+When a collector fails, the intake batch records only its name, exit code, and
+error class. It does not place collector output in the model prompt or the
+scheduler log because that output can contain message text or authentication
+material. Run the collector directly to inspect its full error.
+
+Verify the collector from the host:
+
+```bash
+nemohermes my-hermes exec \
+  --workdir /sandbox/memory-driven-chief-of-staff \
+  -- env HERMES_HOME=/sandbox/.hermes/profiles/memory-driven-chief-of-staff \
+  python3 profile/scripts/ingest_graph.py --recheck
+```
+
+Outlook collector exit codes are:
+
+| Exit | Meaning |
+| --- | --- |
+| `0` | Fetch succeeded, can resume, or Outlook is unconfigured |
+| `1` | Other collector error |
+| `2` | Missing, invalid, or refused credential |
+| `3` | Microsoft Graph rate limit |
+| `4` | Token is not a delegated mailbox token with the required scopes |
 
 ## API and Module Reference
 
@@ -610,149 +754,6 @@ Deleting the profile also deletes its workspace, store, and memory.
 ```bash
 hermes profile delete memory-driven-chief-of-staff
 ```
-
-## Connect Messaging Providers
-
-Slack and Microsoft Outlook are independent, optional inputs. Configure either
-one or both after installing the recipe. Each setup script runs on the
-**Linux host**, requires encrypted sandbox storage, and attaches a read-only
-OpenShell provider to the NemoHermes sandbox.
-
-### Slack
-
-Slack setup is optional. Complete it only after placing the sandbox storage on
-an encrypted volume; owner-only permissions are access control, not encryption.
-See [docs/encrypted-storage.md](docs/encrypted-storage.md) first.
-
-Run the setup script from the recipe checkout on the **Linux host**, not inside
-the sandbox. The host has `openshell`; the sandbox has `hermes`.
-
-```bash
-export SANDBOX_STORAGE_PATH="<host-path-containing-sandbox-storage>"
-export OPENSHELL_SANDBOX_NAME="my-hermes"
-bash scripts/setup-slack.sh
-```
-
-The script imports `docs/slack_app_manifest.json`, requests user scopes, checks
-the provider type and read-only policy, configures token rotation, and attaches
-the provider to the named sandbox. The required scopes are:
-
-```yaml
-user_scopes:
-  - im:read
-  - im:history
-  - mpim:read
-  - mpim:history
-  - channels:read
-  - channels:history
-  - users:read
-```
-
-Static user tokens, bot tokens, and app tokens are refused. Attachments are not
-downloaded. Full setup and workspace-admin recovery steps are in
-[docs/set-up-slack.md](docs/set-up-slack.md).
-
-Verify the live collector from the host through the supported sandbox exec
-path. Replace both placeholders.
-
-```bash
-nemohermes my-hermes exec \
-  --workdir /sandbox/memory-driven-chief-of-staff \
-  -- env HERMES_HOME=/sandbox/.hermes/profiles/memory-driven-chief-of-staff \
-  python3 profile/scripts/ingest_slack.py --recheck
-```
-
-Collector exit codes are stable diagnostics:
-
-| Exit | Meaning |
-| --- | --- |
-| `0` | Fetch succeeded, or Slack is intentionally unconfigured |
-| `1` | Other collector error |
-| `2` | Missing/wrong credential type or unreachable API |
-| `3` | Slack rate limit |
-| `4` | Required Slack scope missing |
-
-### Microsoft Outlook
-
-Outlook intake uses the Microsoft Graph inbox delta API. Register a Microsoft
-Entra application with public-client flows enabled and delegated `Mail.Read`,
-`User.Read`, and `offline_access` permissions. Do not grant application-level
-mail permissions, which would authorize access beyond the signed-in mailbox.
-
-Run the device-code setup from the recipe checkout on the Linux host:
-
-```bash
-export SANDBOX_STORAGE_PATH="<host-path-containing-sandbox-storage>"
-export OPENSHELL_SANDBOX_NAME="my-hermes"
-export GRAPH_CLIENT_ID="<entra-application-client-id>"
-export GRAPH_TENANT_ID="<entra-directory-tenant-id>"
-bash scripts/setup-graph.sh
-```
-
-If the script reports that another attached provider already exposes
-`MS_GRAPH_ACCESS_TOKEN`, treat that as a hard stop. Detach the conflicting
-provider or use a dedicated sandbox, then rerun setup. Do not run the Graph
-collector while the credential source is ambiguous.
-
-On the supported path, the gateway stores and refreshes the delegated
-credential, and the sandbox receives only an OpenShell placeholder. Confirm
-that the attached provider has type `memory-driven-cos-graph-user` and that its
-exported profile declares `access: read-only` with `enforcement: enforce` before
-running the collector. The initial synchronization covers seven days by default
-and resumes across intake ticks when more pages remain. Configure a different
-`GRAPH_BACKFILL_DAYS` in the profile environment file before the first
-synchronization. See [docs/set-up-graph.md](docs/set-up-graph.md) for the
-application registration, provider inspection, backfill, revocation, and
-recovery steps.
-
-### Link identities across providers
-
-Slack identifies a person by user ID, while email uses an address. The recipe
-never assumes that matching display names belong to the same person. The memory
-job reports likely matches as `identity_candidates`; only the user can confirm
-or reject them.
-
-Run the identity command from the Linux host through sandbox exec:
-
-```bash
-nemohermes my-hermes exec \
-  --workdir /sandbox/memory-driven-chief-of-staff \
-  -- env HERMES_HOME=/sandbox/.hermes/profiles/memory-driven-chief-of-staff \
-  python3 profile/scripts/link_identity.py same \
-    slack:U01DANA email:dana@example.com
-```
-
-Use `different` instead of `same` to reject a match. Confirmed relationships
-compose across providers. Rejected candidates are not proposed again. If saved
-answers conflict, the recipe reports `identity_conflicts` and changes nothing.
-Existing page names remain stable after identities are linked so that index
-entries and source-backed links do not move.
-
-### Collector failures
-
-When a collector fails, the intake batch records only its name, exit code, and
-error class. It does not place collector output in the model prompt or the
-scheduler log because that output can contain message text or authentication
-material. Run the collector directly to inspect its full error.
-
-Verify the collector from the host:
-
-```bash
-nemohermes my-hermes exec \
-  --workdir /sandbox/memory-driven-chief-of-staff \
-  -- env HERMES_HOME=/sandbox/.hermes/profiles/memory-driven-chief-of-staff \
-  python3 profile/scripts/ingest_graph.py --recheck
-```
-
-Outlook collector exit codes are:
-
-| Exit | Meaning |
-| --- | --- |
-| `0` | Fetch succeeded, can resume, or Outlook is unconfigured |
-| `1` | Other collector error |
-| `2` | Missing, invalid, or refused credential |
-| `3` | Microsoft Graph rate limit |
-| `4` | Token is not a delegated mailbox token with the required scopes |
 
 ## Data Lifecycle and Privacy
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -195,22 +195,26 @@ rows exit with status `3` and explain the required state transition.
 
 ## Install in NemoClaw
 
-The scheduled path is Linux-only and requires a running NemoHermes sandbox.
+The scheduled jobs run inside a Linux NemoHermes sandbox. Your own computer is
+outside that sandbox and can use any platform supported by NemoHermes.
 
-The host and sandbox have different tools. Keep this boundary visible while
-following the steps below:
+This guide uses two command locations:
 
 <!-- markdownlint-disable MD013 -->
-| Phase | Run it on | CLI available there |
+| Location | What it means | CLI available there |
 | --- | --- | --- |
-| Check the sandbox, upload files, and configure messaging providers | Linux host | `nemohermes`, `openshell` |
-| Run `scripts/install.sh`, configure the Hermes profile, and manage jobs | Inside the NemoHermes sandbox | `hermes` |
+| Your machine, outside the sandbox | The terminal with the repository checkout that you use to manage NemoHermes | `nemohermes`, `openshell` |
+| NemoHermes sandbox | The isolated Linux environment where Hermes and the scheduled jobs run | `hermes` |
 <!-- markdownlint-enable MD013 -->
 
-`scripts/install.sh` is never a host command. The host is not expected to have
-`hermes` on `PATH`.
+The sandbox satisfies the recipe's Linux runtime requirement. The current
+provider setup helpers still require Linux or WSL on your machine; this is a
+helper-script limitation, not a recipe runtime requirement.
 
-### 1. Confirm and inspect a Hermes sandbox from the host
+`scripts/install.sh` always runs inside the sandbox. Your machine is not
+expected to have `hermes` on `PATH`.
+
+### 1. Confirm and inspect a Hermes sandbox from your machine
 
 If NemoClaw is not installed, follow the upstream
 [NemoClaw setup guide](https://github.com/NVIDIA/NemoClaw) and select Hermes,
@@ -236,7 +240,7 @@ identify which attached provider supplied it. Use a dedicated sandbox or
 detach the conflicting provider before installing or starting the scheduled
 runtime.
 
-### 2. Upload the recipe from the host
+### 2. Upload the recipe from your machine
 
 Run this from the cloned `nemoclaw-community` repository root.
 
@@ -247,7 +251,7 @@ nemohermes sandbox upload my-hermes \
 nemohermes my-hermes connect
 ```
 
-The upload is required: the sandbox cannot see the host checkout directly.
+The upload is required: the sandbox cannot see the checkout on your machine.
 After `connect` opens a shell, the remaining commands in this subsection run
 **inside the sandbox**.
 
@@ -321,15 +325,15 @@ successfully and reports that state.
 | `SLACK_USER_TOKEN` | OpenShell provider | Injected | Rotating user token | Collector credential; do not set manually on the supported path |
 | `MS_GRAPH_ACCESS_TOKEN` | OpenShell provider | Injected | Rotating delegated token | Outlook collector credential; the collector cannot currently attest which attached provider supplied it |
 | `GRAPH_BACKFILL_DAYS` | Scheduled runtime | No | `7`; integer `1..3650` | Initial Outlook mailbox synchronization window |
-| `GRAPH_CLIENT_ID` | Linux host Outlook setup | Yes | No default | Microsoft Entra application client ID |
-| `GRAPH_TENANT_ID` | Linux host Outlook setup | No | `common` | Microsoft Entra directory tenant ID |
-| `GRAPH_PROVIDER_NAME` | Linux host Outlook setup | No | `memory-driven-cos-graph` | Name used when creating the recipe provider; it does not resolve a conflicting attached provider that exposes the same credential key |
-| `SANDBOX_STORAGE_PATH` | Linux host provider setup | Yes | No default | Host path whose encryption status protects sandbox storage |
-| `OPENSHELL_SANDBOX_NAME` | Linux host provider setup | No | Falls back to `SANDBOX_NAME`, then `hermes` | Sandbox receiving the provider |
-| `SANDBOX_NAME` | Linux host provider setup | No | `hermes` | Compatibility fallback for the sandbox name |
-| `SLACK_PROVIDER_NAME` | Linux host Slack setup | No | `memory-driven-cos-slack-user` | OpenShell provider name |
-| `STORE_ENCRYPTION_ACKNOWLEDGED` | Linux host provider setup | No | `0`; unattended confirmation is `1` | Acknowledges an encryption result the script cannot prove |
-| `FORCE_REAUTH` | Linux host provider setup | No | `0`; replacement is `1` | Replaces an attached rotating provider credential |
+| `GRAPH_CLIENT_ID` | Outlook setup on your machine | Yes | No default | Microsoft Entra application client ID |
+| `GRAPH_TENANT_ID` | Outlook setup on your machine | No | `common` | Microsoft Entra directory tenant ID |
+| `GRAPH_PROVIDER_NAME` | Outlook setup on your machine | No | `memory-driven-cos-graph` | Name used when creating the recipe provider; it does not resolve a conflicting attached provider that exposes the same credential key |
+| `SANDBOX_STORAGE_PATH` | Provider setup on your machine | Yes | No default | Path whose encryption status protects sandbox storage |
+| `OPENSHELL_SANDBOX_NAME` | Provider setup on your machine | No | Falls back to `SANDBOX_NAME`, then `hermes` | Sandbox receiving the provider |
+| `SANDBOX_NAME` | Provider setup on your machine | No | `hermes` | Compatibility fallback for the sandbox name |
+| `SLACK_PROVIDER_NAME` | Slack setup on your machine | No | `memory-driven-cos-slack-user` | OpenShell provider name |
+| `STORE_ENCRYPTION_ACKNOWLEDGED` | Provider setup on your machine | No | `0`; unattended confirmation is `1` | Acknowledges an encryption result the script cannot prove |
+| `FORCE_REAUTH` | Provider setup on your machine | No | `0`; replacement is `1` | Replaces an attached rotating provider credential |
 <!-- markdownlint-enable MD013 -->
 
 Scheduled environment variables must reach the target profile. Persist a value
@@ -388,7 +392,8 @@ The `api_key` value is the non-secret routing marker configured during
 installation. OpenShell replaces it at egress; it is not a credential to rotate
 or hide.
 
-Provider setup now continues on the **Linux host**.
+Provider setup now continues on **your machine, outside the sandbox**. The
+current setup helpers require a Linux shell; use WSL on Windows.
 
 ### Slack
 
@@ -396,11 +401,11 @@ Slack setup is optional. Complete it only after placing the sandbox storage on
 an encrypted volume; owner-only permissions are access control, not encryption.
 See [docs/encrypted-storage.md](docs/encrypted-storage.md) first.
 
-Run the setup script from the recipe checkout on the **Linux host**, not inside
-the sandbox. The host has `openshell`; the sandbox has `hermes`.
+Run the setup script from the recipe checkout on **your machine**, not inside
+the sandbox. Your machine has `openshell`; the sandbox has `hermes`.
 
 ```bash
-export SANDBOX_STORAGE_PATH="<host-path-containing-sandbox-storage>"
+export SANDBOX_STORAGE_PATH="<path-containing-sandbox-storage>"
 export OPENSHELL_SANDBOX_NAME="my-hermes"
 bash scripts/setup-slack.sh
 ```
@@ -424,7 +429,7 @@ Static user tokens, bot tokens, and app tokens are refused. Attachments are not
 downloaded. Full setup and workspace-admin recovery steps are in
 [docs/set-up-slack.md](docs/set-up-slack.md).
 
-Verify the live collector from the host through the supported sandbox exec
+Verify the live collector from your machine through the supported sandbox exec
 path. Replace both placeholders.
 
 ```bash
@@ -451,10 +456,10 @@ Entra application with public-client flows enabled and delegated `Mail.Read`,
 `User.Read`, and `offline_access` permissions. Do not grant application-level
 mail permissions, which would authorize access beyond the signed-in mailbox.
 
-Run the device-code setup from the recipe checkout on the Linux host:
+Run the device-code setup from the recipe checkout on your machine:
 
 ```bash
-export SANDBOX_STORAGE_PATH="<host-path-containing-sandbox-storage>"
+export SANDBOX_STORAGE_PATH="<path-containing-sandbox-storage>"
 export OPENSHELL_SANDBOX_NAME="my-hermes"
 export GRAPH_CLIENT_ID="<entra-application-client-id>"
 export GRAPH_TENANT_ID="<entra-directory-tenant-id>"
@@ -484,7 +489,7 @@ never assumes that matching display names belong to the same person. The memory
 job reports likely matches as `identity_candidates`; only the user can confirm
 or reject them.
 
-Run the identity command from the Linux host through sandbox exec:
+Run the identity command from your machine through sandbox exec:
 
 ```bash
 nemohermes my-hermes exec \
@@ -507,7 +512,7 @@ error class. It does not place collector output in the model prompt or the
 scheduler log because that output can contain message text or authentication
 material. Run the collector directly to inspect its full error.
 
-Verify the collector from the host:
+Verify the collector from your machine:
 
 ```bash
 nemohermes my-hermes exec \
@@ -582,7 +587,7 @@ write operations.
 > this checkout. `ingest_graph.py` currently trusts whichever attached provider
 > supplies `MS_GRAPH_ACCESS_TOKEN`; it does not verify the provider name, type,
 > or policy at runtime. A different provider exposing the same key can therefore
-> bypass the setup-time refusal. Inspect the attached providers on the host and
+> bypass the setup-time refusal. Inspect the attached providers on your machine
 > do not run Graph intake unless the effective provider is the recipe's
 > read-only, enforced profile.
 
@@ -654,9 +659,9 @@ python3 profile/scripts/tests/test_ingest_graph.py
 
 ### The installer says the platform is unsupported
 
-The offline path runs on macOS, Linux, and WSL. The scheduled skills declare
-Linux support only, so `scripts/install.sh` refuses native macOS and Windows.
-Use a Linux NemoClaw sandbox or WSL for scheduling.
+The offline path runs on macOS, Linux, and WSL. Scheduled skills require the
+Linux environment inside a NemoHermes sandbox. If `scripts/install.sh` reports
+another platform, run it inside the sandbox rather than on your machine.
 
 ### The installer reports no model or API credential
 
@@ -693,13 +698,14 @@ Install and start the service, or use the foreground command shown in
 
 That is a supported state. The scheduler continues over existing store rows.
 Enable the source by running `scripts/setup-slack.sh` or
-`scripts/setup-graph.sh` on the Linux host, then run its collector with
+`scripts/setup-graph.sh` on your machine, then run its collector with
 `--recheck` through sandbox exec.
 
 ### Provider setup says `openshell` is missing
 
-The setup command is running inside the sandbox or on a host without OpenShell.
-Return to the Linux host checkout and confirm the CLI and sandbox name.
+The setup command is running inside the sandbox or on a machine without
+OpenShell. Return to the checkout on your machine and confirm the CLI and
+sandbox name.
 
 ```bash
 command -v openshell
@@ -724,9 +730,9 @@ required `Mail.Read` and `User.Read` scopes. Follow the recovery steps in
 
 ### Graph setup refuses an attached provider with the same credential key
 
-Treat the refusal as a provider collision. From the host, inspect and detach
-the conflicting provider or use a dedicated sandbox before starting Graph
-intake.
+Treat the refusal as a provider collision. From your machine, inspect and
+detach the conflicting provider or use a dedicated sandbox before starting
+Graph intake.
 
 ```bash
 openshell sandbox provider list my-hermes
@@ -744,7 +750,8 @@ read-write provider would make the platform-level write-refusal claim false.
 
 ## Limitations and Support
 
-- The scheduled path is Linux-only, including WSL.
+- Scheduled jobs require the Linux environment inside a NemoHermes sandbox.
+  The current provider setup helpers require Linux or WSL on your machine.
 - Recorded judgment turns test the workflow, not model quality.
 - Live connectors currently cover Slack and a Microsoft Outlook inbox through
   Microsoft Graph. Other messaging providers need their own collector and
@@ -832,9 +839,9 @@ memory-driven-chief-of-staff/
 │   ├── register-jobs.sh              # Sandbox: idempotent Hermes cron registration
 │   ├── require-encrypted-storage.sh  # Shared connector storage prerequisite
 │   ├── require-linux.sh              # Shared scheduled-runtime platform check
-│   ├── setup-graph.sh                # Host: authorize and attach Outlook mailbox access
-│   ├── setup-slack.sh                # Host: authorize and attach rotating Slack token
-│   └── validate-provider-profile.sh  # Host: fail-closed provider policy validation
+│   ├── setup-graph.sh                # Outside sandbox: authorize and attach Outlook access
+│   ├── setup-slack.sh                # Outside sandbox: authorize and attach a Slack token
+│   └── validate-provider-profile.sh  # Outside sandbox: validate provider policy
 └── docs/
     ├── data-lifecycle.md             # Retention, exclusions, export, reset, migration
     ├── encrypted-storage.md          # Required storage-encryption checks
@@ -1029,4 +1036,4 @@ license: Apache-2.0
 | --- | --- |
 | Description | Builds a revisable local memory from email and Slack, then ranks obligations against the user's priorities while preserving pins and ignores without changing source systems. |
 | Industry | ✨ Other |
-| Requirements | Python 3.10+ · scheduled use: Linux/WSL, Hermes 0.19+, and an inference provider API key · Slack and Microsoft Graph collectors optional |
+| Requirements | Python 3.10+ · scheduled use: a Linux NemoHermes sandbox, Hermes 0.19+, and an inference provider API key · provider setup helpers: Linux/WSL · Slack and Microsoft Graph collectors optional |

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -73,18 +73,15 @@ recipe complements Hermes memory and optional external memory providers.
 - [From Message Overload to the Work That Needs You](#from-message-overload-to-the-work-that-needs-you)
 - [Memory That Tracks Work, Not Just Preferences](#memory-that-tracks-work-not-just-preferences)
 - [How It Works](#how-it-works)
-- [Project Structure](#project-structure)
 - [Quick Start](#quick-start)
 - [Install in NemoClaw](#install-in-nemoclaw)
 - [Configuration](#configuration)
 - [Connect Messaging Providers](#connect-messaging-providers)
-- [API and Module Reference](#api-and-module-reference)
 - [Scheduled Operation](#scheduled-operation)
 - [Data Lifecycle and Privacy](#data-lifecycle-and-privacy)
-- [Verification](#verification)
 - [Troubleshooting and FAQ](#troubleshooting-and-faq)
 - [Limitations and Support](#limitations-and-support)
-- [Recipe Metadata](#recipe-metadata)
+- [For Contributors](#for-contributors)
 
 ## How It Works
 
@@ -137,90 +134,6 @@ code used by scheduled runs.
 | Intent gate | Proof in memory that the user chose the work; required for `high` |
 | Wake gate | The last non-empty selector line that tells Hermes not to call the model |
 | Envelope | Versioned JSON containing model decisions for the transactional writer |
-<!-- markdownlint-enable MD013 -->
-
-## Project Structure
-
-Paths below are relative to this recipe directory.
-
-<!-- markdownlint-disable MD013 -->
-```text
-memory-driven-chief-of-staff/
-├── README.md                         # Start here: setup, operation, and API contract
-├── profile/
-│   ├── distribution.yaml            # Version, Hermes requirement, owned paths
-│   ├── SOUL.md                       # Chief-of-staff persona and response boundary
-│   ├── schema.md                     # Memory page types, provenance, decay, ceilings
-│   ├── seed/                         # Initial index and attention pages for a new memory
-│   ├── scripts/
-│   │   ├── schema.sql                # Current v5 SQLite store schema
-│   │   ├── schema-v1.sql             # Frozen schemas used by migration tests
-│   │   ├── schema-v2.sql
-│   │   ├── schema-v3.sql
-│   │   ├── schema-v4.sql
-│   │   ├── _db.py                    # Profile-home, connection, and transaction boundary
-│   │   ├── identity.py               # Cross-provider identity relation resolver
-│   │   ├── link_identity.py          # User command for identity confirmations
-│   │   ├── normalize.py              # Source payloads to source-neutral item rows
-│   │   ├── ingest_graph.py           # Optional read-only Outlook mailbox collector
-│   │   ├── ingest_slack.py           # Optional read-only Slack collector
-│   │   ├── select_intake.py          # Intake batch selector and wake gate
-│   │   ├── select_review.py          # Review batch selector and wake gate
-│   │   ├── select_memory.py          # Evidence selector for scheduled wiki writing
-│   │   ├── apply_decisions.py        # Validates and commits agent envelopes
-│   │   ├── ranking.py                # Deterministic cap, reservation, and cascade
-│   │   ├── correct.py                # User pin, ignore, and unignore writer
-│   │   ├── walkthrough.py            # Offline end-to-end entry point
-│   │   ├── retention.py              # Scheduled message-body clearing
-│   │   ├── exclusions.py             # Sender, domain, and channel filtering
-│   │   ├── export_store.py           # Complete Markdown and JSON export
-│   │   ├── reset.py                  # Store, memory, and policy reset
-│   │   ├── migrate.py                # Forward-only store migration
-│   │   ├── memory_check.py           # Deterministic memory invariant checker
-│   │   └── tests/                    # 14 direct-execution unittest modules
-│   └── skills/
-│       ├── inbound-judging/          # New-message judgment instructions
-│       ├── obligation-review/        # Scheduled re-judgment instructions
-│       ├── memory-writing/            # Evidence-grounded people and attention pages
-│       ├── memory-repair/            # Safe invariant repair instructions
-│       ├── memory-consolidation/     # Bounded compaction instructions
-│       └── preference-update/        # Repeated-correction learning instructions
-├── fixtures/
-│   ├── README.md                     # Fixture schema, controls, and provenance
-│   ├── graph_messages.json           # Five synthetic Graph-shaped messages
-│   ├── slack_messages.json           # Three synthetic Slack-shaped messages
-│   ├── envelopes/intake.json         # Recorded intake model turn
-│   └── memory/                       # Synthetic seed memory for the walkthrough
-├── providers/
-│   ├── graph-user.yaml               # Read-only delegated Graph mailbox policy
-│   └── slack-user.yaml               # Read-only Slack endpoint and credential policy
-├── scripts/
-│   ├── install.sh                    # Sandbox: install profile and register jobs
-│   ├── register-jobs.sh              # Sandbox: idempotent Hermes cron registration
-│   ├── require-encrypted-storage.sh  # Shared connector storage prerequisite
-│   ├── require-linux.sh              # Shared scheduled-runtime platform check
-│   ├── setup-graph.sh                # Host: authorize and attach Outlook mailbox access
-│   ├── setup-slack.sh                # Host: authorize and attach rotating Slack token
-│   └── validate-provider-profile.sh  # Host: fail-closed provider policy validation
-└── docs/
-    ├── data-lifecycle.md             # Retention, exclusions, export, reset, migration
-    ├── encrypted-storage.md          # Required storage-encryption checks
-    ├── set-up-graph.md               # Full Outlook mailbox authorization walkthrough
-    ├── set-up-slack.md               # Full Slack authorization walkthrough
-    └── slack_app_manifest.json       # User-scoped Slack app manifest
-```
-<!-- markdownlint-enable MD013 -->
-
-### Dependencies
-
-<!-- markdownlint-disable MD013 -->
-| Dependency source | Path | Purpose |
-| --- | --- | --- |
-| Python package manifest | None | All Python modules use the standard library |
-| Recipe manifest | `profile/distribution.yaml` | Pins recipe version and Hermes 0.19.0+ |
-| SQLite schema | `profile/scripts/schema.sql` | Defines application state schema v5 |
-| Outlook provider policy | `providers/graph-user.yaml` | Declares the recipe's intended read-only delegated `graph.microsoft.com` boundary |
-| Slack provider policy | `providers/slack-user.yaml` | Declares the recipe's intended read-only `slack.com` boundary |
 <!-- markdownlint-enable MD013 -->
 
 ## Quick Start
@@ -613,105 +526,6 @@ Outlook collector exit codes are:
 | `3` | Microsoft Graph rate limit |
 | `4` | Token is not a delegated mailbox token with the required scopes |
 
-## API and Module Reference
-
-### Decision envelope
-
-`apply_decisions.py` reads one JSON document from standard input. The supported
-decisions are `CREATE`, `KEEP_OPEN`, `MARK_DONE`, and `SKIP`. A create or keep
-decision requires a rank, title, and intent-gate verdict.
-
-```json
-{
-  "version": 1,
-  "pass": "intake",
-  "decisions": [
-    {
-      "source_id": "msg-priorities-match",
-      "decision": "CREATE",
-      "rank": 1,
-      "intent_gated": true,
-      "title": "Review the migration plan",
-      "context": "Matches a current priority",
-      "urgency_reason": "Requested before the planning review",
-      "kind": "response",
-      "est_effort": "minutes"
-    },
-    {
-      "source_id": "msg-automated-noise",
-      "decision": "SKIP"
-    }
-  ],
-  "cursor": {
-    "source": "email",
-    "scope": "inbox",
-    "value": "synthetic-cursor"
-  }
-}
-```
-
-Run the writer against a saved envelope from the recipe root.
-
-```bash
-python3 profile/scripts/apply_decisions.py < /path/to/envelope.json
-```
-
-Valid optional values are:
-
-```yaml
-kind:
-  - response
-  - action
-  - null
-est_effort:
-  - minutes
-  - hours
-  - day
-  - multi_day
-  - null
-```
-
-### Module contracts
-
-<!-- markdownlint-disable MD013 -->
-| Module | Reads | Writes / returns |
-| --- | --- | --- |
-| `normalize.py` | Graph- or Slack-shaped source objects | Source-neutral item dictionaries; recipient lists become one addressing value |
-| `_db.py` | `HERMES_HOME`, `schema.sql` | Validated profile path, SQLite connection, transactions, automatic migration |
-| `ingest_graph.py` | Delegated Graph token and inbox delta | New Outlook message rows, resumable cursor state, and source-removal tombstones |
-| `ingest_slack.py` | Rotating Slack token and selected conversations | New Slack rows and per-conversation watermarks |
-| `select_intake.py` | Collectors and pending rows | JSON batch or a final wake-gate line |
-| `select_review.py` | Open obligations | Oldest-review-first JSON batch or a final wake-gate line |
-| `select_memory.py` | Message evidence, open obligations, and user corrections | Bounded memory-writing evidence or a final wake-gate line |
-| `apply_decisions.py` | Versioned JSON envelope on standard input | Items, obligations, cursor, and append-only events in one transaction |
-| `correct.py` | One user command | Pin/ignore state plus `actor='user'` audit events |
-| `identity.py` | Stored pairwise identity answers | Resolved identity groups, candidates, and conflicts |
-| `link_identity.py` | User confirmation or rejection | Durable relationship between two provider identities |
-| `ranking.py` | Open obligations and gate verdicts | Deterministic bounded tiers and positions |
-| `preferences.py` | User correction events | Bounded preference policy after the fixed threshold is met |
-| `memory_check.py` | Memory Markdown pages | Diagnostics and exit status; no model call |
-| `retention.py` | Store and `RETENTION_DAYS` | Clears expired bodies; keeps metadata, obligations, and history |
-| `export_store.py` | Store, memory, and policy | Complete Markdown and JSON export directory |
-| `reset.py` | Profile workspace | Removes store, memory, policy, and collection state after confirmation |
-| `migrate.py` | Existing store | Forward-only schema migration or compatibility check |
-<!-- markdownlint-enable MD013 -->
-
-### Store and migration commands
-
-```bash
-python3 profile/scripts/retention.py --dry-run
-python3 profile/scripts/retention.py
-python3 profile/scripts/export_store.py --to /path/to/export
-python3 profile/scripts/migrate.py --check
-python3 profile/scripts/migrate.py
-python3 profile/scripts/reset.py --dry-run
-python3 profile/scripts/reset.py --yes
-```
-
-`reset.py --yes` is destructive. Stop or pause the schedule first, export if
-needed, detach and revoke external credentials separately, and verify the
-profile named by `HERMES_HOME` before running it.
-
 ## Scheduled Operation
 
 `scripts/register-jobs.sh` is idempotent: it edits jobs with matching names
@@ -801,47 +615,6 @@ The store and memory directories are created with owner-only permissions. That
 does not protect a lost disk, disk image, or unencrypted backup. Before
 connecting Slack or Outlook, follow
 [docs/encrypted-storage.md](docs/encrypted-storage.md).
-
-## Verification
-
-This is an integration-level reference implementation. Its evidence includes
-an offline end-to-end walkthrough, deterministic tests, scheduled Linux
-validation, plus live Slack and Outlook collector and credential-rotation
-validation.
-
-### Offline acceptance walkthrough
-
-```bash
-export RECIPE_VERIFY_HOME="$(mktemp -d)"
-export HERMES_HOME="$RECIPE_VERIFY_HOME"
-python3 profile/scripts/walkthrough.py --fixtures fixtures
-```
-
-### Full test suite
-
-Run from the recipe root. Each test file is executed directly because some
-tests verify direct-execution behavior.
-
-```bash
-cd profile/scripts
-export NO_PROXY="${NO_PROXY:+$NO_PROXY,}127.0.0.1,localhost"
-export no_proxy="${no_proxy:+$no_proxy,}127.0.0.1,localhost"
-fail=0
-for t in tests/*.py; do python3 "$t" || fail=1; done
-echo "failed=$fail"
-cd ../..
-test "$fail" -eq 0
-```
-
-Expected result: every file ends with `OK`, the fourteen files report 603 tests
-in total, and the final line is `failed=0`. Do not shorten the loop with an
-early break; running every module is part of the documented check.
-
-The suite covers schema migration, memory invariants, concurrency and crash
-recovery, deterministic ranking, preference thresholds, normalization,
-transactional decisions, correction state transitions, the walkthrough,
-intake, review, and memory-writing selector wake gates, scheduler contracts,
-lifecycle controls, and Slack and Outlook collection/rotation behavior.
 
 ## Troubleshooting and FAQ
 
@@ -994,7 +767,236 @@ This NVIDIA-authored recipe was proposed and reviewed in
 Support is best effort under the repository [support policy](../../../../SUPPORT.md).
 Security reports should follow [SECURITY.md](../../../../SECURITY.md).
 
-## Recipe Metadata
+## For Contributors
+
+The following sections document the implementation, contracts, and evidence
+used to review or extend this recipe.
+
+### Project Structure
+
+Paths below are relative to this recipe directory.
+
+<!-- markdownlint-disable MD013 -->
+```text
+memory-driven-chief-of-staff/
+├── README.md                         # Start here: setup, operation, and API contract
+├── profile/
+│   ├── distribution.yaml            # Version, Hermes requirement, owned paths
+│   ├── SOUL.md                       # Chief-of-staff persona and response boundary
+│   ├── schema.md                     # Memory page types, provenance, decay, ceilings
+│   ├── seed/                         # Initial index and attention pages for a new memory
+│   ├── scripts/
+│   │   ├── schema.sql                # Current v5 SQLite store schema
+│   │   ├── schema-v1.sql             # Frozen schemas used by migration tests
+│   │   ├── schema-v2.sql
+│   │   ├── schema-v3.sql
+│   │   ├── schema-v4.sql
+│   │   ├── _db.py                    # Profile-home, connection, and transaction boundary
+│   │   ├── identity.py               # Cross-provider identity relation resolver
+│   │   ├── link_identity.py          # User command for identity confirmations
+│   │   ├── normalize.py              # Source payloads to source-neutral item rows
+│   │   ├── ingest_graph.py           # Optional read-only Outlook mailbox collector
+│   │   ├── ingest_slack.py           # Optional read-only Slack collector
+│   │   ├── select_intake.py          # Intake batch selector and wake gate
+│   │   ├── select_review.py          # Review batch selector and wake gate
+│   │   ├── select_memory.py          # Evidence selector for scheduled wiki writing
+│   │   ├── apply_decisions.py        # Validates and commits agent envelopes
+│   │   ├── ranking.py                # Deterministic cap, reservation, and cascade
+│   │   ├── correct.py                # User pin, ignore, and unignore writer
+│   │   ├── walkthrough.py            # Offline end-to-end entry point
+│   │   ├── retention.py              # Scheduled message-body clearing
+│   │   ├── exclusions.py             # Sender, domain, and channel filtering
+│   │   ├── export_store.py           # Complete Markdown and JSON export
+│   │   ├── reset.py                  # Store, memory, and policy reset
+│   │   ├── migrate.py                # Forward-only store migration
+│   │   ├── memory_check.py           # Deterministic memory invariant checker
+│   │   └── tests/                    # 14 direct-execution unittest modules
+│   └── skills/
+│       ├── inbound-judging/          # New-message judgment instructions
+│       ├── obligation-review/        # Scheduled re-judgment instructions
+│       ├── memory-writing/            # Evidence-grounded people and attention pages
+│       ├── memory-repair/            # Safe invariant repair instructions
+│       ├── memory-consolidation/     # Bounded compaction instructions
+│       └── preference-update/        # Repeated-correction learning instructions
+├── fixtures/
+│   ├── README.md                     # Fixture schema, controls, and provenance
+│   ├── graph_messages.json           # Five synthetic Graph-shaped messages
+│   ├── slack_messages.json           # Three synthetic Slack-shaped messages
+│   ├── envelopes/intake.json         # Recorded intake model turn
+│   └── memory/                       # Synthetic seed memory for the walkthrough
+├── providers/
+│   ├── graph-user.yaml               # Read-only delegated Graph mailbox policy
+│   └── slack-user.yaml               # Read-only Slack endpoint and credential policy
+├── scripts/
+│   ├── install.sh                    # Sandbox: install profile and register jobs
+│   ├── register-jobs.sh              # Sandbox: idempotent Hermes cron registration
+│   ├── require-encrypted-storage.sh  # Shared connector storage prerequisite
+│   ├── require-linux.sh              # Shared scheduled-runtime platform check
+│   ├── setup-graph.sh                # Host: authorize and attach Outlook mailbox access
+│   ├── setup-slack.sh                # Host: authorize and attach rotating Slack token
+│   └── validate-provider-profile.sh  # Host: fail-closed provider policy validation
+└── docs/
+    ├── data-lifecycle.md             # Retention, exclusions, export, reset, migration
+    ├── encrypted-storage.md          # Required storage-encryption checks
+    ├── set-up-graph.md               # Full Outlook mailbox authorization walkthrough
+    ├── set-up-slack.md               # Full Slack authorization walkthrough
+    └── slack_app_manifest.json       # User-scoped Slack app manifest
+```
+<!-- markdownlint-enable MD013 -->
+
+#### Dependencies
+
+<!-- markdownlint-disable MD013 -->
+| Dependency source | Path | Purpose |
+| --- | --- | --- |
+| Python package manifest | None | All Python modules use the standard library |
+| Recipe manifest | `profile/distribution.yaml` | Pins recipe version and Hermes 0.19.0+ |
+| SQLite schema | `profile/scripts/schema.sql` | Defines application state schema v5 |
+| Outlook provider policy | `providers/graph-user.yaml` | Declares the recipe's intended read-only delegated `graph.microsoft.com` boundary |
+| Slack provider policy | `providers/slack-user.yaml` | Declares the recipe's intended read-only `slack.com` boundary |
+<!-- markdownlint-enable MD013 -->
+
+### API and Module Reference
+
+#### Decision envelope
+
+`apply_decisions.py` reads one JSON document from standard input. The supported
+decisions are `CREATE`, `KEEP_OPEN`, `MARK_DONE`, and `SKIP`. A create or keep
+decision requires a rank, title, and intent-gate verdict.
+
+```json
+{
+  "version": 1,
+  "pass": "intake",
+  "decisions": [
+    {
+      "source_id": "msg-priorities-match",
+      "decision": "CREATE",
+      "rank": 1,
+      "intent_gated": true,
+      "title": "Review the migration plan",
+      "context": "Matches a current priority",
+      "urgency_reason": "Requested before the planning review",
+      "kind": "response",
+      "est_effort": "minutes"
+    },
+    {
+      "source_id": "msg-automated-noise",
+      "decision": "SKIP"
+    }
+  ],
+  "cursor": {
+    "source": "email",
+    "scope": "inbox",
+    "value": "synthetic-cursor"
+  }
+}
+```
+
+Run the writer against a saved envelope from the recipe root.
+
+```bash
+python3 profile/scripts/apply_decisions.py < /path/to/envelope.json
+```
+
+Valid optional values are:
+
+```yaml
+kind:
+  - response
+  - action
+  - null
+est_effort:
+  - minutes
+  - hours
+  - day
+  - multi_day
+  - null
+```
+
+#### Module contracts
+
+<!-- markdownlint-disable MD013 -->
+| Module | Reads | Writes / returns |
+| --- | --- | --- |
+| `normalize.py` | Graph- or Slack-shaped source objects | Source-neutral item dictionaries; recipient lists become one addressing value |
+| `_db.py` | `HERMES_HOME`, `schema.sql` | Validated profile path, SQLite connection, transactions, automatic migration |
+| `ingest_graph.py` | Delegated Graph token and inbox delta | New Outlook message rows, resumable cursor state, and source-removal tombstones |
+| `ingest_slack.py` | Rotating Slack token and selected conversations | New Slack rows and per-conversation watermarks |
+| `select_intake.py` | Collectors and pending rows | JSON batch or a final wake-gate line |
+| `select_review.py` | Open obligations | Oldest-review-first JSON batch or a final wake-gate line |
+| `select_memory.py` | Message evidence, open obligations, and user corrections | Bounded memory-writing evidence or a final wake-gate line |
+| `apply_decisions.py` | Versioned JSON envelope on standard input | Items, obligations, cursor, and append-only events in one transaction |
+| `correct.py` | One user command | Pin/ignore state plus `actor='user'` audit events |
+| `identity.py` | Stored pairwise identity answers | Resolved identity groups, candidates, and conflicts |
+| `link_identity.py` | User confirmation or rejection | Durable relationship between two provider identities |
+| `ranking.py` | Open obligations and gate verdicts | Deterministic bounded tiers and positions |
+| `preferences.py` | User correction events | Bounded preference policy after the fixed threshold is met |
+| `memory_check.py` | Memory Markdown pages | Diagnostics and exit status; no model call |
+| `retention.py` | Store and `RETENTION_DAYS` | Clears expired bodies; keeps metadata, obligations, and history |
+| `export_store.py` | Store, memory, and policy | Complete Markdown and JSON export directory |
+| `reset.py` | Profile workspace | Removes store, memory, policy, and collection state after confirmation |
+| `migrate.py` | Existing store | Forward-only schema migration or compatibility check |
+<!-- markdownlint-enable MD013 -->
+
+#### Store and migration commands
+
+```bash
+python3 profile/scripts/retention.py --dry-run
+python3 profile/scripts/retention.py
+python3 profile/scripts/export_store.py --to /path/to/export
+python3 profile/scripts/migrate.py --check
+python3 profile/scripts/migrate.py
+python3 profile/scripts/reset.py --dry-run
+python3 profile/scripts/reset.py --yes
+```
+
+`reset.py --yes` is destructive. Stop or pause the schedule first, export if
+needed, detach and revoke external credentials separately, and verify the
+profile named by `HERMES_HOME` before running it.
+
+### Verification
+
+This is an integration-level reference implementation. Its evidence includes
+an offline end-to-end walkthrough, deterministic tests, scheduled Linux
+validation, plus live Slack and Outlook collector and credential-rotation
+validation.
+
+#### Offline acceptance walkthrough
+
+```bash
+export RECIPE_VERIFY_HOME="$(mktemp -d)"
+export HERMES_HOME="$RECIPE_VERIFY_HOME"
+python3 profile/scripts/walkthrough.py --fixtures fixtures
+```
+
+#### Full test suite
+
+Run from the recipe root. Each test file is executed directly because some
+tests verify direct-execution behavior.
+
+```bash
+cd profile/scripts
+export NO_PROXY="${NO_PROXY:+$NO_PROXY,}127.0.0.1,localhost"
+export no_proxy="${no_proxy:+$no_proxy,}127.0.0.1,localhost"
+fail=0
+for t in tests/*.py; do python3 "$t" || fail=1; done
+echo "failed=$fail"
+cd ../..
+test "$fail" -eq 0
+```
+
+Expected result: every file ends with `OK`, the fourteen files report 603 tests
+in total, and the final line is `failed=0`. Do not shorten the loop with an
+early break; running every module is part of the documented check.
+
+The suite covers schema migration, memory invariants, concurrency and crash
+recovery, deterministic ranking, preference thresholds, normalization,
+transactional decisions, correction state transitions, the walkthrough,
+intake, review, and memory-writing selector wake gates, scheduler contracts,
+lifecycle controls, and Slack and Outlook collection/rotation behavior.
+
+### Recipe Metadata
 
 ```yaml
 name: memory-driven-chief-of-staff

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -557,8 +557,15 @@ the same nightly sequence.
 Jobs live in `$HERMES_HOME/cron/jobs.json`. The distribution does not own the
 `cron` path, so profile updates leave job definitions and run history unchanged.
 
-Jobs survive a reboot, but resume automatically only when the gateway runs as a
-service. Hermes collapses missed recurring runs into one run over current state.
+Jobs survive a reboot. Do they resume automatically?
+Only if the gateway was installed as a service with `gateway install`. A
+gateway started with `gateway run` is a foreground process and must be started
+again after a reboot.
+
+What happens to recurring runs missed while the gateway was down? One of them
+runs, not the entire backlog. Hermes advances the schedule and runs once over
+current state. A machine that was off for two days does not wake to ninety-six
+intake runs; it wakes to one and then resumes its half-hourly schedule.
 
 List or remove registered jobs inside the sandbox.
 
@@ -588,7 +595,7 @@ write operations.
 > supplies `MS_GRAPH_ACCESS_TOKEN`; it does not verify the provider name, type,
 > or policy at runtime. A different provider exposing the same key can therefore
 > bypass the setup-time refusal. Inspect the attached providers on your machine
-> do not run Graph intake unless the effective provider is the recipe's
+> and do not run Graph intake unless the effective provider is the recipe's
 > read-only, enforced profile.
 
 **Source-system behavior:** the shipped collectors read Slack and the signed-in

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -1,5 +1,7 @@
+<!-- markdownlint-disable MD013 -->
 <!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- markdownlint-enable MD013 -->
 
 # Memory-Driven Chief of Staff
 
@@ -9,341 +11,579 @@
 | Industry | ✨ Other |
 | Requirements | Python 3.10+ · scheduled use: Linux/WSL, Hermes 0.19+, and an inference provider API key · Slack and Microsoft Graph collectors optional |
 
-Memory-Driven Chief of Staff is a recipe that keeps a local, revisable record
-for each inbound email and Slack message. It re-judges those records on a
-schedule and re-ranks them under fixed caps, on jobs it registers with the
-runtime's scheduler. The user's own ignores and priority overrides change the
-ranking. The recipe never writes back to the
-source system.
+Turn NemoHermes into an attention bridge for inbound conversations. This recipe
+builds a source-backed work wiki and surfaces the decisions, replies, and
+follow-ups that require the user's attention.
 
-Three phases are here: the store with its tests and an offline walkthrough,
-the installer and scheduled jobs that run it without a person present, and a
-Slack collector that reads the messages the user receives. The first two need
-no account, no workspace and no network, and the walkthrough and the tests
-still need none. The collector is optional; until it is set up it reports
-itself unconfigured and the schedule runs over whatever the store holds. Only
-the scheduled path needs an inference endpoint, and only when a job finds
-work. A fixture corpus exercises the same code a
-live source would. Two recorded model turns stand in for the two steps that
-would otherwise need a model: the intake judgment, in
-`fixtures/envelopes/intake.json`, and the scheduled re-judgment, recorded
-inline in `profile/scripts/walkthrough.py`.
+## From Message Overload to the Work That Needs You
 
-## Concepts
+Work arrives across threads and providers. NemoHermes rebuilds the context
+needed to understand what changed and where the user must step in.
 
-These terms appear throughout this document and in the code.
+With this recipe, you can ask NemoHermes questions such as:
 
+> **What changed on this project since yesterday?**
+>
+> **Which conversations need a decision, response, or follow-up from me?**
+>
+> **What are the most important items on my todo list today?**
+>
+> **What should I know about this person or project, and how does it connect to
+> my work?**
+
+NemoHermes turns the same inbound stream into one continuous workflow:
+
+```text
+direct messages · group chats · channels · email
+                         │
+                         ▼
+              living, source-backed work wiki
+                │                         │
+                ▼                         ▼
+       “What changed?”          “Where do I need to act?”
+                │                         │
+                └────────────┬────────────┘
+                             ▼
+                ranked attention recommendations
+                             ▲
+                             │
+              user pins · ignores · corrections
+```
+
+Answers show what changed, where the user is needed, why an item matters, and
+which sources support it. A message can update the wiki without becoming a todo;
+an urgent broadcast can rank below work the user has chosen.
+
+## Memory That Tracks Work, Not Just Preferences
+
+[Hermes built-in memory](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/features/memory.md)
+stores compact preferences, environment facts, and lessons across sessions.
+
+This recipe tracks the work around the person in evolving, linked pages for
+people, projects, goals, patterns, concepts, and current attention. Its
+scheduled writer currently maintains people and attention pages from message
+evidence and user corrections. It also keeps the evidence behind non-obvious
+claims and the user's corrections to message-derived obligations.
+
+> **Hermes built-in memory:** “What should the agent know about me?”
+>
+> **This recipe's operational memory:** “What changed around my work, what is
+> the evidence, and where does my attention matter now?”
+
+General personalization stays compact. Operational memory can grow with the
+work while remaining linked, source-backed, schema-checked, and repairable. The
+recipe complements Hermes memory and optional external memory providers.
+
+## Table of Contents
+
+- [From Message Overload to the Work That Needs You](#from-message-overload-to-the-work-that-needs-you)
+- [Memory That Tracks Work, Not Just Preferences](#memory-that-tracks-work-not-just-preferences)
+- [How It Works](#how-it-works)
+- [Project Structure](#project-structure)
+- [Quick Start](#quick-start)
+- [Install in NemoClaw](#install-in-nemoclaw)
+- [Configuration](#configuration)
+- [API and Module Reference](#api-and-module-reference)
+- [Scheduled Operation](#scheduled-operation)
+- [Connect Messaging Providers](#connect-messaging-providers)
+- [Data Lifecycle and Privacy](#data-lifecycle-and-privacy)
+- [Verification](#verification)
+- [Troubleshooting and FAQ](#troubleshooting-and-faq)
+- [Limitations and Support](#limitations-and-support)
+- [Recipe Metadata](#recipe-metadata)
+
+## How It Works
+
+Hermes built-in memory remains available for general identity, preferences,
+and learned facts. The recipe adds a workflow around three connected layers:
+
+1. **Inbound signals** bring new information from configured messaging
+   providers into a source-neutral format.
+2. **The work wiki** organizes durable context about people, projects, goals,
+   patterns, concepts, and current attention, with provenance and maintenance
+   rules. Its scheduled writer currently maintains people and attention pages,
+   and user-confirmed identity links connect the same person across providers.
+3. **The attention layer** uses that context to identify work that requires the
+   user's response, decision, or follow-up; recommend priorities; and preserve
+   the user's corrections over time.
+
+```text
+configured IM providers ──► normalized inbound signals
+                                      │
+                   ┌──────────────────┴─────────────────┐
+                   ▼                                    ▼
+        self-maintaining work wiki             attention recommendations
+ people · projects · goals · patterns        ranked obligations · todos
+                   │                                    ▲
+                   └──► sourced retrieval               │
+                                                        │
+                    user corrections ──► learned preferences
+
+Hermes built-in memory ──► general profile and cross-session context
+```
+
+The model does not write SQL. It returns a versioned JSON envelope;
+`apply_decisions.py` validates that envelope and applies it transactionally.
+The offline walkthrough substitutes recorded envelopes only at the two points
+where inference would otherwise be required. Everything downstream is the same
+code used by scheduled runs.
+
+### Core concepts
+
+<!-- markdownlint-disable MD013 -->
 | Term | Meaning |
 | --- | --- |
-| [Hermes](https://github.com/NousResearch/hermes-agent) | The agent runtime this recipe is packaged for. |
-| Profile | One Hermes configuration: a persona, a set of skills, and the user's own data. The [profile guide](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/profiles.md) describes the layout. |
-| Profile home | The directory holding one profile. The `HERMES_HOME` environment variable names it. |
-| Store | The SQLite database of messages, obligations, and an audit trail, at `$HERMES_HOME/workspace/ledger/state.db`. |
-| Memory | The Markdown pages describing the person, at `$HERMES_HOME/workspace/memory/`. |
-| Obligation | One message that needs an action, with a tier, a position, and its own history. |
-| Tier | The priority band an obligation sits in: `high`, `medium`, or `low`. |
-| Envelope | The JSON document a model turn returns: a list of decisions for the writer to apply. The recipe's recorded turns are envelopes. |
-| Addressing | Whether a message was aimed at the user: `direct`, `mentioned`, or `broadcast`. Ingest derives it from the recipient list, which is not stored. |
-| Pre-step | The script a scheduled job runs before its agent turn. Hermes calls it the `--script`; it decides what the turn sees, and whether there is one. |
-| Wake gate | The `{"wakeAgent": false}` line a pre-step prints when it found no work. Hermes reads only the last non-empty line, and skips the agent turn when that line is the gate. |
-| Intent gate | The rule that admits an obligation to the `high` tier only if the memory shows the user chose that work. External urgency alone does not qualify. |
-| Cascade | What happens to an un-gated row that ranked inside the top ten: it drops into the competition for `medium` rather than out of the list. |
-| Reservation | The rule that keeps `high` for gate-passing rows. If fewer pass than the cap allows, the tier stays smaller rather than being filled from the remainder. |
-| Gate verdict | The recorded per-message answer to the intent gate: whether the memory shows the user chose this work. Stored as `intent_gated`. |
+| Profile home | One Hermes profile directory, named by `HERMES_HOME` |
+| Hermes built-in memory | Bounded `USER.md` and `MEMORY.md` notes for general personalization and learned facts |
+| Work wiki | Schema-checked pages for people, projects, goals, patterns, concepts, and attention |
+| Provenance | Source, evidence date, and trust attached to non-obvious wiki claims |
+| Attention layer | Ranked recommendations for inbound work that may require the user's response, decision, or follow-up |
+| Obligation ledger | Message judgments, corrections, and audit history at `$HERMES_HOME/workspace/ledger/state.db` |
+| Obligation | A source message that still needs a response or action |
+| Intent gate | Proof in memory that the user chose the work; required for `high` |
+| Wake gate | The last non-empty selector line that tells Hermes not to call the model |
+| Envelope | Versioned JSON containing model decisions for the transactional writer |
+<!-- markdownlint-enable MD013 -->
 
-## Why it exists
+## Project Structure
 
-A personal assistant is only useful if it remembers one person accurately: who
-they work with, what they are accountable for, and what they have already
-decided. Hermes's built-in memory holds that as free-form notes in `MEMORY.md`
-and `USER.md`, under a fixed character budget. Nothing indexes a note, links it
-to related notes, ages it, or repairs it. As the budget fills, the agent is
-asked to consolidate by hand, and nothing detects a note that has quietly
-drifted out of date. Hermes also ships optional external memory providers; this
-recipe requires none of them, and keeps its own record local under a schema it
-can check.
+Paths below are relative to this recipe directory.
 
-A second kind of record is not a fact but a judgment about a message that
-another system owns. Examples: this message needs a reply, it ranks third this
-week, it is snoozed until Thursday, it was demoted because the user overrode
-the ranking twice. A mailbox has no field for a judgment like that. Writing one
-back into the mailbox would change the user's real data to store the
-assistant's opinion.
+<!-- markdownlint-disable MD013 -->
+```text
+memory-driven-chief-of-staff/
+├── README.md                         # Start here: setup, operation, and API contract
+├── profile/
+│   ├── distribution.yaml            # Version, Hermes requirement, owned paths
+│   ├── SOUL.md                       # Chief-of-staff persona and response boundary
+│   ├── schema.md                     # Memory page types, provenance, decay, ceilings
+│   ├── seed/                         # Initial index and attention pages for a new memory
+│   ├── scripts/
+│   │   ├── schema.sql                # Current v5 SQLite store schema
+│   │   ├── schema-v1.sql             # Frozen schemas used by migration tests
+│   │   ├── schema-v2.sql
+│   │   ├── schema-v3.sql
+│   │   ├── schema-v4.sql
+│   │   ├── _db.py                    # Profile-home, connection, and transaction boundary
+│   │   ├── identity.py               # Cross-provider identity relation resolver
+│   │   ├── link_identity.py          # User command for identity confirmations
+│   │   ├── normalize.py              # Source payloads to source-neutral item rows
+│   │   ├── ingest_graph.py           # Optional read-only Outlook mailbox collector
+│   │   ├── ingest_slack.py           # Optional read-only Slack collector
+│   │   ├── select_intake.py          # Intake batch selector and wake gate
+│   │   ├── select_review.py          # Review batch selector and wake gate
+│   │   ├── select_memory.py          # Evidence selector for scheduled wiki writing
+│   │   ├── apply_decisions.py        # Validates and commits agent envelopes
+│   │   ├── ranking.py                # Deterministic cap, reservation, and cascade
+│   │   ├── correct.py                # User pin, ignore, and unignore writer
+│   │   ├── walkthrough.py            # Offline end-to-end entry point
+│   │   ├── retention.py              # Scheduled message-body clearing
+│   │   ├── exclusions.py             # Sender, domain, and channel filtering
+│   │   ├── export_store.py           # Complete Markdown and JSON export
+│   │   ├── reset.py                  # Store, memory, and policy reset
+│   │   ├── migrate.py                # Forward-only store migration
+│   │   ├── memory_check.py           # Deterministic memory invariant checker
+│   │   └── tests/                    # 14 direct-execution unittest modules
+│   └── skills/
+│       ├── inbound-judging/          # New-message judgment instructions
+│       ├── obligation-review/        # Scheduled re-judgment instructions
+│       ├── memory-writing/            # Evidence-grounded people and attention pages
+│       ├── memory-repair/            # Safe invariant repair instructions
+│       ├── memory-consolidation/     # Bounded compaction instructions
+│       └── preference-update/        # Repeated-correction learning instructions
+├── fixtures/
+│   ├── README.md                     # Fixture schema, controls, and provenance
+│   ├── graph_messages.json           # Five synthetic Graph-shaped messages
+│   ├── slack_messages.json           # Three synthetic Slack-shaped messages
+│   ├── envelopes/intake.json         # Recorded intake model turn
+│   └── memory/                       # Synthetic seed memory for the walkthrough
+├── providers/
+│   ├── graph-user.yaml               # Read-only delegated Graph mailbox policy
+│   └── slack-user.yaml               # Read-only Slack endpoint and credential policy
+├── scripts/
+│   ├── install.sh                    # Sandbox: install profile and register jobs
+│   ├── register-jobs.sh              # Sandbox: idempotent Hermes cron registration
+│   ├── require-encrypted-storage.sh  # Shared connector storage prerequisite
+│   ├── require-linux.sh              # Shared scheduled-runtime platform check
+│   ├── setup-graph.sh                # Host: authorize and attach Outlook mailbox access
+│   ├── setup-slack.sh                # Host: authorize and attach rotating Slack token
+│   └── validate-provider-profile.sh  # Host: fail-closed provider policy validation
+└── docs/
+    ├── data-lifecycle.md             # Retention, exclusions, export, reset, migration
+    ├── encrypted-storage.md          # Required storage-encryption checks
+    ├── set-up-graph.md               # Full Outlook mailbox authorization walkthrough
+    ├── set-up-slack.md               # Full Slack authorization walkthrough
+    └── slack_app_manifest.json       # User-scoped Slack app manifest
+```
+<!-- markdownlint-enable MD013 -->
 
-The clearest consequence is how the recipe treats a message that announces its
-own urgency. A message whose subject reads `URGENT: expense policy
-attestation closes Friday`, matching nothing the person chose to work on, is
-capped at the middle tier. A quieter request that maps to
-their stated priorities is not. A ranking with no memory behind it cannot tell
-those two apart.
+### Dependencies
 
-## What is in this recipe
+<!-- markdownlint-disable MD013 -->
+| Dependency source | Path | Purpose |
+| --- | --- | --- |
+| Python package manifest | None | All Python modules use the standard library |
+| Recipe manifest | `profile/distribution.yaml` | Pins recipe version and Hermes 0.19.0+ |
+| SQLite schema | `profile/scripts/schema.sql` | Defines application state schema v5 |
+| Outlook provider policy | `providers/graph-user.yaml` | Declares the recipe's intended read-only delegated `graph.microsoft.com` boundary |
+| Slack provider policy | `providers/slack-user.yaml` | Declares the recipe's intended read-only `slack.com` boundary |
+<!-- markdownlint-enable MD013 -->
 
-| Path | What it is |
-| --- | --- |
-| `profile/distribution.yaml` | The manifest: what an install replaces, and what it leaves alone |
-| `profile/SOUL.md` | The persona, including the rule that answers come from the memory or not at all |
-| `profile/schema.md` | The memory contract: six page types, index rules, provenance, decay, growth ceilings |
-| `profile/scripts/schema.sql` | The store: items, obligations, an append-only audit trail, and source cursors |
-| `profile/scripts/ranking.py` | Cap-and-cascade tier assignment, deterministic |
-| `profile/scripts/memory_check.py` | Invariant detection over the memory, deterministic |
-| `profile/scripts/preferences.py` | Correction counting against a fixed threshold |
-| `profile/scripts/apply_decisions.py` | Applies model decisions; the model returns an envelope and never writes SQL |
-| `profile/scripts/migrate.py` | Schema versioning, forward-only, v1 through v5. Each step is idempotent; v5 rebuilds `items` to trade a hardcoded source list for a foreign key, and refuses rather than completing if the copy would lose a row |
-| `profile/scripts/normalize.py` | Source payloads to store rows, kept separate from the network calls |
-| `profile/scripts/_db.py` | Connection and transaction boundary |
-| `profile/scripts/correct.py` | The user's writer: pins, ignores, and the only source of `actor='user'` events |
-| `profile/scripts/identity.py` | Which identities are one person: pairwise answers, resolved with a disjoint set |
-| `profile/scripts/link_identity.py` | The user's other writer, and the only thing that answers "are these the same person?" |
-| `profile/scripts/load_fixtures.py` | Replays the fixtures through the real ingest path |
-| `profile/scripts/walkthrough.py` | The fixture walkthrough, end to end, with no credentials and no model |
-| `profile/scripts/select_intake.py` | The intake job's pre-step: what to judge, and whether to wake the model at all |
-| `profile/scripts/ingest_graph.py` | The mailbox collector: a delta synchronisation, resumable, with deletions reconciled |
-| `profile/scripts/ingest_slack.py` | The Slack collector: bounded conversation coverage, per-thread watermarks |
-| `profile/scripts/select_review.py` | The review job's pre-step: the stalest open obligations, oldest review first |
-| `profile/scripts/select_memory.py` | The memory-writing job's pre-step: recurring correspondents, and whether the attention pages have gone stale |
-| `profile/scripts/retention.py` | The retention job: clears message bodies past the window, keeps the record |
-| `profile/scripts/exclusions.py` | Senders, domains and channels that are never written, applied in `insert_items` |
-| `profile/scripts/export_store.py` | Writes the whole store and memory out as Markdown beside JSON |
-| `profile/scripts/reset.py` | Removes the store, the memory and the learned policy together |
-| `profile/seed/` | The pages a fresh memory starts from — copied in if missing, never overwritten |
-| `scripts/install.sh` | Installs the profile, inherits the runtime's model config, registers the jobs |
-| `scripts/register-jobs.sh` | Registers the seven scheduled jobs through the cron CLI. Re-runnable |
-| `profile/skills/` | Six skills: judging, review, memory writing, repair, consolidation, preference update. Retention needs none — it clears bodies and never wakes the agent |
-| `fixtures/` | Eight synthetic messages, a seed memory, and one recorded model turn |
+## Quick Start
 
-Slack is connected through `scripts/setup-slack.sh` and a mailbox through
-`scripts/setup-graph.sh`. Either can be set up alone; with neither, the
-scheduled jobs judge and re-judge whatever the store already holds.
+This offline walkthrough needs only Python 3.10+ on macOS, Linux, or WSL.
 
-## Requirements
+### 1. Clone and enter the recipe
 
-- Python 3.10 or newer. Nothing else is needed for the fixture path.
-- The fixture path — everything under [Try it](#try-it) and
-  [Verify](#verify) — runs on Linux, macOS, or Windows under Windows Subsystem
-  for Linux. Every command is written for a POSIX shell.
-- **The scheduled path is Linux only**, including WSL. All six shipped skills
-  declare `platforms: [linux]`, and Hermes refuses to load a skill outside its
-  declared platforms. On macOS the jobs would still fire and the model would
-  still be called — with no skill attached and a "skill not found" notice in
-  its prompt. Registering them there buys a scheduled expense and no
-  assistant.
-- No credentials for the fixture path. The scheduled path is different: a
-  woken job runs an agent turn, so the profile it fires under needs a model it
-  can reach and a credential of its own. The installer carries over the model
-  settings and never a key, because a key is not a thing to copy — you set one
-  on the new profile with `hermes -p <profile> config set model.api_key`. It is
-  not inherited: a profile without one sends the literal placeholder
-  `no-key-required`, so every scheduled job would fail to authenticate. The
-  installer stops before registering any job when either the model or the
-  credential is missing.
+```bash
+git clone https://github.com/NVIDIA/nemoclaw-community.git
+cd nemoclaw-community/examples/recipes/nvidia/memory-driven-chief-of-staff
+```
 
-Nothing in the fixture path needs Hermes. Installing the profile and running
-it on a schedule does: `profile/distribution.yaml` declares
-`hermes_requires: ">=0.19.0"`. On 0.19.x the manifest's `distribution_owned`
-list is validated but not yet honored by the copy — the path-aware allowlist
-first shipped in 0.20.0 — which changes nothing for this recipe, because what
-it ships and what it declares are the same set, and a test keeps them so. The
-same 0.19.0 figure under [Where state lives](#where-state-lives) records the
-version the persistence claim was measured against.
-
-## Try it
-
-Run the walkthrough from the recipe root. It prints seven steps and exits `0`.
-From the repository root:
+If you are already at the repository root, only run the second command.
 
 ```bash
 cd examples/recipes/nvidia/memory-driven-chief-of-staff
-export HERMES_HOME=$(mktemp -d)
+```
+
+### 2. Create isolated local state and run the walkthrough
+
+```bash
+export RECIPE_TMP_HOME="$(mktemp -d)"
+export HERMES_HOME="$RECIPE_TMP_HOME"
 python3 profile/scripts/walkthrough.py --fixtures fixtures
 ```
 
-The seven steps:
+The command prints seven stages and exits with status `0`. The important
+outcomes are:
 
-1. **Collect.** The fixtures go through the same normalization and writer path
-   a connector will use. Nothing is judged yet. This is what ingestion alone
-   produces.
-2. **Judge.** The first recorded turn (`fixtures/envelopes/intake.json`) is
-   applied by the real writer. Three rows pass the intent gate, so the `high`
-   tier holds three rather than its maximum of ten. The tier is never padded.
-   The mandatory expense-attestation deadline ranks fourth and is capped at
-   `medium`, because the recorded verdict says the user never chose that work.
-   The step ends by re-running the shipped ranking over the same rows with the
-   gate verdicts withheld: the `high` tier then holds none, which is what the
-   reservation buys.
-3. **Correct.** The user pins a gate-passing row to the bottom tier. It leaves
-   the `high`
-   tier, because a pin outranks what the memory inferred, and the whole open
-   list is re-ranked around it.
-4. **Correct again.** A row is ignored outright and leaves the open list.
-5. **Re-judge.** The second recorded turn, written inline in the script rather
-   than in `fixtures/`, tries to restore the pinned row and cannot. An agent
-   pass never clears a user's pin.
-6. **Learn.** The recorded corrections are counted against the threshold that a
-   preference rule requires. Two corrections do not reach the threshold of
-   three. The walkthrough reports that rather than inventing a third.
-7. **Verify.** The memory is checked against its own schema. A required field
-   is then removed on purpose, so the check is seen to fail as well as pass,
-   and restored.
+- eight messages are ingested and two are skipped;
+- six obligations remain open;
+- exactly three memory-gated obligations enter `high`;
+- an urgent deadline unrelated to the user's chosen work stays in `medium`;
+- a user pin and ignore survive a later recorded review;
+- the memory checker is shown succeeding and failing on a deliberate defect.
 
-The two recorded turns are the only parts standing in for inference.
-Everything downstream of them is the shipped code. One consequence is worth
-being explicit about: the gate verdict on each row is part of the recorded
-intake turn, because deciding it means reading the memory, which needs a model.
-Deleting the seed memory therefore does not change the tiers this run
-prints. It does change step 7, which checks the memory itself. What
-the run does show is everything those verdicts feed into — the caps, the
-reservation, the cascade, the writer, the correction path and the re-ranking —
-and the contrast printed in step 2. For the ranking behavior itself, the
-evidence is `tests/test_ranking.py` and `tests/test_apply_decisions.py`, which
-drive the gate flags directly. The walkthrough states which parts are recorded
-on screen, and [`fixtures/README.md`](fixtures/README.md) states it again.
+### 3. Prove fixture ingestion is idempotent
 
-To watch ingestion by itself, and to confirm that it is idempotent, use a
-profile home the walkthrough has not already filled:
+Use a new profile home because the walkthrough has already populated the first
+one.
 
 ```bash
-export HERMES_HOME=$(mktemp -d)
+export RECIPE_TMP_HOME_2="$(mktemp -d)"
+export HERMES_HOME="$RECIPE_TMP_HOME_2"
 python3 profile/scripts/load_fixtures.py --fixtures fixtures
 python3 profile/scripts/load_fixtures.py --fixtures fixtures
 ```
 
-The first run reports `"added": 8` and the second reports `"added": 0`, because
-intake is keyed on the source's own identifier. Both runs must use the same
-profile home, or the second run has nothing to recognize.
+The first loader run reports `"added": 8`; the second reports `"added": 0`.
 
-The individual pieces are callable on their own, from the recipe root:
+### 4. Inspect or correct state
 
-```bash
-python3 profile/scripts/memory_check.py                     # invariants
-python3 profile/scripts/correct.py priority <source_id> low # pin a tier
-python3 profile/scripts/correct.py ignore <source_id>       # stop tracking
-python3 profile/scripts/correct.py unignore <source_id>     # track it again
-```
-
-`correct.py` needs `HERMES_HOME` to name an existing profile home, and creates
-or migrates the store there if it is absent. `memory_check.py` is the
-exception: with no `HERMES_HOME` it falls back to `workspace/memory` under the
-current directory, and it needs no store at all. Neither creates the profile
-home itself.
-
-A correction applies only where it means something, so on a populated store:
-
-- All three refuse an obligation that is `done` and exit `3`. A completed
-  obligation is history, and rewriting it would turn finished work into a
-  standing instruction.
-- `priority` also refuses an ignored row and exits `3`, printing the exact
-  `unignore` command that restores it, ready to copy. The walkthrough ignores
-  `msg-cc-only` in step 4, so a `priority` command against that row right
-  afterwards reaches this.
-- Repeating a correction that is already in force changes nothing. It prints
-  `"changed": false` and exits `0`.
-- With no matching obligation, `correct.py` exits `3`. With `HERMES_HOME`
-  unset it exits `1` with an unhandled `RuntimeError` naming the variable, and
-  `memory_check.py` exits `2` reporting that it found no memory.
-
-## Verify
-
-Run the test suite from `profile/scripts`. It needs no network and no
-credentials. From the recipe root:
+Replace the placeholder with a source identifier printed by the walkthrough.
 
 ```bash
-cd profile/scripts
-fail=0
-for t in tests/*.py; do python3 "$t" || fail=1; done
-echo "failed=$fail"
-cd ../..
-test "$fail" -eq 0
+python3 profile/scripts/memory_check.py
+python3 profile/scripts/correct.py priority msg-priorities-match low
+python3 profile/scripts/correct.py ignore msg-cc-only
+python3 profile/scripts/correct.py unignore msg-cc-only
 ```
 
-Expected result: every file ends with `OK`, the fourteen files report 603 tests in
-total, and the last line is `failed=0`. Do not use `|| break` here; a `for`
-loop reports the status of its last command, so a failing test would still
-leave the loop exiting `0`.
+Repeated corrections are no-ops. Corrections against completed or incompatible
+rows exit with status `3` and explain the required state transition.
 
-| What it covers | Where |
-| --- | --- |
-| Schema versioning | `tests/test_migration.py` |
-| Invariant detection, idempotency, compaction detection | `tests/test_memory_check.py` |
-| Concurrency, crash recovery, reinstall survival, profile-home resolution, installation, failed-write cause reporting, skill-path anchoring and existence | `tests/test_durability.py` |
-| Bounded ranking, including user pins | `tests/test_ranking.py` |
-| Preference counting | `tests/test_preferences.py` |
-| Source normalization | `tests/test_normalize.py` |
-| Writer behavior, audit trail, caps across batches, correction idempotency, correction state transitions, displaced-row audit | `tests/test_apply_decisions.py` |
-| The walkthrough, and its central claims | `tests/test_walkthrough.py` |
-| Selector output, the wake gate, and the scheduler contract | `tests/test_selectors.py` |
-| Identity across connectors: composing answers, refusing to guess, and the user's command | `tests/test_identity.py` |
-| What the memory job hands the agent: who is worth a page, stable identity across namesakes and renames, quiet days costing nothing, and corrections counted once | `tests/test_select_memory.py` |
-| Retention, exclusion, export and reset | `tests/test_lifecycle.py` |
-| The Slack collector: watermarks, partial failure, scope probing, thread discovery and rotation, the credential never reaching a stream, and the lifecycle controls applying to what it writes | `tests/test_ingest_slack.py` |
-| The mailbox collector: delta synchronisation, resumption, deletions reconciled, the window bound, and the credential never reaching a stream | `tests/test_ingest_graph.py` |
+## Install in NemoClaw
 
-Four points are worth calling out.
+The scheduled path is Linux-only and requires a running NemoHermes sandbox.
 
-- `TestNoSourceMutation` in `tests/test_durability.py` scans every module for
-  the common shapes of an HTTP write — `requests.post`, a `.patch(` call, and
-  their siblings — and a companion test proves the scan fires on real
-  examples, including `urlopen(url, data=…)` and a `subprocess` call to
-  `curl`. Read it as a tripwire rather than a proof: it matches call shapes, so
-  a write spelled in some further way could still pass it. What actually holds
-  the property is enforced twice on the connector path: the provider profile
-  declares `slack.com` at `access: read-only` with `enforcement: enforce`, so
-  a write is refused at the egress boundary before any test runs, and the
-  collector reaches no other host.
-- `test_nothing_this_example_ships_lands_on_a_user_owned_path`, also in
-  `tests/test_durability.py`, asserts that nothing this recipe ships occupies a
-  user-owned name, and that the user-owned and distribution-owned sets stay
-  disjoint. Both directions fail, and neither is loud. Hermes never installs a
-  shipped path whose top-level name is user-owned, so a shipped `workspace`
-  would never land at all; and a store placed under a distribution-owned path
-  is removed and replaced on every update, because that is what installing a
-  distribution means.
-- `tests/test_walkthrough.py` runs the walkthrough and asserts its central
-  claims against the store the run produced: the gate bounding the top tier,
-  loud urgency staying out of it, the pin deciding the tier and surviving a
-  later pass, and both corrections being attributed to the user.
-- Several of its tests assert against the printed output instead, because what
-  is printed is itself a claim. They check six of them:
-  - the run names which part is recorded;
-  - it discloses both recorded turns;
-  - it says the gate verdict is recorded;
-  - it scopes the seed-memory claim to the tiers;
-  - it shows the top tier emptying without the gate;
-  - the memory check is seen to fail as well as pass.
+The host and sandbox have different tools. Keep this boundary visible while
+following the steps below:
 
-  It does not assert every line the script prints.
+<!-- markdownlint-disable MD013 -->
+| Phase | Run it on | CLI available there |
+| --- | --- | --- |
+| Check the sandbox, upload files, and configure messaging providers | Linux host | `nemohermes`, `openshell` |
+| Run `scripts/install.sh`, configure the Hermes profile, and manage jobs | Inside the NemoHermes sandbox | `hermes` |
+<!-- markdownlint-enable MD013 -->
 
-## Running it on a schedule
+`scripts/install.sh` is never a host command. The host is not expected to have
+`hermes` on `PATH`.
 
-Everything above runs by hand. To have it run on its own, install the profile
-into a Hermes runtime and register the jobs:
+### 1. Confirm and inspect a Hermes sandbox from the host
+
+If NemoClaw is not installed, follow the upstream
+[NemoClaw setup guide](https://github.com/NVIDIA/NemoClaw) and select Hermes,
+an inference provider, and a model during onboarding.
 
 ```bash
-scripts/install.sh
+nemohermes my-hermes status
+openshell sandbox provider list my-hermes
 ```
 
-From the recipe root. It does three things: `hermes profile install` for the
-distribution, a carry-over of the model settings so the new profile inherits a
-model, and `scripts/register-jobs.sh` for the schedule. `PROFILE_NAME`
-overrides the profile it installs into.
+Replace `my-hermes` in this section with your registered sandbox name.
 
-The carry-over is three named settings — `model.default`, `model.provider` and
-`model.base_url` — transferred through `hermes config set`. No file is copied
-and no key is: the `model:` block is documented to hold an inline `api_key`,
-and a copy would write that key into a second file. Set the key on the new
-profile instead. Each transfer fails closed and is read back off the target
-profile afterwards, so a setting that could not be written — or that reports
-success without sticking — ends the run rather than leaving a profile that
-took some of its configuration. The installer then checks both — that a model
-resolves and that a credential is present — and exits before registering any
-job if either is missing, rather than scheduling seven jobs that would each
-fail. If your endpoint genuinely needs no key, pass `ALLOW_NO_API_KEY=1` to
-say so.
+Before starting scheduled intake, inspect every provider already attached to
+the sandbox:
 
-Re-running it is safe: the registration looks each job up by name and edits it
-rather than adding another copy.
+```bash
+openshell provider get "<provider-name>"
+```
 
-Seven jobs are registered:
+Do not continue if an unrelated provider exposes `MS_GRAPH_ACCESS_TOKEN`.
+The current Graph collector can see the injected environment value but cannot
+identify which attached provider supplied it. Use a dedicated sandbox or
+detach the conflicting provider before installing or starting the scheduled
+runtime.
+
+### 2. Upload the recipe from the host
+
+Run this from the cloned `nemoclaw-community` repository root.
+
+```bash
+nemohermes sandbox upload my-hermes \
+  examples/recipes/nvidia/memory-driven-chief-of-staff \
+  /sandbox/memory-driven-chief-of-staff
+nemohermes my-hermes connect
+```
+
+The upload is required: the sandbox cannot see the host checkout directly.
+After `connect` opens a shell, the remaining commands in this subsection run
+**inside the sandbox**.
+
+### 3. Install the profile and jobs inside the sandbox
+
+```bash
+cd /sandbox/memory-driven-chief-of-staff
+export PROFILE_NAME="memory-driven-chief-of-staff"
+bash scripts/install.sh
+```
+
+The installer creates the target profile and copies only `model.default`,
+`model.provider`, and `model.base_url`. It never copies a credential. On a first
+run without a target-profile credential, it
+stops before registering jobs.
+
+In a NemoClaw-managed sandbox, set the non-secret OpenShell rewrite sentinel,
+then rerun the installer:
+
+```bash
+hermes -p "$PROFILE_NAME" config set model.api_key \
+  "sk-OPENSHELL-PROXY-REWRITE"
+bash scripts/install.sh
+```
+
+The sentinel is not an upstream API key. Hermes requires an `sk-` value before
+it sends a request, and OpenShell removes this marker and injects the managed
+inference credential at the egress boundary. Do not copy a real inference key
+into the recipe profile on the supported NemoClaw path.
+
+Use the explicit opt-out only for a genuinely keyless, non-NemoClaw endpoint;
+it is not a substitute for the rewrite sentinel.
+
+```bash
+ALLOW_NO_API_KEY=1 bash scripts/install.sh
+```
+
+### 4. Start and verify the scheduled runtime inside the sandbox
+
+```bash
+hermes -p "$PROFILE_NAME" gateway install
+hermes -p "$PROFILE_NAME" gateway start
+hermes -p "$PROFILE_NAME" cron status
+```
+
+On WSL without systemd, keep the gateway in the foreground instead.
+
+```bash
+hermes -p "$PROFILE_NAME" gateway run
+```
+
+At this point the schedule works over any rows already in the store. Slack and
+Outlook are independent and optional; each unconfigured collector exits
+successfully and reports that state.
+
+## Configuration
+
+### Environment variables
+
+<!-- markdownlint-disable MD013 -->
+| Name | Location | Required | Default / valid range | Meaning |
+| --- | --- | --- | --- | --- |
+| `HERMES_HOME` | Offline or sandbox | Yes for stateful scripts | No default | Existing Hermes profile home; state is written below `workspace/` |
+| `PROFILE_NAME` | Sandbox installer | No | `memory-driven-chief-of-staff` | Target profile for installation and cron registration |
+| `ALLOW_NO_API_KEY` | Sandbox installer | No | `0`; set to `1` only for a genuinely keyless non-NemoClaw endpoint | Explicit credential-check bypass; do not use for a managed NemoClaw route |
+| `INTAKE_SLICE` | Scheduled runtime | No | `25`; integer `1..200` | Maximum pending rows given to an intake turn |
+| `REVIEW_BATCH` | Scheduled runtime | No | `15`; integer `1..200` | Maximum open rows given to a review turn |
+| `INTAKE_SLACK_BUDGET` | Scheduled runtime | No | `10`; integer `1..200` | Maximum Slack history calls per intake tick |
+| `MEMORY_WINDOW_DAYS` | Scheduled runtime | No | `30`; integer `1..3650` | Evidence window used by the memory-writing selector |
+| `RETENTION_DAYS` | Scheduled runtime | No | `30`; integer `1..3650` | Age at which stored message bodies are cleared |
+| `SLACK_USER_TOKEN` | OpenShell provider | Injected | Rotating user token | Collector credential; do not set manually on the supported path |
+| `MS_GRAPH_ACCESS_TOKEN` | OpenShell provider | Injected | Rotating delegated token | Outlook collector credential; the collector cannot currently attest which attached provider supplied it |
+| `GRAPH_BACKFILL_DAYS` | Scheduled runtime | No | `7`; integer `1..3650` | Initial Outlook mailbox synchronization window |
+| `GRAPH_CLIENT_ID` | Linux host Outlook setup | Yes | No default | Microsoft Entra application client ID |
+| `GRAPH_TENANT_ID` | Linux host Outlook setup | No | `common` | Microsoft Entra directory tenant ID |
+| `GRAPH_PROVIDER_NAME` | Linux host Outlook setup | No | `memory-driven-cos-graph` | Name used when creating the recipe provider; it does not resolve a conflicting attached provider that exposes the same credential key |
+| `SANDBOX_STORAGE_PATH` | Linux host provider setup | Yes | No default | Host path whose encryption status protects sandbox storage |
+| `OPENSHELL_SANDBOX_NAME` | Linux host provider setup | No | Falls back to `SANDBOX_NAME`, then `hermes` | Sandbox receiving the provider |
+| `SANDBOX_NAME` | Linux host provider setup | No | `hermes` | Compatibility fallback for the sandbox name |
+| `SLACK_PROVIDER_NAME` | Linux host Slack setup | No | `memory-driven-cos-slack-user` | OpenShell provider name |
+| `STORE_ENCRYPTION_ACKNOWLEDGED` | Linux host provider setup | No | `0`; unattended confirmation is `1` | Acknowledges an encryption result the script cannot prove |
+| `FORCE_REAUTH` | Linux host provider setup | No | `0`; replacement is `1` | Replaces an attached rotating provider credential |
+<!-- markdownlint-enable MD013 -->
+
+Scheduled environment variables must reach the target profile. Persist a value
+through the profile environment file returned by Hermes rather than relying on
+a temporary shell export. See [docs/data-lifecycle.md](docs/data-lifecycle.md)
+for retention and memory settings, and
+[docs/set-up-graph.md](docs/set-up-graph.md) for Outlook backfill.
+
+### Profile configuration
+
+The source of truth for installed files is `profile/distribution.yaml`.
+A conceptual target profile model block has this shape; use Hermes commands to
+set values rather than editing the file directly.
+
+```yaml
+model:
+  default: "<provider/model>"
+  provider: "<provider>"
+  base_url: "<https-endpoint>"
+  api_key: sk-OPENSHELL-PROXY-REWRITE
+```
+
+The `api_key` value above is the required non-secret routing marker for a
+NemoClaw-managed Hermes profile. OpenShell replaces it at egress; it is not a
+credential to rotate or hide.
+
+### Public Slack channels
+
+Direct messages and group DMs are discovered automatically. Public channels
+are read only when explicitly listed at
+`$HERMES_HOME/workspace/slack_channels.json`.
+
+```json
+{
+  "channels": ["C0TEAM0001", "C0PROJECT2"]
+}
+```
+
+### Ingest exclusions
+
+Create `$HERMES_HOME/workspace/exclusions.json` to prevent matching rows from
+ever reaching the store. Matching is exact and case-insensitive; glob patterns
+are not supported. Invalid or unknown fields fail closed.
+
+```json
+{
+  "senders": ["recruiter@agency.example", "U01RECRUIT"],
+  "domains": ["agency.example"],
+  "channels": ["C0SALARY01", "D0PRIVATE1"]
+}
+```
+
+## API and Module Reference
+
+### Decision envelope
+
+`apply_decisions.py` reads one JSON document from standard input. The supported
+decisions are `CREATE`, `KEEP_OPEN`, `MARK_DONE`, and `SKIP`. A create or keep
+decision requires a rank, title, and intent-gate verdict.
+
+```json
+{
+  "version": 1,
+  "pass": "intake",
+  "decisions": [
+    {
+      "source_id": "msg-priorities-match",
+      "decision": "CREATE",
+      "rank": 1,
+      "intent_gated": true,
+      "title": "Review the migration plan",
+      "context": "Matches a current priority",
+      "urgency_reason": "Requested before the planning review",
+      "kind": "response",
+      "est_effort": "minutes"
+    },
+    {
+      "source_id": "msg-automated-noise",
+      "decision": "SKIP"
+    }
+  ],
+  "cursor": {
+    "source": "email",
+    "scope": "inbox",
+    "value": "synthetic-cursor"
+  }
+}
+```
+
+Run the writer against a saved envelope from the recipe root.
+
+```bash
+python3 profile/scripts/apply_decisions.py < /path/to/envelope.json
+```
+
+Valid optional values are:
+
+```yaml
+kind:
+  - response
+  - action
+  - null
+est_effort:
+  - minutes
+  - hours
+  - day
+  - multi_day
+  - null
+```
+
+### Module contracts
+
+<!-- markdownlint-disable MD013 -->
+| Module | Reads | Writes / returns |
+| --- | --- | --- |
+| `normalize.py` | Graph- or Slack-shaped source objects | Source-neutral item dictionaries; recipient lists become one addressing value |
+| `_db.py` | `HERMES_HOME`, `schema.sql` | Validated profile path, SQLite connection, transactions, automatic migration |
+| `ingest_graph.py` | Delegated Graph token and inbox delta | New Outlook message rows, resumable cursor state, and source-removal tombstones |
+| `ingest_slack.py` | Rotating Slack token and selected conversations | New Slack rows and per-conversation watermarks |
+| `select_intake.py` | Collectors and pending rows | JSON batch or a final wake-gate line |
+| `select_review.py` | Open obligations | Oldest-review-first JSON batch or a final wake-gate line |
+| `select_memory.py` | Message evidence, open obligations, and user corrections | Bounded memory-writing evidence or a final wake-gate line |
+| `apply_decisions.py` | Versioned JSON envelope on standard input | Items, obligations, cursor, and append-only events in one transaction |
+| `correct.py` | One user command | Pin/ignore state plus `actor='user'` audit events |
+| `identity.py` | Stored pairwise identity answers | Resolved identity groups, candidates, and conflicts |
+| `link_identity.py` | User confirmation or rejection | Durable relationship between two provider identities |
+| `ranking.py` | Open obligations and gate verdicts | Deterministic bounded tiers and positions |
+| `preferences.py` | User correction events | Bounded preference policy after the fixed threshold is met |
+| `memory_check.py` | Memory Markdown pages | Diagnostics and exit status; no model call |
+| `retention.py` | Store and `RETENTION_DAYS` | Clears expired bodies; keeps metadata, obligations, and history |
+| `export_store.py` | Store, memory, and policy | Complete Markdown and JSON export directory |
+| `reset.py` | Profile workspace | Removes store, memory, policy, and collection state after confirmation |
+| `migrate.py` | Existing store | Forward-only schema migration or compatibility check |
+<!-- markdownlint-enable MD013 -->
+
+### Store and migration commands
+
+```bash
+python3 profile/scripts/retention.py --dry-run
+python3 profile/scripts/retention.py
+python3 profile/scripts/export_store.py --to /path/to/export
+python3 profile/scripts/migrate.py --check
+python3 profile/scripts/migrate.py
+python3 profile/scripts/reset.py --dry-run
+python3 profile/scripts/reset.py --yes
+```
+
+`reset.py --yes` is destructive. Stop or pause the schedule first, export if
+needed, detach and revoke external credentials separately, and verify the
+profile named by `HERMES_HOME` before running it.
+
+## Scheduled Operation
+
+`scripts/register-jobs.sh` is idempotent: it edits jobs with matching names
+instead of creating duplicates.
 
 | Job | Schedule | Pre-step | Skill |
 | --- | --- | --- | --- |
@@ -355,499 +595,439 @@ Seven jobs are registered:
 | memory consolidation | daily 04:00 | — | `memory-consolidation` |
 | preference update | daily 04:30 | — | `preference-update` |
 
-**Where the memory comes from.** Three of the memory jobs maintain one and
-none of them creates it: repair checks invariants, consolidation compacts
-pages past their ceiling, preference-update writes the policy. The
-memory-writing job is what fills the gap. `select_memory.py` does the
-counting — who has been in touch inside the window, how often, who already has
-a page, which attention pages are past their decay window — and the skill
-decides who is worth a page and what it says. `MEMORY_WINDOW_DAYS` moves the
-window, which matters on a first run against a store that already holds
-months of history.
+Intake, review, and memory writing run their selector before an agent turn. If
+no work is available, the selector's final non-empty line is the wake gate and
+Hermes skips inference. Retention never wakes the agent. Memory writing runs
+before repair and consolidation so every new page is checked and compacted in
+the same nightly sequence.
 
-That job is load-bearing rather than decorative. `ranking.py` reserves `high`
-for work the person has *chosen*, and only `attention/` and `goals/` can
-answer that. With an empty memory nothing reaches the top tier and the
-assistant is left measuring how loudly the outside world is asking, which is
-the thing it exists not to do. Measured on a real mailbox: 952 collected
-messages produced obligations that were all `medium` or `low`, because no page
-could gate one higher.
+### Persistence and reboot behavior
 
-It writes people and attention pages only, and `schema.md` now carries a
-table saying which page types have a writer at all — `projects/`,
-`patterns/`, `concepts/` and `event_triggers.md` do not yet, and a rule about
-a page nothing creates is a rule about a page somebody would keep by hand.
-Naming that is the point: the schema previously said ingest checked
-`event_triggers.md` against every incoming message, which no shipped job has
-ever done.
+Jobs live in `$HERMES_HOME/cron/jobs.json`. The distribution does not own the
+`cron` path, so profile updates leave job definitions and run history unchanged.
 
-`goals/` is the one absence that is a decision. It gates the ranking job's
-top tier alongside `attention/`, so a goal inferred from somebody's inbox
-promotes work they never chose. The job also declines to invent a priority:
-when the evidence supports none it writes the page saying so, because a
-guessed priority produces the same failure by the same route.
+Jobs survive a reboot, but resume automatically only when the gateway runs as a
+service. Hermes collapses missed recurring runs into one run over current state.
 
-**An idle tick costs nothing.** Each of the first two jobs runs its pre-step
-script first, then one agent turn over that script's output. When the script
-finds no work it prints `{"wakeAgent": false}` as its last line, and Hermes
-skips the agent entirely — no model call, no delivery. That last-line detail
-is the whole mechanism: Hermes reads only the final non-empty line of the
-script's output, so a gate printed anywhere else is ignored and the model
-wakes. A test asserts the gate exactly the way the scheduler parses it, rather
-than looking for the string somewhere in the output.
-
-The intake pre-step also runs whichever collectors are present. Both ship
-with the recipe, and each reports `{"unconfigured": true}` until its setup
-script has run — `scripts/setup-slack.sh` or `scripts/setup-graph.sh` —
-exiting zero so an idle tick still costs nothing. They run in the same tick
-and independently: a mailbox credential that has expired does not stop Slack
-being read, and neither can hold the tick open, because each is bounded in
-requests and in the time it may spend waiting. Either way the tick carries on
-with whatever the store already holds.
-
-**Registering is not starting.** Under the builtin scheduler the jobs fire
-only while a gateway is serving the profile, and starting one takes two steps
-on Linux:
+List or remove registered jobs inside the sandbox.
 
 ```bash
-hermes -p memory-driven-chief-of-staff gateway install  # once
-hermes -p memory-driven-chief-of-staff gateway start
-hermes -p memory-driven-chief-of-staff cron status
+hermes -p memory-driven-chief-of-staff cron list
+JOB_ID="<copy-an-id-from-the-list>"
+hermes -p memory-driven-chief-of-staff cron remove "$JOB_ID"
 ```
 
-`gateway start` fails with "Gateway service is not installed" until `gateway
-install` has run. Where no service manager is available — WSL without
-systemd — run it in the foreground instead: `hermes -p
-memory-driven-chief-of-staff gateway run`.
-
-`cron status` says plainly whether the scheduler is running, and lists the
-active jobs and the next run. A registered job on a profile with no running
-gateway does not tick and reports nothing. Two paths do fire without one:
-`hermes cron tick` runs anything due once and exits, and an external cron
-provider takes over from the in-process ticker.
-
-**The job store is not part of the distribution.** `distribution.yaml` does not
-declare `cron`. An update replaces what it does declare — `SOUL.md`,
-`schema.md`, `skills`, `scripts` and the manifest — and leaves the jobs and
-their run history alone. This is worth being deliberate about: `profile
-update` lists `cron/` among the directories it overwrites, and it leaves ours
-alone only because the manifest never claims it. Measured, not assumed: seven
-jobs registered, `hermes profile update` run on Hermes 0.19.0, seven jobs
-still there with the same ids. A test asserts the manifest never claims `cron`
-or `workspace`.
-
-To undo, remove the jobs individually. Deleting the profile removes its
-`workspace` too, which is where the store and the memory live; removing the
-jobs does not. `profile delete` prompts unless given `-y`:
+Deleting the profile also deletes its workspace, store, and memory.
 
 ```bash
-hermes -p memory-driven-chief-of-staff cron remove <job-id>
 hermes profile delete memory-driven-chief-of-staff
 ```
 
-## Where state lives
+## Connect Messaging Providers
 
-The store is at `$HERMES_HOME/workspace/ledger/state.db` and the memory is at
-`$HERMES_HOME/workspace/memory/`. Both sit under `workspace`, which a
-distribution install and update leave alone. That was measured rather than
-assumed: a row written there survived both `hermes profile install --force` and
-`hermes profile update` on Hermes 0.19.0.
+Slack and Microsoft Outlook are independent, optional inputs. Configure either
+one or both after installing the recipe. Each setup script runs on the
+**Linux host**, requires encrypted sandbox storage, and attaches a read-only
+OpenShell provider to the NemoHermes sandbox.
 
-Both directories are created with owner-only permissions (`0700`). That is a
-filesystem access control rather than encryption. It stops another account on
-the same machine from reading the store. It does nothing against anyone who can
-read the disk.
+### Slack
 
-Once a connector is attached, the store holds message subjects, senders, and
-bodies. Before that happens, this recipe requires either an encrypted volume
-underneath `$HERMES_HOME` or an application-level encryption design. That
-requirement is separate from credential custody, which belongs to the runtime's
-own credential handling — Hermes keeps provider credentials outside
-`workspace` — and never to the store.
+Slack setup is optional. Complete it only after placing the sandbox storage on
+an encrypted volume; owner-only permissions are access control, not encryption.
+See [docs/encrypted-storage.md](docs/encrypted-storage.md) first.
 
-## Privacy
-
-The fixture path reaches no network and reads no real account. The Slack
-collector does both, once you have configured it, and everything below is
-written for that case rather than for the fixtures.
-
-One reduction already ships, because it is part of the schema under review:
-recipient lists are never stored. Ingest reduces them to a single `addressing`
-value — `direct`, `mentioned`, or `broadcast` — so the store never holds a
-copy of who else was on a thread. `normalize.py` does this today, and
-`tests/test_normalize.py` asserts it.
-
-One thing the store does keep, and should be said plainly rather than found
-in the schema: **each row carries the sender's stable identity** — their mail
-address, or their Slack user id — in `sender_key`. It is there because a
-display name cannot identify anybody, and a memory page named after one is
-overwritten by the next person who shares it. It is not kept for any other
-purpose: nothing matches on it but the memory job, and it is one column both
-sources agree on rather than a per-source pair. An excluded sender's identity
-is not stored either, because exclusion is applied inside `insert_items` and
-nothing about them is written at all.
-
-**An upgraded store does not get this retroactively.** The value was never
-kept, and it cannot be recovered from a display name — deriving it that way is
-the mistake the field exists to prevent. So rows collected before the upgrade
-carry no identity, and the memory job does not guess at one: it counts them,
-reports the count as `messages_without_identity`, and writes nobody's page
-from them. Two things close the gap. Re-reading a message fills its identity
-in, so a rolling collection window keys the recent past within a window; and
-the job only looks thirty days back, so the gap is gone once the window has
-turned over. What is lost in between is that a person's pre-upgrade messages
-do not count toward whether they are worth a page — not that anything was
-attributed to the wrong person, which is the failure this refuses.
-
-Four controls over what is kept ship alongside it, and they were in place
-before the collector that fills the store was. They apply to real Slack
-messages exactly as they apply to the fixtures, because the collector writes
-through the same function every other writer does. The commands, the rules
-file and the exact boundaries are in
-[docs/data-lifecycle.md](docs/data-lifecycle.md); what follows is why they are
-drawn where they are.
-
-**Message bodies are cleared on a schedule.** `retention.py` runs daily and
-clears the text of anything past the window — thirty days by default,
-`RETENTION_DAYS` to change it. What stays is the record: sender, subject,
-timestamp, addressing, the obligation and its title, and every event with its
-actor. A month later you can still see that Dana asked about the cutover on the
-third, that it ranked high, and that you ignored it on the fifth. You cannot
-re-read Dana's words, which is the point. `body_cleared_at` marks a body that
-was cleared, so it is not confused with one that never existed.
-
-**Senders, domains and channels can be excluded at ingest.** Rules live in
-`workspace/exclusions.json` and are applied in `insert_items`, which is the one
-place every writer passes through — the fixture loader, the Slack collector,
-and anything added later — so an excluded message is never written by any of
-them. Filtering at display would leave the text on disk, which is no use to
-somebody excluding their doctor. A test drives the collector against a rule
-and asserts the row never appears, rather than reading the call chain and
-concluding it should not.
-
-**Everything can be exported and everything can be removed.**
-`export_store.py` writes the store and the memory as Markdown beside JSON —
-the first to read, the second to process — and omits nothing.
-`reset.py --yes` removes the store, the memory and the learned preference
-policy together, and reports each; a partial reset would answer the question
-wrongly. It also prints how to revoke the credential, which lives with the
-gateway rather than here, because somebody withdrawing consent wants both.
-
-Three things about the connectors themselves:
-
-- Attachments are not fetched. The collector stores a file-sharing message's
-  text and never requests the file behind it.
-- For Microsoft Graph, an item deleted at the source is tombstoned locally and
-  its body cleared at once. The delta query reports that a message left the
-  folder, which is not the same as reporting a deletion — filing it in Archive
-  reads identically — so the collector asks a second question, by
-  `internetMessageId`, and only a message the mailbox no longer holds anywhere
-  is tombstoned. If that question cannot be answered the round stops and the
-  next one asks again, rather than advancing past a removal it did not
-  resolve. If there is no identity to ask about — a row collected before the
-  connector stored one — the removal is left unresolved and counted, never
-  guessed: reading an absent identity as a deletion cleared the body of a
-  message that had only been filed away. The row stays: obligations and events hang off it, and removing it
-  would break the record of why something was ranked.
-- For Slack, that guarantee is not available. A deleted message stops appearing
-  in `conversations.history`, and its absence from a bounded, paginated read
-  cannot be told apart from it lying outside the window. Reliable notice
-  requires the Slack Events API, which this design does not use. Slack's legacy
-  Real Time Messaging (RTM) API carries the event too, but Slack states that
-  granular-permission apps cannot use it and that classic apps can no longer be
-  created, so it is not an option this collector could take. Slack content
-  therefore ages out on the scheduled body-clearing pass rather than at the
-  moment of deletion — the weaker guarantee, kept, rather than the stronger one
-  implied.
-
-## Fixtures
-
-The fixtures were written from scratch. The people, the company, the projects,
-and every message body are invented. Nothing is derived from a real mailbox or
-from an anonymized copy of one. See [`fixtures/README.md`](fixtures/README.md)
-for what each record is a control for.
-
-### Before a connector: encrypted storage
-
-The fixture path stores invented messages. A connector changes that — the store
-then holds real subjects, senders and bodies — so the profile home must sit on
-an encrypted volume before one is attached. Owner-only permissions are not
-encryption: they stop another account reading the file on a running system and
-do nothing for a disk that is lost, imaged, or backed up.
-
-`scripts/setup-slack.sh` checks what it can and refuses to attach a provider
-until the rest is confirmed. What it inspects is the **host** filesystem under
-the sandbox's storage, because `HERMES_HOME` inside a sandbox is an overlay
-with no block device behind it — encryption is not observable from in there.
-[`docs/encrypted-storage.md`](docs/encrypted-storage.md) has the verification
-commands per platform, and what to do when the answer is no.
-
-### Connecting Slack
-
-The scheduled intake reads whichever collectors are present in
-`profile/scripts/`. Slack is one of them, and it is read-only: direct
-messages, group DMs, and the public channels you name. It never posts.
+Run the setup script from the recipe checkout on the **Linux host**, not inside
+the sandbox. The host has `openshell`; the sandbox has `hermes`.
 
 ```bash
+export SANDBOX_STORAGE_PATH="<host-path-containing-sandbox-storage>"
+export OPENSHELL_SANDBOX_NAME="my-hermes"
 bash scripts/setup-slack.sh
 ```
 
-Run it on the host, not in the sandbox — it needs `openshell`, which the
-sandbox does not have. It reuses a Slack credential already attached when it
-finds one, and otherwise walks you through authorizing the app. Full
-walkthrough, including what to do when a workspace admin grants less than the
-app asked for: [`docs/set-up-slack.md`](docs/set-up-slack.md).
+The script imports `docs/slack_app_manifest.json`, requests user scopes, checks
+the provider type and read-only policy, configures token rotation, and attaches
+the provider to the named sandbox. The required scopes are:
 
-Three things are deliberate. The recipe needs a **user** token, not a bot
-token — a bot cannot read your direct messages, and using one produces an
-assistant that quietly never sees them, so the collector checks the prefix and
-names the mistake. That token **rotates**: the gateway holds it and refreshes
-it every twelve hours, and a non-rotating one is refused, because a user token
-that never expires is a permanent key to your entire Slack. And public
-channels are read only when you **name** them in
-`workspace/slack_channels.json` — Slack allows one history request per minute
-for affected apps, so a workspace sweep cannot finish inside a scheduled tick,
-and reading every channel you happen to be in collects more than the job
-needs.
+```yaml
+user_scopes:
+  - im:read
+  - im:history
+  - mpim:read
+  - mpim:history
+  - channels:read
+  - channels:history
+  - users:read
+```
 
-Until this is set up the collector still runs — it ships with the recipe — but
-reports `{"unconfigured": true}` and exits zero, so the schedule runs over
-whatever is already in the store and an idle tick still costs nothing. That is
-a supported state, not a broken one.
+Static user tokens, bot tokens, and app tokens are refused. Attachments are not
+downloaded. Full setup and workspace-admin recovery steps are in
+[docs/set-up-slack.md](docs/set-up-slack.md).
 
-### Connecting a mailbox
-
-Microsoft Graph is the other collector, and it is read-only: the messages in
-your Inbox. It never sends, never replies, and never touches a draft.
+Verify the live collector from the host through the supported sandbox exec
+path. Replace both placeholders.
 
 ```bash
+nemohermes my-hermes exec \
+  --workdir /sandbox/memory-driven-chief-of-staff \
+  -- env HERMES_HOME=/sandbox/.hermes/profiles/memory-driven-chief-of-staff \
+  python3 profile/scripts/ingest_slack.py --recheck
+```
+
+Collector exit codes are stable diagnostics:
+
+| Exit | Meaning |
+| --- | --- |
+| `0` | Fetch succeeded, or Slack is intentionally unconfigured |
+| `1` | Other collector error |
+| `2` | Missing/wrong credential type or unreachable API |
+| `3` | Slack rate limit |
+| `4` | Required Slack scope missing |
+
+### Microsoft Outlook
+
+Outlook intake uses the Microsoft Graph inbox delta API. Register a Microsoft
+Entra application with public-client flows enabled and delegated `Mail.Read`,
+`User.Read`, and `offline_access` permissions. Do not grant application-level
+mail permissions, which would authorize access beyond the signed-in mailbox.
+
+Run the device-code setup from the recipe checkout on the Linux host:
+
+```bash
+export SANDBOX_STORAGE_PATH="<host-path-containing-sandbox-storage>"
+export OPENSHELL_SANDBOX_NAME="my-hermes"
+export GRAPH_CLIENT_ID="<entra-application-client-id>"
+export GRAPH_TENANT_ID="<entra-directory-tenant-id>"
 bash scripts/setup-graph.sh
 ```
 
-Run it on the host, not in the sandbox, for the same reason as Slack — it
-needs `openshell`. It walks you through Microsoft's device-code flow: a code
-to type into a browser on any machine, and a consent your tenant may require
-an administrator to approve. Full walkthrough:
-[`docs/set-up-graph.md`](docs/set-up-graph.md).
+If the script reports that another attached provider already exposes
+`MS_GRAPH_ACCESS_TOKEN`, treat that as a hard stop. Detach the conflicting
+provider or use a dedicated sandbox, then rerun setup. Do not run the Graph
+collector while the credential source is ambiguous.
 
-**The first synchronisation asks how far back to read.** The default is seven
-days; the prompt offers seven, fourteen or thirty, and takes any number you
-type instead. `GRAPH_BACKFILL_DAYS` sets it without the prompt. The window
-applies once — after the first round the collector tracks changes rather than
-re-reading, so a larger number costs a slower first sync and nothing after
-that.
+On the supported path, the gateway stores and refreshes the delegated
+credential, and the sandbox receives only an OpenShell placeholder. Confirm
+that the attached provider has type `memory-driven-cos-graph-user` and that its
+exported profile declares `access: read-only` with `enforcement: enforce` before
+running the collector. The initial synchronization covers seven days by default
+and resumes across intake ticks when more pages remain. Configure a different
+`GRAPH_BACKFILL_DAYS` in the profile environment file before the first
+synchronization. See [docs/set-up-graph.md](docs/set-up-graph.md) for the
+application registration, provider inspection, backfill, revocation, and
+recovery steps.
 
-Two things are deliberate here as well. The scopes are **named** — `Mail.Read`,
-`User.Read`, `offline_access` — rather than `.default`, which would return
-whatever the application has already been granted and make the permission the
-recipe actually holds unknowable from the code. And `login.microsoftonline.com`
-is **not** in the sandbox's egress policy: the token exchange and every refresh
-belong to the gateway, so the collector holds a placeholder it cannot spend and
-cannot reach the endpoint that would turn it into a real one.
+### Link identities across providers
 
-Both connectors can be set up, or either one alone. They write into the same
-store and run in the same tick, independently — see [When a collector
-fails](#when-a-collector-fails) for what happens when one of them cannot.
+Slack identifies a person by user ID, while email uses an address. The recipe
+never assumes that matching display names belong to the same person. The memory
+job reports likely matches as `identity_candidates`; only the user can confirm
+or reject them.
 
-**A person is a set of identities, and only the user says which.** Slack
-identifies people by user id, mail by address, and a third connector will do
-it a third way; nothing in the data links them, because a shared display name
-is not evidence and the reason this recipe keeps a stable identity per sender
-at all is that guessing from a name puts two people on one page.
-
-So the memory job proposes and never decides. When identities share a handle
-— stronger, because a handle is unique within its own source — or a display
-name, they are reported as `identity_candidates` and each still gets its own
-page. The user answers whenever they get to it:
+Run the identity command from the Linux host through sandbox exec:
 
 ```bash
-python3 profile/scripts/link_identity.py same slack:U01DANA email:dana@example.com
+nemohermes my-hermes exec \
+  --workdir /sandbox/memory-driven-chief-of-staff \
+  -- env HERMES_HOME=/sandbox/.hermes/profiles/memory-driven-chief-of-staff \
+  python3 profile/scripts/link_identity.py same \
+    slack:U01DANA email:dana@example.com
 ```
 
-and the next run reports them as one person. If each identity had already
-been written up, that run also names the other pages as `merge_into_slug`, so
-the agent folds them into one and removes what it emptied — a page nobody
-merged is history attributed to nobody, and it will not surface again on its
-own. **Nothing waits for that answer.** The job records what it noticed and exits; an unanswered
-question costs nothing, and a nightly job whose completion depends on when
-somebody read a message is a job that does not complete.
+Use `different` instead of `same` to reject a match. Confirmed relationships
+compose across providers. Rejected candidates are not proposed again. If saved
+answers conflict, the recipe reports `identity_conflicts` and changes nothing.
+Existing page names remain stable after identities are linked so that index
+entries and source-backed links do not move.
 
-Answers are stored pairwise and composed, so confirming two pairs joins three
-identities without a third question, and a fourth connector is one more pair
-rather than a new shape. A rejection is recorded as durably as a
-confirmation, so a candidate the user has dismissed is not proposed again on
-every run. When answers stop agreeing with each other — two identities
-answered as different people, joined anyway by other confirmations since —
-that is reported as `identity_conflicts` and nothing is changed, because
-neither answer is knowably the wrong one.
+### Collector failures
 
-### When a collector fails
+When a collector fails, the intake batch records only its name, exit code, and
+error class. It does not place collector output in the model prompt or the
+scheduler log because that output can contain message text or authentication
+material. Run the collector directly to inspect its full error.
 
-A collector that exits non-zero, or prints something the selector cannot read,
-is recorded in the batch as a failure with its exit code and a stable error
-class, and the tick wakes the agent even when nothing is pending. An idle tick
-is free; a broken one must not be quiet.
-
-What nothing carries is the collector's own output. A collector is a
-subprocess talking to a mail or chat API, so its stderr can hold a bearer
-token, a signed URL, or someone's message body, and both of the places that
-wanted it are wrong: the batch is the agent's prompt, and the selector's own
-stderr is captured by the scheduler into the job log, where something
-transient becomes a file that outlives the token in it.
-
-So both get the same sanitized triple — which collector, what exit code, which
-error class. To read what a collector actually said, run it directly:
+Verify the collector from the host:
 
 ```bash
-HERMES_HOME="/path/to/profile" python3 profile/scripts/ingest_graph.py
+nemohermes my-hermes exec \
+  --workdir /sandbox/memory-driven-chief-of-staff \
+  -- env HERMES_HOME=/sandbox/.hermes/profiles/memory-driven-chief-of-staff \
+  python3 profile/scripts/ingest_graph.py --recheck
 ```
 
-That prints to your terminal rather than to a file. The text is dropped rather
-than redacted on purpose: a pattern-matching redactor cannot promise it caught
-everything, and a stored log is the wrong place to discover that it did not.
+Outlook collector exit codes are:
 
-## Cleanup
+| Exit | Meaning |
+| --- | --- |
+| `0` | Fetch succeeded, can resume, or Outlook is unconfigured |
+| `1` | Other collector error |
+| `2` | Missing, invalid, or refused credential |
+| `3` | Microsoft Graph rate limit |
+| `4` | Token is not a delegated mailbox token with the required scopes |
 
-The fixture path writes application state only inside the profile home passed
-to it:
+## Data Lifecycle and Privacy
+
+**Network boundary:** the offline walkthrough makes no network requests.
+Scheduled jobs call the configured inference endpoint only when work is found.
+The shipped provider profiles declare read-only access to `slack.com` and
+`graph.microsoft.com`, and the shipped collectors contain no source-system
+write operations.
+
+> **Runtime provenance limitation:** the effective network boundary is the
+> policy of the provider actually attached to the sandbox, not the YAML file in
+> this checkout. `ingest_graph.py` currently trusts whichever attached provider
+> supplies `MS_GRAPH_ACCESS_TOKEN`; it does not verify the provider name, type,
+> or policy at runtime. A different provider exposing the same key can therefore
+> bypass the setup-time refusal. Inspect the attached providers on the host and
+> do not run Graph intake unless the effective provider is the recipe's
+> read-only, enforced profile.
+
+**Source-system behavior:** the shipped collectors read Slack and the signed-in
+Outlook mailbox but do not post, reply, edit, delete, move, or mark messages as
+read. This describes the collector code; it is not a claim that an unrelated
+read-write provider attached to the same sandbox would refuse writes from other
+code.
+
+- The offline fixtures are entirely synthetic and make no network request.
+- Recipient lists are reduced to `direct`, `mentioned`, or `broadcast` and are
+  never stored.
+- Message bodies are cleared after 30 days by default; metadata, obligation
+  state, and audit history remain.
+- Exclusions are enforced at the shared insert boundary, before a row reaches
+  the store.
+- Export includes the complete store, memory, and learned policy in Markdown
+  and JSON.
+- Slack content deleted at the source is not detected immediately because a
+  bounded history read cannot distinguish deletion from an older page. It ages
+  out through retention.
+- Outlook messages removed from the inbox are reconciled through Microsoft
+  Graph. A confirmed deletion is tombstoned and its body is cleared immediately;
+  the metadata, obligation, and audit history remain. A move to another folder
+  is not treated as a deletion.
+- Microsoft Graph files in `fixtures/` remain synthetic and exercise the same
+  normalization path without contacting a mailbox.
+
+The store and memory directories are created with owner-only permissions. That
+does not protect a lost disk, disk image, or unencrypted backup. Before
+connecting Slack or Outlook, follow
+[docs/encrypted-storage.md](docs/encrypted-storage.md).
+
+## Verification
+
+This is an integration-level reference implementation. Its evidence includes
+an offline end-to-end walkthrough, deterministic tests, scheduled Linux
+validation, plus live Slack and Outlook collector and credential-rotation
+validation.
+
+### Offline acceptance walkthrough
 
 ```bash
-rm -rf "$HERMES_HOME"
+export RECIPE_VERIFY_HOME="$(mktemp -d)"
+export HERMES_HOME="$RECIPE_VERIFY_HOME"
+python3 profile/scripts/walkthrough.py --fixtures fixtures
 ```
 
-Each `mktemp -d` in this document creates a separate profile home. Remove each
-one you made, not only the last.
+### Full test suite
 
-Running the scripts also leaves a Python bytecode cache at
-`profile/scripts/__pycache__/` in the checkout, unless the interpreter is
-configured not to write one (`python3 -B`, or `PYTHONPYCACHEPREFIX`). The
-repository `.gitignore` covers it, so it never appears in `git status`. Remove
-it as well if you want the checkout byte-for-byte as you found it.
+Run from the recipe root. Each test file is executed directly because some
+tests verify direct-execution behavior.
 
-## Known limitations
+```bash
+cd profile/scripts
+export NO_PROXY="${NO_PROXY:+$NO_PROXY,}127.0.0.1,localhost"
+export no_proxy="${no_proxy:+$no_proxy,}127.0.0.1,localhost"
+fail=0
+for t in tests/*.py; do python3 "$t" || fail=1; done
+echo "failed=$fail"
+cd ../..
+test "$fail" -eq 0
+```
 
-**A page keeps the name it was created with, even when the reason for that
-name goes away.** Two people who present the same display name each get a
-name ending in a digest, because neither can be given the readable one
-without deciding between them. If the user later confirms that two such
-identities are one person, that person is no longer ambiguous and could hold
-the readable name — but the page they already have keeps its digest. Renaming
-would mean rewriting the index entry and every link that points at it, which
-is a real risk taken for an appearance, and a page name that moves is how
-history gets lost. It is cosmetic and it is permanent.
+Expected result: every file ends with `OK`, the fourteen files report 603 tests
+in total, and the final line is `failed=0`. Do not shorten the loop with an
+early break; running every module is part of the documented check.
 
-- Under the builtin scheduler the jobs fire only while a gateway is serving
-  this profile, and registering them starts nothing. `hermes cron tick` runs
-  what is due once without one, and an external cron provider replaces the
-  in-process ticker entirely.
-- The scheduled path is Linux only, including WSL, because every shipped skill
-  declares `platforms: [linux]`. See [Requirements](#requirements).
-- The installer transfers three named model settings and no file, so nothing
-  it writes can carry a secret. It checks that a model resolves and that a
-  credential is present, and stops before registering anything if either is
-  missing. What it cannot do is prove the credential is *valid*: that is one
-  request to your provider away, and the installer does not make it. A wrong
-  key still installs cleanly and fails at the first scheduled run.
-- The walkthrough's two judgment steps are recorded envelopes rather than live
-  model turns. That is the limit of a fixture corpus, and the limit falls in a
-  specific place: the gate verdict is recorded, so this run cannot show the
-  memory producing it. Everything the verdicts feed into is the shipped code.
-- Compaction is detected but not performed here. Detection is mechanical and
-  testable. Deciding what to compact needs the skill, which needs a model.
-- The memory ships with a seed that passes its own checks. It illustrates the
-  schema; it is not a starting point for real use.
-- The audit trail records one row per obligation a correction displaces, and
-  `events` is append-only. That is deliberate — the store has to be able to
-  explain why a row moved — but the cost scales with the open list: on a
-  200-row list, one ignore writes a row for every obligation below the
-  corrected one: 199 when it sat at the top, none when it sat at the bottom.
-  A long-lived store with
-  a large open list will need a compaction path for `reranked` events, which
-  this phase does not provide.
-- Paths in the skills are written against `$HERMES_HOME` rather than relative
-  to a working directory. This is not a style choice. The agent's working
-  directory is not the profile home, so a relative path resolves to nothing.
-  An unreadable memory cannot be told apart from an empty one, so the failure
-  is silent: the agent answers confidently from nothing instead of reporting an
-  error.
+The suite covers schema migration, memory invariants, concurrency and crash
+recovery, deterministic ranking, preference thresholds, normalization,
+transactional decisions, correction state transitions, the walkthrough,
+intake, review, and memory-writing selector wake gates, scheduler contracts,
+lifecycle controls, and Slack and Outlook collection/rotation behavior.
 
-## Intended users and support boundary
+## Troubleshooting and FAQ
 
-One person's own work stream, on a machine they control. This is a recipe
-rather than a product. There is no support commitment, and catalog placement is
-for discovery rather than a maturity claim.
+### `HERMES_HOME` is unset, missing, or points at the checkout
 
-## Dependencies
+Stateful scripts require an existing profile-like directory and refuse a file,
+a missing path, or an occupied non-profile directory. For an offline run, make
+a fresh directory and export it first.
 
-Standard library only. No module in this recipe imports a third-party Python
-package, so nothing is added to the repository's third-party notices.
+```bash
+export HERMES_HOME="$(mktemp -d)"
+```
 
-## Sandbox and policy
+### The walkthrough refuses a second run
 
-Every script except the Slack collector reaches no network. They read the
-recipe's files from the checkout and write application state only inside the
-profile home, and they also leave a Python bytecode cache beside the scripts —
-see [Cleanup](#cleanup). The six skill files a runtime loads add nothing to
-that.
+The walkthrough demonstrates a clean first run and rejects state that contains
+old corrections. Create a new temporary profile home.
 
-The collectors reach two hosts between them, `slack.com` and
-`graph.microsoft.com`, and only for reads. Each is declared in its provider
-profile — `providers/slack-user.yaml` and `providers/graph-user.yaml` — as
-`access: read-only` with `enforcement: enforce`, so the egress proxy refuses
-anything else, and refuses the other collector's host to each of them. The
-property is enforced by policy rather than promised by prose. Neither
-credential enters the sandbox: the gateway holds both and substitutes them at
-the boundary, so a collector handles a placeholder it cannot spend.
-`login.microsoftonline.com` is deliberately absent from the sandbox's
-allow-list — the token exchange is the gateway's, not the collector's.
+```bash
+export HERMES_HOME="$(mktemp -d)"
+python3 profile/scripts/walkthrough.py --fixtures fixtures
+```
 
-The scheduled path does reach one. A job that wakes runs an agent turn, and the
-runtime calls whichever inference provider it is configured for, over its own
-egress path — the recipe holds no credential and opens no connection itself.
-A job that does not wake makes no call at all.
+### Collector tests try to reach the real network or report HTTP 503
 
-Egress to a message source is here, and it is narrow: the Slack collector
-reaches `slack.com` and nothing else, the Graph collector reaches
-`graph.microsoft.com` and nothing else, each declared in its own provider
-profile at `access: read-only` with `enforcement: enforce`, so a write is
-refused at the boundary rather than caught by a test. The credential it uses is held by the
-gateway and substituted there — see
-[Connecting Slack](#connecting-slack).
+The Slack and Outlook tests use local HTTP stand-ins at `127.0.0.1`. If your
+shell sets a proxy without a localhost bypass, the proxy can intercept those
+requests. The documented test command extends both `NO_PROXY` and `no_proxy`;
+for an individual test, apply the same bypass first.
 
-## Startup
+```bash
+export NO_PROXY="${NO_PROXY:+$NO_PROXY,}127.0.0.1,localhost"
+export no_proxy="${no_proxy:+$no_proxy,}127.0.0.1,localhost"
+python3 profile/scripts/tests/test_ingest_slack.py
+python3 profile/scripts/tests/test_ingest_graph.py
+```
 
-The scripts run on demand and need nothing started.
+### The installer says the platform is unsupported
 
-The scheduled jobs need a gateway. Registration and firing are separate: a
-registered job on a profile with no running gateway does not run and reports
-nothing.
+The offline path runs on macOS, Linux, and WSL. The scheduled skills declare
+Linux support only, so `scripts/install.sh` refuses native macOS and Windows.
+Use a Linux NemoClaw sandbox or WSL for scheduling.
 
-### After a reboot
+### The installer reports no model or API credential
 
-Three separate questions, with three different answers.
+The new profile receives three model routing settings but never a copied
+secret. Set `model.default` if the source profile had none. On NemoClaw, set the
+OpenShell rewrite sentinel as the target profile's `model.api_key`, then rerun
+the installer.
 
-**Do the jobs survive?** Yes. They live in `$HERMES_HOME/cron/jobs.json`, which
-is ordinary disk state — not part of the distribution, so a profile update
-leaves it alone, and not tied to any process, so shutting everything down and
-starting again finds the same seven jobs with the same ids.
+```bash
+MODEL_ID="<provider/model>"
+hermes -p memory-driven-chief-of-staff \
+  config set model.default "$MODEL_ID"
+hermes -p memory-driven-chief-of-staff \
+  config set model.api_key "sk-OPENSHELL-PROXY-REWRITE"
+bash scripts/install.sh
+```
 
-**Do they start firing again on their own?** Only if the gateway was installed
-as a service. `hermes -p <profile> gateway install` registers one — a launchd
-agent on macOS, a systemd unit on Linux — and both are configured to come back
-after a reboot. `hermes -p <profile> gateway run` is a foreground process and
-is not: after a restart you run it again yourself. `cron status` tells you
-which situation you are in.
+The sentinel is a non-secret routing marker. Do not use
+`ALLOW_NO_API_KEY=1` for a NemoClaw-managed inference route.
 
-**What about the runs that were missed while it was down?** One of them
-happens, not all of them. Hermes collapses a backlog rather than replaying it:
-when a recurring job's scheduled time is more than one period in the past, it
-fast-forwards to the next future occurrence and fires once now. A machine that
-was off for two days does not wake to ninety-six intake runs; it wakes to one,
-which judges whatever accumulated, and then resumes its half-hourly rhythm.
-That suits this recipe, whose jobs act on the current state of the store rather
-than on a history of events.
+### Jobs are registered but do not run
 
-## Provenance
+Registration does not start the scheduler. Check the gateway and cron status.
 
-NVIDIA-authored. Proposed and reviewed in
+```bash
+hermes -p memory-driven-chief-of-staff gateway status
+hermes -p memory-driven-chief-of-staff cron status
+```
+
+Install and start the service, or use the foreground command shown in
+[Install in NemoClaw](#install-in-nemoclaw).
+
+### A collector reports `unconfigured`
+
+That is a supported state. The scheduler continues over existing store rows.
+Enable the source by running `scripts/setup-slack.sh` or
+`scripts/setup-graph.sh` on the Linux host, then run its collector with
+`--recheck` through sandbox exec.
+
+### Provider setup says `openshell` is missing
+
+The setup command is running inside the sandbox or on a host without OpenShell.
+Return to the Linux host checkout and confirm the CLI and sandbox name.
+
+```bash
+command -v openshell
+openshell sandbox list
+```
+
+### Slack is rate-limited or missing a scope
+
+The collector exits `3` for a rate limit and `4` for a missing scope. Reduce
+the named public channels or call budget for rate limits. For missing scopes,
+have the workspace administrator grant the manifest scopes, reinstall the app,
+and replace the rotating credential as described in
+[docs/set-up-slack.md](docs/set-up-slack.md).
+
+### Outlook synchronization is incomplete, rate-limited, or rejected
+
+`"complete": false` means the bounded initial synchronization will resume on
+the next intake tick. Exit `3` means Microsoft Graph rate-limited the current
+round. Exit `4` means the token is not a delegated mailbox token with the
+required `Mail.Read` and `User.Read` scopes. Follow the recovery steps in
+[docs/set-up-graph.md](docs/set-up-graph.md).
+
+### Graph setup refuses an attached provider with the same credential key
+
+Treat the refusal as a provider collision. From the host, inspect and detach
+the conflicting provider or use a dedicated sandbox before starting Graph
+intake.
+
+```bash
+openshell sandbox provider list my-hermes
+openshell provider get "<provider-name>"
+```
+
+### Does the recipe modify Outlook or Slack?
+
+The shipped collectors do not. They normalize source records into a local
+SQLite store and contain no post, reply, move, delete, or mark-as-read calls.
+The shipped provider profiles also declare read-only access. However, verify
+the provider actually attached to the sandbox: the current Graph collector
+cannot attest which provider supplied `MS_GRAPH_ACCESS_TOKEN`, so a foreign
+read-write provider would make the platform-level write-refusal claim false.
+
+## Limitations and Support
+
+- The scheduled path is Linux-only, including WSL.
+- Recorded judgment turns test the workflow, not model quality.
+- Live connectors currently cover Slack and a Microsoft Outlook inbox through
+  Microsoft Graph. Other messaging providers need their own collector and
+  OpenShell provider policy.
+- Graph credential provenance is not yet enforced at collector runtime. An
+  unrelated attached provider exposing `MS_GRAPH_ACCESS_TOKEN` can be used even
+  after `setup-graph.sh` refuses it. Use a dedicated sandbox or remove the
+  collision before enabling Graph intake.
+- Slack deletion is not observed immediately; retention clears old bodies.
+- The scheduled writer maintains people and attention pages. Other page types
+  have schemas but no automatic writer.
+- Memory compaction is model-guided. `memory_check.py` detects invariant and
+  ceiling violations but does not invent a safe consolidation.
+- Append-only reranking events are not compacted.
+- This is a reference recipe for one user's work stream on a machine they
+  control, not a hosted service or a production-readiness claim.
+
+This NVIDIA-authored recipe was proposed and reviewed in
 [NemoClaw Community #122](https://github.com/NVIDIA/nemoclaw-community/issues/122).
+Support is best effort under the repository [support policy](../../../../SUPPORT.md).
+Security reports should follow [SECURITY.md](../../../../SECURITY.md).
+
+## Recipe Metadata
+
+```yaml
+name: memory-driven-chief-of-staff
+version: "0.1.0"
+kind: nvidia-recipe
+status: reference-example
+target_runtime: NemoHermes
+tech_stack:
+  - "Python 3.10+"
+  - SQLite
+  - Bash
+  - "Hermes >=0.19.0"
+  - NemoClaw
+  - OpenShell
+entry_point: profile/scripts/walkthrough.py
+install_entry_point: scripts/install.sh
+configuration_manifest: profile/distribution.yaml
+state_root: "$HERMES_HOME/workspace"
+source_connectors:
+  available:
+    - Slack
+    - "Microsoft Outlook (via Microsoft Graph)"
+evidence_level: integration
+license: Apache-2.0
+```

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/docs/data-lifecycle.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/docs/data-lifecycle.md
@@ -1,12 +1,14 @@
+<!-- markdownlint-disable MD013 -->
 <!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- markdownlint-enable MD013 -->
 
 # What is kept, and how to be rid of it
 
 Four controls, all of them local. They were built against the fixture corpus,
-which is how they are tested, and they apply unchanged to the real Slack
-messages the collector brings in. That order was deliberate: the controls
-landed before the thing that would need them.
+which is how they are tested, and they apply unchanged to the real Slack and
+Outlook messages the collectors bring in. That order was deliberate: the
+controls landed before the thing that would need them.
 
 Every command below runs from `profile/scripts/`, against the store belonging
 to the profile named by `HERMES_HOME`.
@@ -44,11 +46,13 @@ kind of mistake found only afterwards.
 
 What a cleared row keeps:
 
+<!-- markdownlint-disable MD013 -->
 | Kept | Gone |
 | --- | --- |
 | sender and their stable identity, subject, timestamp, addressing, state | the message body |
 | the obligation and the title the judging turn wrote | |
 | every event, with its actor and its before and after | |
+<!-- markdownlint-enable MD013 -->
 
 So a month later you can still see that Dana asked about the cutover on the
 third, that it ranked high because the memory said you had chosen that work,
@@ -97,7 +101,7 @@ asserting the row never appears, not by reading the call chain.
 
 A dropped message is reported on stderr as a count, never as content:
 
-```
+```text
 exclusions: 2 message(s) not stored
 ```
 
@@ -158,8 +162,9 @@ cannot be removed it says so and exits non-zero — a reset that half worked
 must not read as one that worked. The policy goes with the rest because it
 encodes what its subject ignores, which is about them.
 
-The credential is not removed, because it was never held here: it lives with
-the OpenShell gateway. `reset.py` prints the commands to revoke it, since
+On the supported provider path, the credential is not removed because it was
+never held here: it lives with the OpenShell gateway. `reset.py` prints the
+commands to revoke it, since
 somebody withdrawing consent wants both and would otherwise stop after the one
 that felt complete.
 
@@ -174,8 +179,7 @@ guessed either way, and one with no identity to ask about — a row from before
 the connector stored one — is reported as unresolved rather than treated as a
 deletion.
 
-Slack, which is the connector that ships, offers no such notice. A deleted
-message stops appearing in
+The Slack collector offers no such notice. A deleted message stops appearing in
 `conversations.history`, and its absence from a bounded, paginated read cannot
 be told apart from it lying outside the window. Reliable notice needs the
 Events API, which this design does not use; the legacy RTM API carries the

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/docs/set-up-graph.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/docs/set-up-graph.md
@@ -1,11 +1,13 @@
+<!-- markdownlint-disable MD013 -->
 <!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- markdownlint-enable MD013 -->
 
 # Connecting a mailbox
 
-Fifteen minutes, most of it waiting for a sign-in page. What you end up with is
-a credential the sandbox never holds and a collector that reads your inbox and
-writes nothing back to it.
+Fifteen minutes, most of it waiting for a sign-in page. On the supported path,
+what you end up with is a credential the sandbox never holds and a collector
+that reads your inbox and writes nothing back to it.
 
 ## What holds the credential
 
@@ -20,12 +22,31 @@ encrypted token cache, which keeps a recipe self-contained at the cost of the
 refresh token living inside the sandbox — where an encrypted cache is a
 mitigation rather than a boundary.
 
-## The one thing that goes wrong
+## Request delegated permissions
 
 An application permission instead of a delegated one. `Mail.Read` exists in
 both flavours, and the application flavour reads every mailbox in the tenant.
 The collector refuses it — a token whose `/me` has no address is not a
 delegated token — but it is worth not requesting in the first place.
+
+## Provider provenance is an operator check in this version
+
+The provider profile in this checkout describes the intended boundary; it is
+not proof of which provider is active on a particular sandbox. The current
+collector reads `MS_GRAPH_ACCESS_TOKEN` from its environment and cannot identify
+the attached provider that supplied it.
+
+Before running setup or intake, list the sandbox's attached providers on the
+host and inspect each one:
+
+```bash
+openshell sandbox provider list <sandbox>
+openshell provider get <provider-name>
+```
+
+If an unrelated provider exposes `MS_GRAPH_ACCESS_TOKEN`, stop. Do not run the
+collector, even if that provider happens to hold a valid Outlook token. Use a
+dedicated sandbox or detach the conflicting provider first.
 
 ## Where each step runs
 
@@ -47,7 +68,8 @@ guessed.
 
 At the Microsoft Entra admin centre, register an application with:
 
-- **Delegated** `Mail.Read` and `offline_access`. Delegated, not application.
+- **Delegated** `Mail.Read`, `User.Read`, and `offline_access`. Delegated, not
+  application.
 - **Public client flows enabled** — the device-code flow needs it, and it is
   off by default.
 - No redirect URI. There is no browser on the machine running the collector,
@@ -69,6 +91,10 @@ It prints a short code and an address. Open the address anywhere you trust,
 enter the code, approve. The terminal waits; nothing is stored until you
 finish, and the refresh token that comes back goes to the gateway rather than
 into the sandbox.
+
+If setup reports that another attached provider exposes
+`MS_GRAPH_ACCESS_TOKEN`, treat the refusal as a hard stop. Detach the conflicting
+provider or use a dedicated sandbox before rerunning setup.
 
 ## 4. Choose how far back the first synchronisation reaches
 
@@ -94,7 +120,21 @@ A wider window costs a longer first synchronisation. Each tick spends a bounded
 number of requests and saves its place, so a first round over thirty days
 finishes across several ticks rather than in one.
 
-## 5. Verify
+## 5. Verify the effective provider, then the collector
+
+On the host, confirm that the attached Graph provider has type
+`memory-driven-cos-graph-user`, then export that profile and verify its Graph
+endpoint declares `access: read-only` and `enforcement: enforce`:
+
+```bash
+openshell sandbox provider list <sandbox>
+openshell provider get <provider-name>
+openshell provider profile export memory-driven-cos-graph-user
+```
+
+Do not infer those properties from `providers/graph-user.yaml`; the exported
+gateway profile is the effective policy. Do not proceed if a different provider
+also exposes `MS_GRAPH_ACCESS_TOKEN`.
 
 Inside the sandbox:
 
@@ -118,7 +158,7 @@ failure. `resumed: true` says this tick continued one.
 
 | Exit | Means |
 | --- | --- |
-| `0` | Collected, or never configured. Never configured is a state, not a fault |
+| `0` | Collected or unconfigured; unconfigured is not a fault |
 | `1` | Something else; the message says what |
 | `2` | The credential is missing, wrong, or was refused |
 | `3` | Rate limited before the work finished |

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/fixtures/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/fixtures/README.md
@@ -1,127 +1,362 @@
+<!-- markdownlint-disable MD013 -->
 <!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- markdownlint-enable MD013 -->
 
-# Fixtures
+# Memory-Driven Chief of Staff Fixtures
 
-Eight messages, a small seed memory, and one of the two recorded model turns.
-Together they run the recipe from end to end without a mailbox, a Slack
-workspace, or an inference endpoint. See the
-[recipe README](../README.md) for what the recipe does and for the terms used
-below.
+This directory provides eight synthetic messages, a small seed memory, and one
+file-backed recorded model turn. Together with a second envelope embedded in
+the walkthrough, they run the parent recipe end to end without a mailbox,
+Slack workspace, inference endpoint, credential, or network connection.
 
-## Provenance
+Start with the [parent recipe README](../README.md) if you want to understand
+the complete system or install it in NemoClaw.
 
-These fixtures were written from scratch. The people, the company, the
-projects, and every message body are invented. Nothing is derived from a real
-mailbox, a real workspace, or an anonymized copy of either. The response shapes
-match what
-[Microsoft Graph's delta query](https://learn.microsoft.com/en-us/graph/api/message-delta)
-and
-[Slack's `conversations.history`](https://docs.slack.dev/reference/methods/conversations.history)
-return for the fields this recipe selects, so the same normalization code will
-run against the fixtures and against a live source.
+## Table of Contents
 
-The files themselves are local wrappers rather than captured responses. The
-Graph file keeps the API's own `value` array and `@odata.deltaLink`; the Slack
-file keys its histories by channel, because a real `conversations.history` call
-returns one `{"ok": true, "messages": [...]}` response per channel and the
-loader would otherwise need one file each. What the normalizer reads — the
-message objects inside — matches what each API returns.
+- [What It Covers](#what-it-covers)
+- [Directory Structure](#directory-structure)
+- [Quick Start](#quick-start)
+- [Fixture Catalog](#fixture-catalog)
+- [Configuration](#configuration)
+- [Format Reference](#format-reference)
+- [Recorded Model Turns](#recorded-model-turns)
+- [Provenance and Safety](#provenance-and-safety)
+- [Troubleshooting and FAQ](#troubleshooting-and-faq)
+- [Fixture Metadata](#fixture-metadata)
 
-## What each record is a control for
+## What It Covers
 
-| Record | What it controls for |
-| --- | --- |
-| `msg-priorities-match` | Matches an entry in `memory/attention/current_priorities.md`, so a judging turn admits it through the intent gate and it can reach the `high` tier. |
-| `msg-urgent-not-chosen` | Loud external urgency that matches nothing the user chose: a mandatory deadline, with "URGENT" in the subject. Capped at `medium`. |
-| `msg-quiet-decay` | Dated seven days before the rest of the batch, and nothing later in the corpus follows up on it. It is named in `memory/attention/current_priorities.md`, so it passes the gate too. The walkthrough pins it to the bottom tier by hand, to show a correction outranking the memory. |
-| `msg-automated-noise` | A build notification from a `noreply@` address. Skipped, and skipping is terminal, so it is never judged again. |
-| `msg-cc-only` | The user is on Cc rather than To. Being copied is not being asked, so `addressing` is `broadcast`. |
-| `D0DIRECT01` message | A direct message. `addressing` is `direct`, with no mention needed. |
-| `C0TEAM0001` mention | A channel message that names the user, about the migration document, so it passes the gate too. `addressing` is `mentioned`. |
-| `C0TEAM0001` notice | A channel announcement that names nobody. `addressing` is `broadcast`. |
+- Fixed source rows and decisions make every run deterministic.
+- Messages cover ranking, addressing, skips, corrections, and the intent gate.
+- Fixtures use the recipe's normalizers and SQLite writer.
+- Two documented envelopes replace the only live model turns.
 
-Two of the eight are skipped rather than tracked: `msg-automated-noise` and the
-`C0TEAM0001` notice. That is why the walkthrough reports `"skipped": 2` and
-carries six obligations rather than eight.
+## Directory Structure
 
-Three of the eight pass the intent gate: `msg-priorities-match`, the
-`C0TEAM0001` mention, and `msg-quiet-decay`. That is why the walkthrough prints
-`high=3`.
+Paths in metadata and commands are relative to the parent recipe root.
 
-`msg-urgent-not-chosen` is the record to watch. It is a real, dated, mandatory
-deadline, and the recorded turn ranks it fourth. It still cannot reach the
-`high` tier, because the recorded verdict says the user never chose that work.
-This is the behavior a ranking without a memory behind it cannot produce.
+<!-- markdownlint-disable MD013 -->
+```text
+fixtures/
+├── README.md                                  # This fixture contract and catalog
+├── graph_messages.json                        # 5 synthetic Graph delta-shaped rows
+├── slack_messages.json                        # 3 synthetic Slack history-shaped rows
+├── envelopes/
+│   └── intake.json                            # Recorded intake decision envelope
+└── memory/
+    ├── index.md                               # Seed memory index
+    ├── attention/
+    │   └── current_priorities.md              # Work that can pass the intent gate
+    ├── people/
+    │   ├── dana_okoro.md                      # Synthetic collaborator page
+    │   └── sam_ruiz.md                        # Synthetic collaborator page
+    └── projects/
+        └── billing_migration/
+            └── billing_migration.md           # Synthetic active-project page
+```
+<!-- markdownlint-enable MD013 -->
 
-## The seed memory
+The second recorded turn is the short review envelope embedded in
+`profile/scripts/walkthrough.py`, next to the step whose correction-survival
+behavior it exercises.
 
-`memory/` holds the pages a live judging turn reads before it decides, for each
-message, whether the user chose that work. In this fixture path that decision
-is already recorded in `envelopes/intake.json`, so removing `memory/` does not
-change the tiers the walkthrough prints. The pages are here because the memory
-is what a live run reads, and because the memory self-check in step 7 runs
-against them.
+## Quick Start
 
-What the ranking does with a gate verdict is shipped code, and the walkthrough
-shows it directly: step 2 re-runs the ranking over the same rows with the
-verdicts withheld, and the `high` tier empties.
-Two tests assert the same property directly:
-`test_no_row_passes_the_gate_high_is_empty_and_all_cascade`, in
-`profile/scripts/tests/test_ranking.py`, and
-`test_an_ungated_population_leaves_the_high_tier_empty`, in
-`profile/scripts/tests/test_apply_decisions.py`.
-
-## The recorded model turns
-
-The walkthrough records two turns, so that it is deterministic and needs no
-inference endpoint:
-
-- `envelopes/intake.json`, the intake judgment. It stands in for what a model
-  returns after reading the batch and the memory.
-- A shorter review envelope for step 5, written inline in
-  `profile/scripts/walkthrough.py` rather than stored here.
-
-Those two are the only recorded parts. Everything downstream of them is the
-shipped code, running for real: the tier caps, the ranking across the whole
-open population, the transactional writer, the correction path, and the
-re-ranking. The gate verdict on each row sits inside the intake envelope,
-because deciding it needs a model reading the memory.
-
-## Running it
-
-Run from the recipe root, not from this directory:
+Run from the **parent recipe root**, not from `fixtures/`.
 
 ```bash
-export HERMES_HOME=$(mktemp -d)
+export FIXTURE_TMP_HOME="$(mktemp -d)"
+export HERMES_HOME="$FIXTURE_TMP_HOME"
 python3 profile/scripts/walkthrough.py --fixtures fixtures
 ```
 
-`HERMES_HOME` must be set. `walkthrough.py` and `load_fixtures.py` both refuse
-to guess a profile home.
+Expected results:
 
-The walkthrough prints seven steps: ingestion, judgment, two corrections, a
-re-judgment that cannot undo them, the state of the preference threshold, and
-the memory self-check. Step 7 breaks one page on purpose, so the check is seen
-to fail as well as pass.
+```text
+source messages: 8
+skipped: 2
+open obligations: 6
+high tier: 3
+exit status: 0
+```
 
-To load the messages without any of the judgment, use the loader on its own in
-a profile home the walkthrough has not already filled:
+The output also shows that a user pin and an ignore survive re-judgment, that a
+preference remains below its learning threshold, and that the memory checker
+both passes and catches an introduced defect.
+
+### Load without judgment
+
+Use a fresh profile home if the walkthrough has already populated the previous
+one.
 
 ```bash
-export HERMES_HOME=$(mktemp -d)
+export FIXTURE_LOAD_HOME="$(mktemp -d)"
+export HERMES_HOME="$FIXTURE_LOAD_HOME"
+python3 profile/scripts/load_fixtures.py --fixtures fixtures
 python3 profile/scripts/load_fixtures.py --fixtures fixtures
 ```
 
+The two runs report `"added": 8` and `"added": 0`. Ingestion is keyed by each
+source's identifier, so replaying the same corpus is idempotent.
 
-Each `mktemp -d` above makes a profile home that is not removed for you. See
-[Cleanup](../README.md#cleanup) in the recipe README.
+## Fixture Catalog
 
-Ingestion is idempotent: a second `load_fixtures.py` run against the same
-profile home adds nothing, because intake is keyed on the source's own
-identifier.
+<!-- markdownlint-disable MD013 -->
+| Record | Source shape | Expected control |
+| --- | --- | --- |
+| `msg-priorities-match` | Graph email | Matches `current_priorities.md`; passes the intent gate and reaches `high` |
+| `msg-urgent-not-chosen` | Graph email | Explicit dated deadline labeled `URGENT`, but no chosen-work match; capped at `medium` |
+| `msg-quiet-decay` | Graph email | Seven days older and priority-matched; starts in `high`, then a user pin moves it to `low` |
+| `msg-automated-noise` | Graph email | No-action `noreply@` build notice; terminal `SKIP` |
+| `msg-cc-only` | Graph email | User appears only on Cc; normalized as `broadcast`, later ignored by the user |
+| `D0DIRECT01:1787055600.000100` | Slack DM | Direct message; normalized as `direct` without a mention |
+| `C0TEAM0001:1787056200.000200` | Slack channel | Names the synthetic user and matches active work; `mentioned`, intent-gated, and `high` |
+| `C0TEAM0001:1787056800.000300` | Slack channel | General no-action notice; `broadcast` and terminal `SKIP` |
+<!-- markdownlint-enable MD013 -->
 
-The walkthrough is not. It narrates a first run, and a second run against the
-same profile home would inherit the first run's corrections, so the commentary
-would no longer match the tables beneath it. It detects that and stops, telling
-you to point `HERMES_HOME` at a fresh directory.
+Two messages are skipped, leaving six obligations. Three pass the intent gate,
+so `high` contains three rows rather than being padded to its cap of ten.
+
+The key negative control is `msg-urgent-not-chosen`: it ranks fourth and has a
+mandatory deadline, but cannot enter `high` because the recorded verdict says
+the user did not choose that work.
+
+## Configuration
+
+### Dependencies
+
+| Item | Path / value |
+| --- | --- |
+| Python dependency manifest | None; standard library only |
+| Parent entry point | `profile/scripts/walkthrough.py` |
+| Loader | `profile/scripts/load_fixtures.py` |
+| Normalizer | `profile/scripts/normalize.py` |
+| Transaction boundary | `profile/scripts/_db.py` |
+| Required environment variable | `HERMES_HOME` |
+| Network or credentials | None |
+
+`HERMES_HOME` must name an existing fresh directory. The walkthrough and loader
+refuse to guess a state location or create the profile home itself.
+
+```yaml
+environment:
+  HERMES_HOME:
+    required: true
+    type: existing_directory
+    recommended_for_fixtures: fresh_temporary_directory
+```
+
+## Format Reference
+
+### Microsoft Graph-shaped wrapper
+
+`graph_messages.json` retains the API-style `value` array and delta cursor. It
+contains five hand-written message objects. The parent recipe also ships a live
+Microsoft Outlook collector through Microsoft Graph; this fixture remains a
+local wrapper and does not configure or contact it.
+
+```json
+{
+  "source": "Synthetic Microsoft Graph delta response",
+  "record_count": 5,
+  "value": [
+    {
+      "id": "msg-priorities-match",
+      "receivedDateTime": "2026-08-18T08:10:00Z",
+      "subject": "Billing migration — need the cutover window confirmed",
+      "from": {
+        "emailAddress": {
+          "name": "Dana Okoro",
+          "address": "dana.okoro@example.com"
+        }
+      },
+      "toRecipients": [
+        {
+          "emailAddress": {
+            "address": "avery.chen@example.com"
+          }
+        }
+      ],
+      "ccRecipients": [],
+      "body": {
+        "contentType": "text",
+        "content": "<synthetic body>"
+      }
+    }
+  ],
+  "@odata.deltaLink": "<synthetic delta URL>"
+}
+```
+
+### Slack-shaped wrapper
+
+`slack_messages.json` groups one API-style history response per channel because
+Slack timestamps are unique only within a channel. The normalizer constructs a
+stable source identifier from the channel ID and timestamp.
+
+```json
+{
+  "source": "Synthetic Slack conversations.history responses",
+  "record_count": 3,
+  "channels": [
+    {"id": "D0DIRECT01", "type": "im"},
+    {"id": "C0TEAM0001", "type": "channel"}
+  ],
+  "history": {
+    "D0DIRECT01": {
+      "ok": true,
+      "messages": [
+        {
+          "ts": "1787055600.000100",
+          "user": "U0DANA0001",
+          "text": "<synthetic body>"
+        }
+      ]
+    }
+  }
+}
+```
+
+### Seed people pages
+
+Each synthetic people page lists the provider identities that the user has
+confirmed for that person. The fixture starts with one email identity per page;
+live runs can add Slack or future-provider identities through
+`link_identity.py`.
+
+```yaml
+name: Dana Okoro
+identities:
+  - email:dana.okoro@example.com
+```
+
+The recipe never joins pages from display names alone. Identity-linking tests
+cover confirmations, rejections, composed relationships, and conflicts.
+
+### Recorded intake envelope
+
+`envelopes/intake.json` follows the writer contract documented in the parent
+README. `intent_gated` is part of the recorded turn because deciding it requires
+a model to read memory; tier assignment after that verdict is live recipe code.
+
+```json
+{
+  "version": 1,
+  "pass": "intake",
+  "decisions": [
+    {
+      "source_id": "msg-priorities-match",
+      "decision": "CREATE",
+      "rank": 1,
+      "intent_gated": true,
+      "title": "Give Dana the billing-migration cutover window",
+      "kind": "response",
+      "est_effort": "minutes"
+    },
+    {
+      "source_id": "msg-automated-noise",
+      "decision": "SKIP"
+    }
+  ],
+  "cursor": {
+    "source": "email",
+    "scope": "inbox",
+    "value": "fixture-delta-1"
+  }
+}
+```
+
+## Recorded Model Turns
+
+The deterministic walkthrough replaces exactly two inference calls:
+
+1. `fixtures/envelopes/intake.json` supplies the intake judgment for all eight
+   source rows.
+2. `profile/scripts/walkthrough.py` contains the shorter step-5 review envelope
+   that attempts, and fails, to override the user's earlier correction.
+
+Everything downstream uses the recipe's normal execution paths: normalization,
+SQLite writes, population ranking, cap and cascade behavior, user corrections,
+audit attribution, preference counting, and memory invariant checking.
+
+Removing `fixtures/memory/` does not alter recorded gate verdicts and therefore
+does not alter the printed tiers. It does cause the final memory check to fail.
+The walkthrough also reruns ranking with all gate verdicts withheld and prints
+the resulting empty `high` tier.
+
+## Provenance and Safety
+
+These fixtures were written from scratch, not captured or anonymized from a
+real account. All identities, projects, timestamps, URLs, and messages are
+invented.
+
+The shapes intentionally resemble the fields consumed from
+[Microsoft Graph message delta](https://learn.microsoft.com/en-us/graph/api/message-delta)
+and [Slack `conversations.history`](https://docs.slack.dev/reference/methods/conversations.history).
+They are local wrappers, not preserved API responses. The Graph wrapper keeps a
+`value` array and delta link; the Slack wrapper keeps one history result per
+channel.
+
+## Troubleshooting and FAQ
+
+### The script says `HERMES_HOME` is required
+
+Run from the parent recipe root and point the variable at an existing directory.
+
+```bash
+cd ..
+export HERMES_HOME="$(mktemp -d)"
+python3 profile/scripts/walkthrough.py --fixtures fixtures
+```
+
+If you are already at the parent root, omit the directory change.
+
+### The walkthrough says the profile home is not fresh
+
+The walkthrough requires fresh state because old corrections would change its
+results. Create a new directory and rerun.
+
+```bash
+export HERMES_HOME="$(mktemp -d)"
+python3 profile/scripts/walkthrough.py --fixtures fixtures
+```
+
+### The loader reports `"added": 0`
+
+The same fixtures have already been loaded into that profile home. This is the
+expected idempotency behavior. Use a new home if you need a clean corpus.
+
+### Does deleting the seed memory test the intent gate?
+
+No. The envelope already records each gate verdict. Deleting memory tests the
+memory checker, while the walkthrough's gate-withheld comparison and the
+ranking tests exercise the tier behavior directly.
+
+### Can these files configure a live mailbox?
+
+No. They are a deterministic corpus, not credentials or connector state. Live
+Slack and Outlook setup is documented in the
+[parent README](../README.md#connect-messaging-providers).
+
+## Fixture Metadata
+
+```yaml
+name: memory-driven-chief-of-staff-fixtures
+version: "0.1.0"
+kind: synthetic-fixture-corpus
+parent_recipe: memory-driven-chief-of-staff
+path_base: parent_recipe_root
+tech_stack:
+  - JSON
+  - Markdown
+  - "Python 3.10+"
+entry_point: profile/scripts/walkthrough.py
+fixture_root: fixtures
+message_count: 8
+recorded_model_turns: 2
+contains_real_data: false
+requires_network: false
+license: Apache-2.0
+```

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/fixtures/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/fixtures/README.md
@@ -311,8 +311,6 @@ export HERMES_HOME="$(mktemp -d)"
 python3 profile/scripts/walkthrough.py --fixtures fixtures
 ```
 
-If you are already at the parent root, omit the directory change.
-
 ### The walkthrough says the profile home is not fresh
 
 The walkthrough requires fresh state because old corrections would change its

--- a/examples/tools/README.md
+++ b/examples/tools/README.md
@@ -9,5 +9,5 @@ Standalone utilities that help developers build, evaluate, inspect, or operate N
 
 | Example | Industry | Description |
 | --- | --- | --- |
-| [Agent Memory Benchmark](agent-memory-benchmark/README.md) | ✨ Other | Benchmarks memory systems on synthetic email and chat, reporting answer accuracy and token cost. |
+| [Agent Memory Benchmark](agent-memory-benchmark/README.md) | ✨ Other | Measures memory built from synthetic email and chat, asks 186 questions on one corpus and 96 on a second, and reports accuracy by question type with ingest and answer token costs. |
 | [Harness Engineering Playground](harness-engineering-playground/README.md) | ✨ Other | Provides an experimental loop for tuning DeepAgents harness profiles against behavioral evaluations, keeping fixes that pass verification and rolling back rejected edits. |

--- a/examples/tools/README.md
+++ b/examples/tools/README.md
@@ -9,5 +9,5 @@ Standalone utilities that help developers build, evaluate, inspect, or operate N
 
 | Example | Industry | Description |
 | --- | --- | --- |
-| [Agent Memory Benchmark](agent-memory-benchmark/README.md) | ✨ Other | Measures the memory an agent builds from synthetic email and chat by asking 186 questions on one corpus and 96 on another, then reports accuracy by question type separately from ingest and answer token costs. |
+| [Agent Memory Benchmark](agent-memory-benchmark/README.md) | ✨ Other | Benchmarks memory systems on synthetic email and chat, reporting answer accuracy and token cost. |
 | [Harness Engineering Playground](harness-engineering-playground/README.md) | ✨ Other | Provides an experimental loop for tuning DeepAgents harness profiles against behavioral evaluations, keeping fixes that pass verification and rolling back rejected edits. |

--- a/examples/tools/agent-memory-benchmark/README.md
+++ b/examples/tools/agent-memory-benchmark/README.md
@@ -5,12 +5,6 @@
 
 # Agent Memory Benchmark
 
-| Catalog field | Value |
-| --- | --- |
-| Description | Benchmarks memory systems on synthetic email and chat, reporting answer accuracy and token cost. |
-| Industry | ✨ Other |
-| Requirements | Python 3.9+ · pytest for offline checks · endpoint and adapter for live scoring |
-
 **mnemo measures what a memory system can answer after ingesting email and chat,
 and what ingesting and answering cost.** It reports quality and cost separately
 across two synthetic corpora.
@@ -508,3 +502,11 @@ question_count: 186  # corpus A; corpus B adds 96, see corpus_b/README.md
 license: Apache-2.0
 evidence_level: local/static
 ```
+
+## Catalog Metadata
+
+| Catalog field | Value |
+| --- | --- |
+| Description | Benchmarks memory systems on synthetic email and chat, reporting answer accuracy and token cost. |
+| Industry | ✨ Other |
+| Requirements | Python 3.9+ · pytest for offline checks · endpoint and adapter for live scoring |

--- a/examples/tools/agent-memory-benchmark/README.md
+++ b/examples/tools/agent-memory-benchmark/README.md
@@ -507,6 +507,6 @@ evidence_level: local/static
 
 | Catalog field | Value |
 | --- | --- |
-| Description | Benchmarks memory systems on synthetic email and chat, reporting answer accuracy and token cost. |
+| Description | Measures memory built from synthetic email and chat, asks 186 questions on one corpus and 96 on a second, and reports accuracy by question type with ingest and answer token costs. |
 | Industry | ✨ Other |
 | Requirements | Python 3.9+ · pytest for offline checks · endpoint and adapter for live scoring |

--- a/examples/tools/agent-memory-benchmark/README.md
+++ b/examples/tools/agent-memory-benchmark/README.md
@@ -1,75 +1,48 @@
----
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
-name: agent-memory-benchmark
-display_name: mnemo — Agent Memory Benchmark
-category: Developer Tool
-provenance: NVIDIA
-language: python
-python_requires: ">=3.9"
-runtime_dependencies: none (Python standard library only)
-dev_dependencies: [pytest]
-entry_point: python3 -m bench.runner
-offline_check: python3 -m pytest tests/
-adapter_contract: docs/SUBMITTING.md
-corpora: [corpus_a/, corpus_b/]
-question_count: 186  # corpus A; corpus B adds 96, see corpus_b/README.md
-license: Apache-2.0
-evidence_level: local/static
----
+<!-- markdownlint-disable MD013 -->
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- markdownlint-enable MD013 -->
 
 # Agent Memory Benchmark
 
 | Catalog field | Value |
 | --- | --- |
-| Description | Measures the memory an agent builds from synthetic email and chat by asking 186 questions on one corpus and 96 on another, then reports accuracy by question type separately from ingest and answer token costs. |
+| Description | Benchmarks memory systems on synthetic email and chat, reporting answer accuracy and token cost. |
 | Industry | ✨ Other |
-| Requirements | Python 3.9+ · pytest for the offline check · endpoint and adapter required only for live scoring |
+| Requirements | Python 3.9+ · pytest for offline checks · endpoint and adapter for live scoring |
 
-**mnemo measures the memory a system builds from a corpus: what it can answer
-afterwards, and what building it cost.** Give it six weeks of one person's email
-and chat, let it build whatever memory it likes, then ask the 186 questions of
-corpus A — or the 96 of corpus B — and check the answers — with quality and cost reported separately and never blended.
-
-*Named for Mnemosyne, memory herself. The hard part is not remembering — it is
-remembering the right version: a later message overturns an earlier one, and a
-system worth using tells you the current answer, not the one it learned first.*
+**mnemo measures what a memory system can answer after ingesting email and chat,
+and what ingesting and answering cost.** It reports quality and cost separately
+across two synthetic corpora.
 
 ---
 
-## 📑 Table of Contents
+## Table of Contents
 
-- [👀 What A Run Looks Like](#-what-a-run-looks-like)
-- [📚 What Is In The Corpora](#-what-is-in-the-corpora)
-- [❓ What It Asks](#-what-it-asks)
-- [🚀 Getting Started](#-getting-started)
-- [✨ Why It Is Built This Way](#-why-it-is-built-this-way)
-- [🗂️ Project Structure](#️-project-structure)
-- [⚙️ Configuration](#️-configuration)
-- [🧩 Adding Your System](#-adding-your-system)
-- [🔐 How The Runner Treats Your Adapter](#-how-the-runner-treats-your-adapter)
-- [📊 Reading A Result](#-reading-a-result)
-- [📈 Published Results](#-published-results)
-- [✅ Verification](#-verification)
-- [🩺 Troubleshooting](#-troubleshooting)
-- [🧹 Cleanup](#-cleanup)
-- [🔎 At A Glance](#-at-a-glance)
-- [🏷️ Provenance And License](#️-provenance-and-license)
+- [What A Run Looks Like](#what-a-run-looks-like)
+- [What Is In The Corpora](#what-is-in-the-corpora)
+- [What It Asks](#what-it-asks)
+- [Getting Started](#getting-started)
+- [Project Structure](#project-structure)
+- [Configuration](#configuration)
+- [Adding Your System](#adding-your-system)
+- [How The Runner Treats Your Adapter](#how-the-runner-treats-your-adapter)
+- [Reading A Result](#reading-a-result)
+- [Published Results](#published-results)
+- [Verification](#verification)
+- [Troubleshooting](#troubleshooting)
+- [Cleanup](#cleanup)
+- [Provenance And License](#provenance-and-license)
+- [Metadata](#metadata)
 
 ---
 
-## 👀 What A Run Looks Like
+## What A Run Looks Like
 
 ![Terminal session: the offline self-test scoring exactly 1.0 on every question type, followed by the test suite passing](docs/assets/offline-self-test.png)
 
-The whole pipeline running with no model and no network: the oracle adapter
-answers a six-document fixture, scores exactly `1.0` on every question type, and
-the benchmark's own test suite passes. Notice that `freshness` is split into two
-lines — a system must not only be current, it must resist a stale value that is
-still sitting in the corpus.
-
-The same output as text, so it is searchable and an agent can read it without
-parsing an image:
+The offline oracle scores `1.0` on a six-document fixture. The text version
+below keeps the result searchable and agent-readable.
 
 ```text
 $ python3 -m bench.runner --adapter selftest/oracle \
@@ -95,22 +68,16 @@ $ python3 -m bench.runner --adapter selftest/oracle \
 
 ---
 
-## 📚 What Is In The Corpora
+## What Is In The Corpora
 
 | | Documents | Period | Domain |
 | --- | ---: | --- | --- |
 | **Corpus A** (`corpus_a/`) — [details](corpus_a/README.md) | 425 — 200 emails, 225 channel-days of chat (559 messages) | 2026-04-16 → 2026-05-27 | a software platform-engineering team |
 | **Corpus B** (`corpus_b/`) — [details](corpus_b/README.md) | 173 — 100 emails, 73 channel-days (383 messages) | 2027-07-20 → 2027-09-24 | a construction program manager running three sites |
 
-Corpus B was written key-first and generated by a different model family, in a
-domain deliberately far from corpus A's, so that a result on one can be checked
-against the other. See [`corpus_b/README.md`](corpus_b/README.md) for how it was
-built and what its audit did and did not fix.
-
-**Both corpora are fully synthetic.** Every person, project, company, domain and
-address is invented, and every message body was generated from a fixed fictional
-cast defined before any document existed. Nothing was collected from a live
-account.
+Corpus B uses a different domain and generation model so results can be checked
+across corpora. Both corpora are fully synthetic; see their READMEs for
+provenance and limitations.
 
 Corpus A ships in two halves, and both are ingested **in order**:
 
@@ -119,19 +86,17 @@ corpus_a/corpus/part_a/   2026-04-16 .. 2026-05-11
 corpus_a/corpus/part_b/   2026-05-12 .. 2026-05-27   # supersedes part_a in places
 ```
 
-Two `ingest` calls, not one. Real memory has to survive being told something new
-that contradicts what it already believed — a launch date moves, a hire is made,
-a cost figure drops. Systems that can only rebuild from scratch may do so; their
-ingest token count will say so.
+The runner makes two `ingest` calls in order, testing whether memory handles
+later information that supersedes earlier claims.
 
 ---
 
-## ❓ What It Asks
+## What It Asks
 
-**Base set (155)**
+### Base set (155)
 
 | Type | Count | What it catches |
-|---|---:|---|
+| --- | ---: | --- |
 | `single_hop` | 30 | a fact stated in one document |
 | `multi_source` | 73 | a fact corroborated across several documents |
 | `disambiguation` | 15 | merging two things that only look alike, or splitting one that is not two |
@@ -139,12 +104,12 @@ ingest token count will say so.
 | `freshness` | 12 | reporting a superseded value as if it were current |
 | `citation` | 12 | recalling a detail only one document carries; cited ids are a diagnostic, not accuracy |
 
-**Hard set (31)** — added because the base set had stopped separating the
-designs being compared at the time; it was saturating, and a set that everything
-passes cannot measure an improvement.
+### Hard set (31)
+
+Added when the base set stopped separating systems.
 
 | Type | Count | What it catches |
-|---|---:|---|
+| --- | ---: | --- |
 | `set_difference` | 6 | which member of a plausible set does *not* belong |
 | `as_of` | 6 | what was true *at a date*, not what is true now |
 | `constraint` | 5 | two or three conditions at once, each matching several candidates alone |
@@ -152,18 +117,13 @@ passes cannot measure an improvement.
 | `attribution` | 5 | who proposed something versus who carried it out |
 | `ordering` | 4 | placing events relative to each other rather than looking one up |
 
-> 🎯 `as_of` is the one type built to be adversarial to ingest-time
-> consolidation: a memory that keeps only the current value has thrown the
-> answer away.
+> `as_of` tests whether a system retained historical values instead of only the
+> latest one.
 
-**All 186 are graded deterministically** — no shipped question defers to a
-judge, so no model runs in the scoring path. The grader does implement an `llm`
-mode and every report carries `deferred_to_judge`; it is always zero, and no
-judge is wired up to resolve one if it were not. Answers are matched after normalizing case, punctuation, whitespace, date
-spelling and thousands separators, against a per-mode rule set. `string_any` uses `accept` / `reject` /
-`require_all`; `boolean` uses `expected` plus `reject` / `require_all` and never
-reads `accept`; `ordering` uses `sequence` alone; `abstain` uses `reject` plus
-an optional `accept_as_decline`, and may not carry `accept` at all.
+**All 186 questions are graded deterministically; no model runs in the scoring
+path.** Answers are normalized for case, punctuation, whitespace, date spelling,
+and thousands separators before applying each mode's explicit rule set. Reports
+still include `deferred_to_judge`, which is always zero for shipped questions.
 
 Abstention questions have no correct answer. Something merely scheduled has not
 happened; a merge request that exists only as a reserved URL has not been
@@ -172,18 +132,15 @@ does not say" is scored right.
 
 ---
 
-## 🚀 Getting Started
+## Getting Started
 
-**What you need.** Python 3.9 or later on macOS or Linux, and `pytest`. Nothing
-else — the harness itself imports only the standard library. The shipped adapter
-definitions invoke `python3`, which a default Windows install does not provide.
-Scoring a real system additionally needs an API key for whatever endpoint you
-point the proxy at.
+Use Python 3.9+ on macOS or Linux and install `pytest`. A real run also needs an
+API key for the configured endpoint. The shipped adapters invoke `python3`,
+which a default Windows installation does not provide.
 
 ### 1. Check it works — offline, free, no API key
 
-> ✅ **Safe by default.** This path sends nothing over the network and costs
-> nothing.
+> **Offline and free.** This path sends nothing over the network.
 
 ```bash
 cd examples/tools/agent-memory-benchmark
@@ -207,7 +164,7 @@ and the report moves a number the tests pin.
 
 ### 2. Score a real system
 
-> ⚠️ **This spends money and sends data.** Corpus text and questions are sent to
+> **This spends money and sends data.** Corpus text and questions are sent to
 > the endpoint you point `--upstream` at, and you pay for those tokens. The
 > harness itself writes only under `results/` — but an adapter you add is not
 > sandboxed and can write anywhere your user can.
@@ -227,38 +184,13 @@ The runner ingests both corpus halves in order, feeds
 | `adapters/agentic_rag` | embedding index; the model writes its own queries over up to three rounds |
 | `adapters/ledger_rag` | drives the [Memory-Driven Chief of Staff](../../recipes/nvidia/memory-driven-chief-of-staff/README.md) ledger; SQLite ingest needs no network |
 
-> 📌 **Read `ledger_rag`'s score carefully.** It measures candidate selection
-> over that ledger plus the model. It is *not* a score of the recipe's own
-> behaviour: the ledger is built for triage and ranking and has no
-> question-answering path, so the selection and the answer call belong to this
-> adapter, not the recipe. Nothing in the adapter writes to or changes the
-> recipe.
+> **`ledger_rag` does not score the recipe itself.** The adapter adds candidate
+> selection and answer generation to a ledger designed for triage and ranking.
+> It does not modify the recipe.
 
 ---
 
-## ✨ Why It Is Built This Way
-
-- **Two numbers, never blended.** Quality (did it answer correctly?) and cost
-  (tokens at ingest, tokens per answer) are reported on separate axes. Total
-  cost of ownership is `ingest_tokens + N × per_question_tokens`; where those
-  curves cross is a question accuracy-only benchmarks do not answer.
-- **Deterministic grading — no judge model.** Answers are normalized for case,
-  punctuation and date spelling, then matched against an explicit rule set. A
-  benchmark whose scores move when the judge is upgraded cannot be compared
-  across years.
-- **Cost is measured, not self-reported.** The runner points `OPENAI_BASE_URL` /
-  `ANTHROPIC_BASE_URL` at a local proxy and counts what crosses the wire. A run
-  that declares proxy accounting and bypasses it is marked invalid.
-- **Any system can enter.** An adapter is a small JSON file naming two commands.
-  No harness change is needed to score a new memory design.
-- **Two corpora, two domains.** A result on one can be checked against the
-  other, so a design that happens to suit one domain cannot hide in the average.
-- **Runs offline.** A six-document fixture with a known score exercises the
-  whole pipeline with no model, no network and no API key.
-
----
-
-## 🗂️ Project Structure
+## Project Structure
 
 ```text
 agent-memory-benchmark/
@@ -305,7 +237,7 @@ its own requirements separately, inside its own directory.
 
 ---
 
-## ⚙️ Configuration
+## Configuration
 
 ### `adapter.json` — the contract for a system under test
 
@@ -352,7 +284,7 @@ interface AdapterConfig {
 }
 ```
 
-> ⚠️ **A declared accounting mode is enforced in both directions.** Three things
+> **A declared accounting mode is enforced in both directions.** Three things
 > make a run invalid:
 >
 > - it declares `proxy` and nothing crossed the proxy — the adapter either
@@ -400,7 +332,7 @@ MY_SYSTEM_PYTHON=~/src/my-system/.venv/bin/python \
 
 ---
 
-## 🧩 Adding Your System
+## Adding Your System
 
 1. Write an `adapter.json` as above.
 2. `answer` reads `questions.jsonl` on **stdin** and writes one JSON object per
@@ -426,30 +358,24 @@ interface AnswerRow {
 }
 ```
 
-3. Run it. Full instructions, including the path for a system that cannot be
+1. Run it. Full instructions, including the path for a system that cannot be
    wrapped in a command line: [`docs/SUBMITTING.md`](docs/SUBMITTING.md).
 
 ---
 
-## 🔐 How The Runner Treats Your Adapter
+## How The Runner Treats Your Adapter
 
-> ⚠️ **An adapter is local code you chose to run. It is not sandboxed.** It
-> executes with your user, your filesystem, and whatever credentials are in the
-> environment. Read an adapter before you run it, exactly as you would any
-> script from a repository.
+> **Adapters are not sandboxed.** They run with your user, filesystem access,
+> and environment credentials. Review an adapter before running it.
 
 **Commands are argument arrays, never shell strings.** `["my-cli", "ingest",
 "--corpus", "{corpus}"]` is executed directly with no shell in between, so a
 path containing a space or a quote cannot become a second command.
 
-**The guards are against accidents, not against an adapter that goes looking.**
-The answer key is *not* out of reach: the benchmark root is on `PYTHONPATH` so
-adapters can import `adapters._lib`, and an adapter can use that to locate and
-read `corpus_a/questions/answers.jsonl` directly.
-`tests/test_isolation_is_not_a_sandbox.py` demonstrates the bypass, reaching
-`REPO` through `bench.runner`. Treat a score as meaningful only for an adapter you
-trust — the benchmark measures memory, it does not police it. What the guards do
-provide:
+The guards prevent accidental answer-key access, not a malicious adapter. The
+benchmark root remains reachable through `PYTHONPATH`, as demonstrated by
+`tests/test_isolation_is_not_a_sandbox.py`. Trust the adapter behind any score.
+The guards provide:
 
 - Adapters are launched from a scratch directory, not from the benchmark root,
   so a relative `open("corpus_a/questions/answers.jsonl")` finds nothing.
@@ -465,16 +391,11 @@ provide:
 
 ---
 
-## 📊 Reading A Result
+## Reading A Result
 
-Accuracy is reported **per question type**. An overall figure is reported too,
-first, because a reader wants one — but it is an average over a question mix
-this benchmark chose, so the per-type rows are what a comparison should rest on.
-Freshness is split further, into questions where the superseded value is also in
-the corpus (the system must resist it) and questions where it is not (a plain
-recency check). Evidence recall and citation coverage sit alongside accuracy and
-are never folded into it — they diagnose *how* a system found an answer, which is
-not the same as whether it was right.
+Compare per-question-type accuracy, not only the overall average. Freshness
+separates cases with and without a competing stale claim. Evidence recall and
+citation coverage remain diagnostics rather than accuracy inputs.
 
 Why the two axes are never combined, and what deterministic grading cannot
 express: [`docs/methodology.md`](docs/methodology.md).
@@ -484,20 +405,12 @@ corpus, same questions, same answer key, same normalization, same scorer.
 
 ---
 
-## 📈 Published Results
+## Published Results
 
-One pair of runs ships as a worked example: a self-model and an agentic
-retrieval baseline on corpus A, both on the same base model, both graded by the
-grader in this repository. **In this pair of runs** the self-model scored higher
-overall and on most question types, and lower on two — `abstention`, where it
-answered 10 of 13 against the baseline's 13, and `single_hop`. Those are counts
-from these two runs; the artifacts do not include the self-model's memory, so
-they cannot say what caused any of it.
-It also spends its tokens differently: most of the self-model's fall in the
-ingest phase, most of the baseline's fall per question — though the self-model's
-per-question figure is the larger of the two. The results page reports the two
-counts separately rather than as one ratio, because neither run carries the
-forwarded-call record that would establish they counted the same events.
+The repository includes one self-model run and one agentic retrieval run on
+corpus A with the same base model and grader. The artifacts show their scores
+and separate ingest and answer costs, but do not include the self-model's memory
+or enough accounting evidence for a cost ratio.
 
 Read [`results/README.md`](results/README.md) **before** the table there. Those
 runs are corpus A only, on one base model; their answers predate a rename at
@@ -506,7 +419,7 @@ limits are stated where the numbers are.
 
 ---
 
-## ✅ Verification
+## Verification
 
 **Evidence level:** `local/static`. **Verified on** Python 3.9.6, macOS. Nothing
 here exercises a live endpoint.
@@ -521,18 +434,13 @@ python3 -m pytest tests/     # expected: 219 passed
 219 passed
 ```
 
-**This verifies:** the runner, grader, report renderer and the ledger adapter's
-SQLite ingest agree with the shipped corpus, questions and answer key; the two
-fixture adapters still score exactly 1.0 and 0.0; and the claims the
-documentation makes about hashes, counts and domains still hold.
-
-**This does not verify:** any scored run against a live endpoint, the accounting
-proxy against real upstream traffic, a real model call from any adapter, or
+This verifies the runner, grader, report renderer, ledger ingest, fixtures, and
+documented corpus counts. It does not test a live endpoint, real model call, or
 Windows.
 
 ---
 
-## 🩺 Troubleshooting
+## Troubleshooting
 
 | Symptom | Cause | Fix |
 | --- | --- | --- |
@@ -546,59 +454,31 @@ Windows.
 | USD is `null` in the report | `bench/pricing.py` has no entry for that model. | Expected. Token counts are still exact; the harness will not invent a price. |
 | Two reports refuse to be compared | Their `fingerprint` blocks differ — corpus, questions, key, normalization or scorer moved. | Re-score the stored answers: `python3 tools/regrade.py --run results/runs/<dir>` |
 | A phase hangs, then dies at six hours | The per-phase wall-clock budget. | Raise `MNEMO_TIMEOUT_SECONDS`, or set `0` to wait indefinitely. |
-| `results/` grew by hundreds of megabytes | Each run keeps whatever memory the system under test built. | Delete the run directory; see [Cleanup](#-cleanup). |
+| `results/` grew by hundreds of megabytes | Each run keeps whatever memory the system under test built. | Delete the run directory; see [Cleanup](#cleanup). |
 
 ---
 
-## 🧹 Cleanup
+## Cleanup
 
-Each run writes `results/runs/<timestamp>-<adapter>/`, holding the report, the
-verdicts, the answers, and whatever memory the system under test built — that
-last part can reach hundreds of megabytes. Delete the run directory to reclaim
-the space.
+Each run writes reports, verdicts, answers, and adapter state under
+`results/runs/<timestamp>-<adapter>/`. Delete that directory to reclaim space.
 
 By default nothing outside that directory is modified by the harness. `--out`
 and `--state` will write wherever you point them, and an adapter is not
 sandboxed, so one you add can write elsewhere; see
-[How the runner treats your adapter](#-how-the-runner-treats-your-adapter).
+[How the runner treats your adapter](#how-the-runner-treats-your-adapter).
 
-A generated run is **ignored**, not merely untracked, so `git add -A` after a run
-cannot sweep one in. Publishing a run means un-ignoring it by name in
-`.gitignore` — the deliberate act that put the two directories in `results/runs/`
-there.
+A generated run is ignored by Git. Publishing one requires an explicit
+`.gitignore` exception.
 
 ---
 
-## 🔎 At A Glance
-The information contract this repository asks every example to publish. The
-rows that change what you do are repeated above, where you need them.
-
-| Question | Answer |
-| --- | --- |
-| Category | Developer Tool |
-| Contributor or provenance | NVIDIA |
-| Use this when | You need to compare memory designs — consolidating, retrieval, or anything else — on the same corpus and the same questions. |
-| You will get | Accuracy per question type, plus ingest and per-answer token cost measured at a proxy rather than self-reported. |
-| Runs on | Any host with Python 3.9 or later, on macOS or Linux. The shipped adapter definitions invoke `python3`, which a default Windows install does not provide. |
-| Requires | `pytest` for the offline check. To score a real system: an API key for an OpenAI-compatible endpoint, and an adapter for the system under test. |
-| Verified on | Python 3.9.6 on macOS. Offline self-test and unit tests only; no scored run against a live endpoint is included as evidence here. |
-| Evidence level | local/static |
-| Support and maturity | Best-effort community support; see [SUPPORT.md](../../../SUPPORT.md). |
-| External access, data, and actions | Scoring a real system sends corpus text and questions to the endpoint you point `--upstream` at, and you pay for those tokens. The harness writes only under `results/`; an adapter you add is not sandboxed and can write anywhere your user can. The offline self-test sends nothing and costs nothing. |
-| Start here | [Getting Started](#-getting-started) — offline, no key required |
-| Confirm success | [Verification](#-verification) |
-
----
-
-## 🏷️ Provenance And License
+## Provenance And License
 
 Authored and maintained by NVIDIA, contributed under Apache-2.0.
 
-Both corpora are fully synthetic: every person, company, project, domain and
-address is invented, every message body was generated from a fixed fictional
-cast, and nothing was collected from a live account. The file and symbol names
-in corpus A's engineering threads describe its own fictional codebase. Every
-address sits under the RFC 2606 reserved `.example` top-level domain.
+Both corpora are synthetic and use invented identities, projects, messages, and
+reserved `.example` domains. Nothing came from a live account.
 
 How the corpora were generated, what was screened before publication, and the
 content hashes that say whether two scores are comparable:
@@ -606,3 +486,25 @@ content hashes that say whether two scores are comparable:
 
 **License:** Apache-2.0 throughout — code, corpus, questions and answer key
 alike, under the repository's [LICENSE](../../../LICENSE).
+
+---
+
+## Metadata
+
+```yaml
+name: agent-memory-benchmark
+display_name: mnemo — Agent Memory Benchmark
+category: Developer Tool
+provenance: NVIDIA
+language: python
+python_requires: ">=3.9"
+runtime_dependencies: none (Python standard library only)
+dev_dependencies: [pytest]
+entry_point: python3 -m bench.runner
+offline_check: python3 -m pytest tests/
+adapter_contract: docs/SUBMITTING.md
+corpora: [corpus_a/, corpus_b/]
+question_count: 186  # corpus A; corpus B adds 96, see corpus_b/README.md
+license: Apache-2.0
+evidence_level: local/static
+```

--- a/examples/tools/agent-memory-benchmark/corpus_a/README.md
+++ b/examples/tools/agent-memory-benchmark/corpus_a/README.md
@@ -1,28 +1,12 @@
----
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
-name: agent-memory-benchmark-corpus-a
-display_name: Corpus A — software platform engineering
-parent: ../README.md
-location_note: kept outside corpus_a/corpus/ because every file under the corpus root is hashed into the corpus fingerprint
-documents: 425
-emails: 200
-chat_documents: 225
-chat_messages: 559
-period: 2026-04-16 .. 2026-05-27
-split_after: 2026-05-11
-questions: 186
-synthetic: true
-license: Apache-2.0
----
+<!-- markdownlint-disable MD013 -->
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- markdownlint-enable MD013 -->
 
-# 💼 Corpus A — software platform engineering
+# Corpus A — software platform engineering
 
-Six weeks of one person's inbox and team chat at a fictional software platform
-company: an ingest pipeline being rebuilt, a launch date that moves, a hire, a
-cost figure that drops, and the ordinary traffic around all of it. **This is the
-corpus every question in `questions/` is asked about, and the one every published
-result was produced on.**
+Six weeks of synthetic email and team chat from a software platform company.
+All published results and questions use this corpus.
 
 | | |
 | --- | --- |
@@ -32,36 +16,20 @@ result was produced on.**
 | Domain | a software platform-engineering team |
 | Questions asked about it | 186, in [`questions/questions.jsonl`](questions/questions.jsonl) |
 
-> 🧪 Everyone and everything in it is fictional. See
-> [Provenance](#️-provenance-and-what-was-checked).
+> Everyone and everything in it is fictional. See
+> [Provenance](#provenance-and-what-was-checked).
 
 ---
 
-## 📑 Table of Contents
-
-- [🔀 Why It Ships In Two Halves](#-why-it-ships-in-two-halves)
-- [🗂️ Layout](#️-layout)
-- [📄 What A Document Looks Like](#-what-a-document-looks-like)
-- [🚀 Using It](#-using-it)
-- [🕵️ Provenance And What Was Checked](#️-provenance-and-what-was-checked)
-- [⚠️ Known Limitations](#️-known-limitations)
-
----
-
-## 🔀 Why It Ships In Two Halves
+## Why It Ships In Two Halves
 
 ```text
 corpus_a/corpus/part_a/   2026-04-16 .. 2026-05-11   212 documents
 corpus_a/corpus/part_b/   2026-05-12 .. 2026-05-27   213 documents — supersedes part_a in places
 ```
 
-The runner makes **two `ingest` calls, not one**, and feeds them in that order.
-
-That is the whole point of the split. Real memory has to survive being told
-something new that contradicts what it already believed — a launch date moves, a
-hire is made, a cost figure drops. A system that answers from `part_a` after
-reading `part_b` is not remembering, it is stuck. Several question types exist
-only to catch that:
+The runner ingests both parts in order. The split tests whether a system handles
+later claims that supersede earlier ones:
 
 | Question type | What the split lets it test |
 | --- | --- |
@@ -69,21 +37,15 @@ only to catch that:
 | `chain_freshness` | a value that moved twice — where it started and where it ended |
 | `as_of` | what was true *at a date*, which a memory that keeps only the current value has thrown away |
 
-A system that can only rebuild from scratch on the second call may do so. Its
-ingest token count will say so.
+A system may rebuild on the second call; its ingest cost records that choice.
 
 ---
 
-## 🗂️ Layout
+## Layout
 
-> 📌 This page sits at `corpus_a/README.md`, one level **above** the documents,
-> because `bench.fingerprint.hash_tree` hashes **every file** under the corpus
-> root — all 428 of them, not only the 425 documents. A README added there
-> changes the corpus hash, and every published result stops being comparable to
-> what ships. The shipped adapters would not have ingested it (the runner hands
-> them `part_a` and `part_b`, and they skip a file with no `doc_id:`), but a
-> third-party adapter is handed a directory and cannot be assumed to do either.
-> `corpus_b/` has the same shape for the same reason.
+> This README stays outside `corpus_a/corpus/` because the fingerprint hashes
+> every file under the corpus root. Adding documentation there would invalidate
+> comparison with published results. Corpus B uses the same layout.
 
 ```text
 corpus_a/
@@ -121,7 +83,7 @@ corpus_a/
 
 ---
 
-## 📄 What A Document Looks Like
+## What A Document Looks Like
 
 Every document is Markdown with a YAML frontmatter block. Two shapes:
 
@@ -160,7 +122,7 @@ diagnostics, and what `verdicts.jsonl` reports as the evidence an answer cited.
 
 ---
 
-## 🚀 Using It
+## Using It
 
 This is the default corpus, so the runner uses it with no flags:
 
@@ -178,51 +140,52 @@ python3 -m bench.runner \
     --gold corpus_a/questions/answers.jsonl
 ```
 
-> 🔍 A corpus A report and a corpus B report are **not** comparable: the
-> `fingerprint` block differs by construction, which is the mechanism that stops
-> the two being averaged together. Compare a system against itself across the two
-> corpora — that is what [`../corpus_b/`](../corpus_b/README.md) is for.
+> Corpus A and B reports have different fingerprints. Compare one system across
+> both corpora; do not average or compare unmatched reports.
 
 ---
 
-## 🕵️ Provenance And What Was Checked
+## Provenance And What Was Checked
 
-**Fully synthetic.** Every person, company, project, domain and address is
-invented. Every message body was generated by a language model constrained to a
-fixed fictional cast written before any document existed, so an identity outside
-that cast cannot appear. Nothing was collected from a live mailbox, workspace or
-account.
+**Fully synthetic.** All identities, organizations, projects, domains, messages,
+and technical identifiers are fictional. Nothing came from a live account.
 
-The technical identifiers in the engineering threads — file paths, module names,
-table names — describe the fictional codebase the corpus is about. They were
-reviewed before publication and renamed where they were not.
+Every address uses an RFC 2606 reserved `.example` domain.
 
-**Every address sits under an RFC 2606 reserved domain.** The corpus uses
-`examplecorp.example`, `gitlab.examplecorp.example`, `chatplatform.example` and
-`metricswatch.example` — all under the `.example` top-level domain, which can
-never be registered. This matters more than it looks: the corpus previously used a `.com` that
-*reads* like a placeholder but is registrable, so it is not named here either.
-
-**`CANARY.txt` is a training-data marker.** It carries a unique string that
-appears nowhere else in this repository. If a model ever emits it, that is
-evidence this corpus reached its training data, which would make any score from
-that model meaningless. Nothing here watches for it — no grader, report or test
-scans an answer for the string. It is a marker for whoever looks, not a gate.
+`CANARY.txt` contains a unique training-data marker. The benchmark does not scan
+answers for it; a reviewer must check any suspected match.
 
 Full generation and screening record, plus the content hashes that decide whether
 two scores are comparable: [`../docs/provenance.md`](../docs/provenance.md).
 
 ---
 
-## ⚠️ Known Limitations
+## Known Limitations
 
 - **Synthetic.** Real email is messier: quoted forwards, dead threads, meaning
   that depends on a conversation held in a corridor.
 - **One persona, one domain, one language, one scale.** A result here is a result
   about six weeks of one fictional engineering team — which is why
   [`../corpus_b/`](../corpus_b/README.md) exists.
-- **This corpus was reviewed and edited for publication.** Corpus B was written
-  key-first from scratch instead, which is a cleaner *procedure* — though both
-  were edited before publication, only the editor differs, and corpus B is the
-  one whose page discloses unresolved defects. Neither is the cleaner artifact
-  on the evidence that ships.
+- **Edited for publication.** Corpus B used a different key-first procedure and
+  documents its own unresolved defects.
+
+---
+
+## Metadata
+
+```yaml
+name: agent-memory-benchmark-corpus-a
+display_name: Corpus A — software platform engineering
+parent: ../README.md
+location_note: kept outside corpus_a/corpus/ because every file under the corpus root is hashed into the corpus fingerprint
+documents: 425
+emails: 200
+chat_documents: 225
+chat_messages: 559
+period: 2026-04-16 .. 2026-05-27
+split_after: 2026-05-11
+questions: 186
+synthetic: true
+license: Apache-2.0
+```

--- a/examples/tools/agent-memory-benchmark/corpus_b/README.md
+++ b/examples/tools/agent-memory-benchmark/corpus_b/README.md
@@ -1,26 +1,13 @@
----
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
-name: agent-memory-benchmark-corpus-b
-display_name: Corpus B — construction program management
-parent: ../README.md
-documents: 173
-questions: 96
-period: 2027-07-20 .. 2027-09-24
-split_after: 2027-08-28
-domain: construction program management
-synthetic: true
-authored_by: DeepSeek V4 Pro (key-first), audited by a second frontier model
-license: Apache-2.0
----
+<!-- markdownlint-disable MD013 -->
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- markdownlint-enable MD013 -->
 
-# 🏗️ Corpus B — construction program management
+# Corpus B — construction program management
 
-A second corpus, in a domain deliberately far from corpus A's software
-engineering, so that a result on one can be checked against the other. Dana
-Okafor runs three building sites across permits, inspections, change orders,
-concrete pours and steel deliveries. **Everyone and everything in it is
-fictional.**
+A synthetic construction-program corpus for checking whether results transfer
+beyond corpus A's software-engineering domain. Dana Okafor manages three
+fictional building sites.
 
 | | |
 | --- | --- |
@@ -33,44 +20,21 @@ fictional.**
 
 ---
 
-## 📑 Table of Contents
+## Why It Exists
 
-- [🎯 Why It Exists](#-why-it-exists)
-- [🔨 How It Was Made, And What That Guarantees](#-how-it-was-made-and-what-that-guarantees)
-- [🗂️ Layout](#️-layout)
-- [🚀 Using It](#-using-it)
-- [⚠️ Known Limitations](#️-known-limitations)
+Corpus B uses a different domain, cast, and generation model. Results that hold
+across both corpora are less likely to depend on one corpus's conventions.
 
 ---
 
-## 🎯 Why It Exists
+## How It Was Made, And What That Guarantees
 
-One corpus cannot tell you whether a result is about the memory system or about
-the corpus. Corpus A is one domain, one cast, one set of conventions — and a
-system whose design happens to suit material like it will look better than it
-is.
+The answer key defined entities, timelines, superseded values, ambiguous
+records, and multi-document facts before generation. DeepSeek V4 Pro wrote the
+corpus; a second model family audited it over nine rounds. Neither model is a
+shipped benchmark baseline.
 
-This corpus was written from scratch in an unrelated domain, by a different
-model family, from an answer key drafted before any document existed. **A result
-that holds on both is a result about the system.**
-
----
-
-## 🔨 How It Was Made, And What That Guarantees
-
-The answer key was written **before** any document existed: entities, a timeline,
-and deliberately planted structure — values that get overturned, records that
-look alike, things scheduled but never held, facts split across several
-documents, one disagreement nobody settles. Documents were then generated from
-that key, which is why nothing had to be annotated afterwards and why every fact
-has exact provenance.
-
-Two models were used, and **neither is a baseline shipped with this benchmark**:
-the corpus was written by **DeepSeek V4 Pro** and audited by a second frontier
-model from a different family. The audit ran nine times. It is worth being
-precise about what it fixed and what it did not.
-
-### ✅ Fixed, and checked at generation time
+### Fixed, and checked at generation time
 
 - documents that described events later than their own date
 - supersession chains recited in a single message
@@ -79,31 +43,24 @@ precise about what it fixed and what it did not.
 - cross-document facts collapsed into one place
 - planted sentences missing altogether
 
-A generation-time checker enforced all of these before publication and reported
-zero. **That checker is not part of this contribution**, so nothing in this
-repository re-checks them; what ships is the corpus it produced. The tests that
-do run here cover the answer key — id agreement, dangling citations, empty-body
-citations, grading-rule sanity — not the six items above.
+A generation-time checker reported zero violations for these items. It does not
+ship; repository tests cover answer-key IDs, citations, bodies, and grading
+rules instead.
 
-> 📌 The checker did **not** test for an empty body, and two documents ship with
+> The checker did **not** test for an empty body, and two documents ship with
 > frontmatter and no body — `E:2027-08-24T12-40-00__1886520e` and
 > `E:2027-08-25T15-01-00__42183c16`. No published question depends on either.
 
-### ❌ Not fixed
+### Not fixed
 
-The reviewer still flags prose-level imperfections: a phrase that reads like an
-answer key, two similar records mentioned in one thread, an incidental date that
-does not line up. Across nine rounds those counts moved between roughly 30 and
-130 without converging, because each regeneration resamples all 173 documents and
-grows a fresh tail of one-off defects. Those are generation-time observations;
-the review records behind them are not part of this contribution.
+The audit still found prose defects, including answer-like phrasing, similar
+records in one thread, and inconsistent incidental dates. Regeneration did not
+converge, and the audit records do not ship.
 
-### 🎯 So what is actually guaranteed
+### Guarantee
 
-**The guarantee this corpus makes is about its questions, not about every
-sentence of its prose.** Each question is checked against the corpus before it
-ships: the expected answer must actually be present, and a question whose answer
-cannot be verified is dropped rather than published.
+The guarantee applies to questions, not every sentence. Each expected answer
+must appear in the corpus; unverifiable questions are dropped.
 
 | Draft pool | Drafted | Dropped | Shipped | Reasons recorded in |
 | --- | ---: | ---: | ---: | --- |
@@ -113,7 +70,7 @@ cannot be verified is dropped rather than published.
 
 ---
 
-## 🗂️ Layout
+## Layout
 
 ```text
 corpus_b/
@@ -137,14 +94,12 @@ corpus_b/
     └── factual_items.json         the 59 drafted factual questions that were kept
 ```
 
-The generator, the answer-key spec it was written from, and the drafts it
-produced are **not** shipped: they are how the corpus was made, not evidence
-about it. What ships is the corpus, its questions, and the record of what was
-dropped.
+The generator, answer-key specification, and drafts do not ship. The corpus
+includes its questions and dropped-question records.
 
 ---
 
-## 🚀 Using It
+## Using It
 
 Point the runner at this corpus instead of corpus A:
 
@@ -156,19 +111,33 @@ python3 -m bench.runner \
     --gold corpus_b/questions/answers.jsonl
 ```
 
-> 🔍 A corpus B report is **not** comparable with a corpus A report: the
-> `fingerprint` block differs by construction, which is the mechanism that stops
-> the two being averaged together. Compare a system against itself across the two
-> corpora, not one system on A against another on B.
+> Corpus A and B reports have different fingerprints. Compare one system across
+> both corpora; do not compare systems on unmatched corpora.
 
 ---
 
-## ⚠️ Known Limitations
+## Known Limitations
 
 - **Synthetic.** Real email is messier: quoted forwards, dead threads, meaning
   that depends on a conversation held in a corridor.
 - **One persona, one domain, one language, one scale.**
-- **The two models are not fully independent.** The auditing model proposed some
-  of the planted structure and, in one round, authored line edits to bring
-  documents onto the key. It never invented facts — the key is ours — but they
-  are not independent.
+- **The two models are not fully independent.** The auditor proposed some
+  structure and authored line edits in one round.
+
+---
+
+## Metadata
+
+```yaml
+name: agent-memory-benchmark-corpus-b
+display_name: Corpus B — construction program management
+parent: ../README.md
+documents: 173
+questions: 96
+period: 2027-07-20 .. 2027-09-24
+split_after: 2027-08-28
+domain: construction program management
+synthetic: true
+authored_by: DeepSeek V4 Pro (key-first), audited by a second frontier model
+license: Apache-2.0
+```

--- a/examples/tools/agent-memory-benchmark/results/README.md
+++ b/examples/tools/agent-memory-benchmark/results/README.md
@@ -96,7 +96,7 @@ below.
 
 ## The Rename, And Why The Answers Were Transformed
 
-Publication renamed 20 text identifiers and 4 question IDs. Each `report.json`
+Publication renamed 20 text identifiers and 4 question ids. Each `report.json`
 lists the ordered substitutions under `provenance_note.substitutions`; stored
 answers predate those names.
 

--- a/examples/tools/agent-memory-benchmark/results/README.md
+++ b/examples/tools/agent-memory-benchmark/results/README.md
@@ -1,51 +1,24 @@
----
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
-name: agent-memory-benchmark-results
-display_name: Reference Results
-parent: ../README.md
-corpus: corpus A only
-base_models: 1
-runs: [agentic-rag_corpus-a_nemotron, self-model_corpus-a_nemotron]
-questions: 186
-reproducible_as_is: false
-cost_comparable: false
-license: Apache-2.0
----
+<!-- markdownlint-disable MD013 -->
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- markdownlint-enable MD013 -->
 
-# 📈 Reference Results
+# Reference Results
 
-One pair of runs on **corpus A only**, both on the same base model, both graded
-by the grader in this repository. They are here so a reader can see what the
-benchmark produces and check a number against the verdicts that produced it —
-**not as a ranking, and not as a claim about either architecture in general.**
+Two reference runs show the benchmark's output and supporting verdicts. Both use
+corpus A, one base model, and the repository's grader; they are not a ranking.
 
-> ⚠️ **Four limits govern everything below:** corpus A only, one base model, not
-> reproducible as-is, and cost that these artifacts cannot compare. Each is
-> explained in [What These Numbers Are Not](#-what-these-numbers-are-not) and in
-> [Cost](#-cost). Read those before quoting anything from the tables.
+> **Limits:** corpus A only, one base model, not reproducible as-is, and no
+> defensible cost comparison. Read [What These Numbers Are Not](#what-these-numbers-are-not)
+> and [Cost](#cost) before quoting the tables.
 
 ---
 
-## 📑 Table of Contents
+## The Two Settings
 
-- [⚖️ The Two Settings](#️-the-two-settings)
-- [📊 Corpus A, NVIDIA Nemotron 3 Ultra](#-corpus-a-nvidia-nemotron-3-ultra)
-- [💰 Cost](#-cost)
-- [🚫 What These Numbers Are Not](#-what-these-numbers-are-not)
-- [🔤 The Rename, And Why The Answers Were Transformed](#-the-rename-and-why-the-answers-were-transformed)
-- [🗂️ Where The Files Are](#️-where-the-files-are)
-
----
-
-## ⚖️ The Two Settings
-
-Both runs read the same 425 documents, answer the same 186 questions, are graded
-by the same answer key and the same grader, and answer with the same base model.
-The difference the benchmark is built to price is **when the reasoning
-happens**. It is not the only difference — the baseline is a round-capped
-configuration and also calls an embedding model — and the rows below say which
-of them the artifacts can show.
+Both runs read 425 documents, answer 186 questions, and use the same key, grader,
+and base model. They differ primarily in when reasoning happens; the baseline
+also uses embeddings and a round cap.
 
 | | Agentic RAG | Self-model |
 | --- | --- | --- |
@@ -54,26 +27,16 @@ of them the artifacts can show.
 | What its memory is when questions start | the raw documents, plus the index | whatever ingest produced; it does not ship, so this page cannot say |
 | How it answers | writes its own search queries, retrieves, and repeats for up to three rounds | 1,675 calls in the answer phase; the mechanism is not observable here |
 | Where the cost falls | per question, every question | once, up front |
-| Ships in this repository | ✅ `adapters/agentic_rag/`, hashed into its report | ❌ |
+| Ships in this repository | Yes: `adapters/agentic_rag/`, hashed into its report | No |
 
-That last row is the important caveat about these numbers. The agentic baseline
-is code you can run: its adapter ships here, and its report records the hash of
-that adapter **as it ships today** — enough to tell whether it has moved since,
-which is not the same as a hash captured while the run was executing. The run
-predates the field. The self-model is a system that exists
-elsewhere; only its outputs ship. Its rows are a data point, not something you
-can re-execute from this repository — [`docs/SUBMITTING.md`](../docs/SUBMITTING.md)
-describes the contract any consolidating system would implement to be scored the
-same way.
-
-The two rows of the cost table below follow directly from this table: a design
-that front-loads its reasoning and a design that defers it do not have one
-comparable "total", so ingest cost and per-question cost are reported separately
-and never summed.
+The agentic adapter ships; the self-model does not, so only its outputs are
+available. The agentic report hashes the current adapter, not the version used
+during the older run. See [`docs/SUBMITTING.md`](../docs/SUBMITTING.md) for the
+adapter contract. Ingest and per-question costs remain separate.
 
 ---
 
-## 📊 Corpus A, NVIDIA Nemotron 3 Ultra
+## Corpus A, NVIDIA Nemotron 3 Ultra
 
 | Metric | Agentic RAG | Self-model | Difference |
 | --- | ---: | ---: | ---: |
@@ -87,25 +50,14 @@ and never summed.
 | Single-hop lookup — `single_hop` (30) | 86.7% | 83.3% | -3.3 pp |
 | Citation coverage (186) | 92.5% | 97.8% | +5.4 pp |
 
-Two rows go the other way, and they are in the table above rather than left out
-of it. **What the artifacts establish is the counts.** On `abstention`, the
-agentic baseline answered 13 of 13 correctly and the self-model 10 of 13. On
-`single_hop`, the baseline scored 86.7% against the self-model's 83.3%. Both
-differences are visible per question in each run's `verdicts.jsonl`.
-
-**Why is not established here, and the difference matters.** These artifacts do
-not include the self-model's adapter or the memory it built, so nothing in them
-can show what a wrong answer was derived from. One hypothesis worth testing is
-that a system answering from a consolidated record is less able to tell "the
-record does not establish this" from "the record does not mention this" — but
-this pair of runs cannot confirm or refute it, and it says nothing about
-ingest-time consolidation in general. Testing it needs runs where the memory is
-inspectable, on more than one corpus and more than one base model. Read the two
-rows as measurements, not as a finding about either architecture.
+The agentic baseline leads on `abstention` and `single_hop`; per-question details
+are in each `verdicts.jsonl`. The artifacts do not include the self-model's
+adapter or memory, so they establish measurements, not causes or architectural
+conclusions.
 
 ---
 
-## 💰 Cost
+## Cost
 
 The benchmark reports cost separately and never blends it into accuracy.
 
@@ -114,44 +66,27 @@ The benchmark reports cost separately and never blends it into accuracy.
 | Ingest tokens | 169,852 | 182,760,709 |
 | Tokens per question | 14,509 | 241,240 |
 
-> 🚫 **Read the two tables together, but not as a ratio.** Each cost column is
-> what that run observed for itself. Neither report carries a forwarded-call
-> record, so nothing in these artifacts establishes that the two runs counted the
-> same events — which is why both set `comparable_on_cost` to false, and why no
-> multiple between the columns is stated here or in the reports.
+> **Do not treat the cost columns as a ratio.** Neither report carries a
+> forwarded-call record proving that both counted the same events; both set
+> `comparable_on_cost` to false.
 
-What each run's own counts do show is where it spends: 80% of the self-model's
-tokens fall in the ingest phase, and 94% of the baseline's fall in the answer
-phase. What those tokens were spent *on* is not in these artifacts. Whether that trade is worth making depends
-on how many questions the memory will ever be asked — a judgement
-[`docs/methodology.md`](../docs/methodology.md) declines to collapse into one
-number. A run that wants a defensible cost comparison has to be executed under
-the current harness, which records forwarded calls.
+The self-model spends 80% of its tokens during ingest; the baseline spends 94%
+during answering. The artifacts do not show what those tokens did. A defensible
+comparison requires a current run with forwarded-call records.
 
-Two notes on the cost table. The agentic baseline's ingest cost is an embedding
-pass and nothing else, which is why its output tokens are zero; it does no
-reasoning at ingest time, which is the whole distinction being measured. And the
-reports price only what `bench/pricing.py` knows. That embedding model has an
-entry, so the agentic ingest phase carries a real figure, $0.0034; the Nemotron
-model that answers in both runs has none, so every other phase reports token
-counts with a null price rather than inventing one. **Read the tables in tokens,
-not dollars**: with three of the four phases unpriced, one dollar figure cannot
-be ranked against them.
+The baseline's ingest phase is embedding-only and reports zero output tokens.
+`bench/pricing.py` prices that embedding pass at $0.0034 but has no Nemotron
+price, so compare token counts rather than incomplete dollar values.
 
 ---
-## 🚫 What These Numbers Are Not
 
-**Corpus A only.** Corpus B ships with the benchmark and was not run on this
-model. Corpus B exists precisely because a result on one corpus is a result
-about that corpus — see [`corpus_b/README.md`](../corpus_b/README.md) — so the
-table above says nothing about how either design behaves on documents shaped
-differently. Do not read it as a general finding.
+## What These Numbers Are Not
 
-**One base model.** [`docs/methodology.md`](../docs/methodology.md) asks a
-submission to run at least two and publish the difference, on the grounds that
-an advantage appearing under one model and vanishing under another is not an
-architectural advantage. This is one. Treat it as a worked example of the output
-format rather than as a submission that meets that bar.
+**Corpus A only.** Corpus B was not run, so the table does not show cross-domain
+behavior.
+
+**One base model.** The methodology asks submissions to run at least two. Treat
+this as an output example, not a complete submission.
 
 **Not reproducible as-is.** The systems answered against the corpus as it stood
 before publication, when a set of identifiers carried different names. See
@@ -159,34 +94,21 @@ below.
 
 ---
 
-## 🔤 The Rename, And Why The Answers Were Transformed
+## The Rename, And Why The Answers Were Transformed
 
-Publishing the corpus renamed 20 text identifiers and 4 question ids. The text
-side covers a project name and its lowercase form, several code symbols, a
-database filename, a workspace directory, a service module, a mailbox folder,
-and six documentation paths; the full list, in the order it was applied, is in
-each `report.json` under `provenance_note.substitutions`. The stored answers were
-produced before that and use the old names.
+Publication renamed 20 text identifiers and 4 question IDs. Each `report.json`
+lists the ordered substitutions under `provenance_note.substitutions`; stored
+answers predate those names.
 
-The same substitution applied to the corpus was applied to the answers, because
-an answer is derived from the corpus that produced it: a system reading the
-published corpus would have written the published name. Nothing else was
-changed, and each run ships `answers.as-answered.jsonl` — the output as
-answered, save for the one substitution noted below — so the transform can be
-checked rather than believed.
+The same substitutions were applied to answers. Each run includes
+`answers.as-answered.jsonl` so the transform can be checked.
 
-> 🔒 **Two changes are deliberately outside that map.** The self-model run's
-> `run_id` was de-identified at publication; it names no answer row, so it is
-> not part of a map whose only job is to reproduce `answers.jsonl`, and each
-> report records it under `provenance_note.run_id_note`. The other:
+> **Two changes sit outside that map.** The self-model `run_id` was de-identified
+> and recorded under `provenance_note.run_id_note`.
 >
-> **One further substitution is applied but not listed.** It replaced an email
-> and URL domain that is a registrable `.com`, with a domain reserved by RFC 2606.
-> Publishing its pre-image would put a registrable domain back into a public
-> artifact, which is the boundary the corpus sanitization exists to hold — so it is
-> **pre-applied** in `answers.as-answered.jsonl` rather than left there and listed
-> for reversal. The published map therefore reproduces `answers.jsonl` from that
-> file exactly, and no artifact in this repository carries the domain.
+> A registrable domain was also replaced by an RFC 2606 reserved domain. Its
+> pre-image is intentionally absent from public artifacts and the replacement is
+> pre-applied in `answers.as-answered.jsonl`.
 
 What it changed, measured:
 
@@ -196,18 +118,14 @@ What it changed, measured:
 | After the substitution | 82.8% | 89.8% |
 | Answers reported unanswered before the id map | 4 | 4 |
 
-The id map does more work than the text map. Four question ids were renamed at
-publication; without mapping them those four answers look absent, and an absent
-answer invalidates a run. That is the runner behaving correctly — it is also why
-a transformed result is weaker evidence than a fresh run.
+Without the four question-ID mappings, four answers appear absent and invalidate
+the run. A transformed result remains weaker evidence than a fresh run.
 
 ---
 
-## 🗂️ Where The Files Are
+## Where The Files Are
 
-One directory per run, all siblings under `results/runs/`. **Nothing nests:**
-each run directory holds its own complete copy of the same five files, and
-neither run lives inside the other.
+Each run is a sibling directory under `results/runs/` and contains five files.
 
 ```text
 results/
@@ -217,10 +135,8 @@ results/
     └── self-model_corpus-a_nemotron/      the self-model's run — the same five
 ```
 
-A directory is named `<system>_<corpus>_<base model>`, so a second corpus or a
-second base model adds a sibling rather than overwriting one of these. Both
-directories here end in `corpus-a_nemotron` because that is the only pair that
-was run; corpus B and a second model would appear alongside them.
+Directories use `<system>_<corpus>_<base model>`; new corpora or models add
+siblings instead of overwriting a run.
 
 Inside each one:
 
@@ -236,5 +152,22 @@ Two reports are comparable only when their `fingerprint` blocks match — same
 corpus, same questions, same answer key, same normalization, same scorer. Both
 of these were graded at the fingerprint the repository carries today.
 
-> 🧪 A generated run is ignored by `.gitignore`, not merely untracked. The two
-> directories above are published deliberately, by name.
+> Generated runs are ignored by default. The two directories above are explicit
+> published exceptions.
+
+---
+
+## Metadata
+
+```yaml
+name: agent-memory-benchmark-results
+display_name: Reference Results
+parent: ../README.md
+corpus: corpus A only
+base_models: 1
+runs: [agentic-rag_corpus-a_nemotron, self-model_corpus-a_nemotron]
+questions: 186
+reproducible_as_is: false
+cost_comparable: false
+license: Apache-2.0
+```

--- a/scripts/build_catalog.py
+++ b/scripts/build_catalog.py
@@ -452,6 +452,7 @@ def discover_example_paths(
 
 CATALOG_TABLE_HEADER = "| Catalog field | Value |"
 CATALOG_TABLE_DIVIDER = "| --- | --- |"
+CATALOG_METADATA_HEADING = "## Catalog Metadata"
 CATALOG_FIELD_ORDER = (
     "Description",
     "Industry",
@@ -672,12 +673,33 @@ def parse_readme_metadata(
     index += 1
     if index >= len(lines) or lines[index].strip():
         raise CatalogError(f"README title must be followed by a blank line in {readme_path}.")
-    index += 1
-    if index >= len(lines) or lines[index] != CATALOG_TABLE_HEADER:
+    body_start = index + 1
+    table_indices = [
+        line_index
+        for line_index in range(body_start, len(lines))
+        if lines[line_index] == CATALOG_TABLE_HEADER
+    ]
+    if not table_indices:
         raise CatalogError(
-            f"README title must be followed by `{CATALOG_TABLE_HEADER}` in {readme_path}."
+            f"README requires `{CATALOG_TABLE_HEADER}` after the title or in a "
+            f"final `{CATALOG_METADATA_HEADING}` section in {readme_path}."
         )
-    index += 1
+    if len(table_indices) > 1:
+        raise CatalogError(f"Duplicate catalog metadata tables in {readme_path}.")
+    table_index = table_indices[0]
+    metadata_heading_index: int | None = None
+    if table_index != body_start:
+        metadata_heading_index = table_index - 2
+        if (
+            metadata_heading_index < body_start
+            or lines[metadata_heading_index] != CATALOG_METADATA_HEADING
+            or lines[metadata_heading_index + 1].strip()
+        ):
+            raise CatalogError(
+                f"Catalog metadata must follow the README title or appear in a "
+                f"final `{CATALOG_METADATA_HEADING}` section in {readme_path}."
+            )
+    index = table_index + 1
     if index >= len(lines) or lines[index] != CATALOG_TABLE_DIVIDER:
         raise CatalogError(
             f"README catalog table must use `{CATALOG_TABLE_DIVIDER}` in {readme_path}."
@@ -713,8 +735,20 @@ def parse_readme_metadata(
             f"README catalog metadata table must be followed by a blank line in "
             f"{readme_path}."
         )
+    if metadata_heading_index is not None and any(
+        line.strip() for line in lines[index:]
+    ):
+        raise CatalogError(
+            f"`{CATALOG_METADATA_HEADING}` must be the final README section in "
+            f"{readme_path}."
+        )
     while index < len(lines) and not lines[index].strip():
         index += 1
+
+    if metadata_heading_index is None:
+        readme_body = "\n".join(lines[index:]).strip()
+    else:
+        readme_body = "\n".join(lines[body_start:metadata_heading_index]).strip()
 
     description = fields["Description"]
     if len(description) > 300:
@@ -780,7 +814,7 @@ def parse_readme_metadata(
         category=category,
         contributor=contributor,
         upstream_url=upstream_url,
-        readme_body="\n".join(lines[index:]).strip(),
+        readme_body=readme_body,
     )
 
 
@@ -955,7 +989,7 @@ def render_readme(
         "",
         "Examples are organized first by artifact type. Reusable recipes are organized",
         "again by contributor provenance. Industry is an independent discovery field.",
-        "This file is generated from the catalog metadata block at the top of each",
+        "This file is generated from the catalog metadata table in each",
         "example README. Edit that README, then run",
         "`python3 scripts/build_catalog.py --write` from the repository root.",
         "",

--- a/scripts/tests/test_build_catalog.py
+++ b/scripts/tests/test_build_catalog.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 from scripts.build_catalog import (
     CATEGORY_DEFINITIONS,
+    CATALOG_METADATA_HEADING,
     COLLECTION_DEFINITIONS,
     CatalogError,
     INDUSTRY_EMOJIS,
@@ -274,7 +275,7 @@ class CatalogBuildTests(unittest.TestCase):
         with self.assertRaisesRegex(CatalogError, "Missing.*Description"):
             load_catalog(root)
 
-    def test_description_paragraph_before_catalog_table_is_rejected(self) -> None:
+    def test_catalog_table_requires_a_supported_position(self) -> None:
         root = self._fixture_root()
         readme = root / "examples" / "recipes" / "community" / "sample" / "README.md"
         content = readme.read_text(encoding="utf-8").replace(
@@ -284,8 +285,24 @@ class CatalogBuildTests(unittest.TestCase):
         )
         readme.write_text(content, encoding="utf-8")
 
-        with self.assertRaisesRegex(CatalogError, "title must be followed by"):
+        with self.assertRaisesRegex(CatalogError, "must follow the README title"):
             load_catalog(root)
+
+    def test_catalog_table_can_be_the_final_readme_section(self) -> None:
+        root = self._fixture_root()
+        readme = root / "examples" / "recipes" / "community" / "sample" / "README.md"
+        title, remainder = readme.read_text(encoding="utf-8").split("\n\n", 1)
+        table, body = remainder.split("\n\n", 1)
+        readme.write_text(
+            f"{title}\n\n{body.rstrip()}\n\n"
+            f"{CATALOG_METADATA_HEADING}\n\n{table}\n",
+            encoding="utf-8",
+        )
+
+        entry = load_catalog(root)[0]
+
+        self.assertEqual(entry.description, "Produces a small observable fixture result.")
+        self.assertEqual(entry.readme_body, "A small fixture.")
 
     def test_description_row_must_be_plain_text_and_at_most_300_characters(self) -> None:
         invalid_descriptions = (


### PR DESCRIPTION
## Related Issue

Related to #122.

## Description

- Reframe the recipe around its user outcome: turning inbound conversations into a source-backed work wiki and focused attention recommendations.
- Distinguish the recipe's operational memory from Hermes built-in memory and document user-confirmed identity links introduced by #145.
- Add complete offline and NemoClaw onboarding, including the host/sandbox boundary, sandbox upload, the OpenShell rewrite sentinel, and effective-provider checks.
- Add structured metadata, directory and module contracts, configuration examples, troubleshooting, fixture documentation, and clearer lifecycle and Microsoft Graph guidance.
- Move technical YAML metadata and both required catalog tables to the end of their READMEs. Extend catalog generation to accept a final `Catalog Metadata` section while retaining existing opening tables.
- Remove decorative emoji, the recipe Features section, the benchmark At A Glance section, and 4,412 words of repeated explanation across six READMEs.
- Rebase on the generated catalog architecture and keep both root README catalog blocks valid.

## Verification

- [x] `python3 scripts/check_license_headers.py --check`
- [x] `python3 scripts/check_label_taxonomy.py --check` when governance metadata changes
- [x] `git diff --check`
- [x] Relevant example setup or syntax checks
  - `markdownlint-cli2` reports no non-MD013 issues; the remaining 48 findings are line-length warnings in required catalog rows, tables, code trees, and metadata values.
  - Field-for-field comparisons confirm that all five relocated metadata blocks retain their original values.
  - All 14 recipe test modules pass, for 603 tests in total.
  - `python3 scripts/build_catalog.py --validate-metadata` passes for 17 examples.
  - `python3 scripts/build_catalog.py --check` passes.
  - All 32 Python catalog tests and 12 Node catalog tests pass.
  - All local links in the changed Markdown files resolve.
  - The pull request title passes `scripts/check_pr_title.py`.

## Documentation Writer Review

- [x] Documentation writer review completed for the final changes
- Result: `docs-updated`
- Evidence or justification: `CONTRIBUTING.md`, `examples/README.md`, `examples/tools/README.md`, `examples/recipes/nvidia/memory-driven-chief-of-staff/README.md`, `examples/recipes/nvidia/memory-driven-chief-of-staff/fixtures/README.md`, `examples/recipes/nvidia/memory-driven-chief-of-staff/docs/data-lifecycle.md`, `examples/recipes/nvidia/memory-driven-chief-of-staff/docs/set-up-graph.md`, `examples/tools/agent-memory-benchmark/README.md`, `examples/tools/agent-memory-benchmark/corpus_a/README.md`, `examples/tools/agent-memory-benchmark/corpus_b/README.md`, and `examples/tools/agent-memory-benchmark/results/README.md`
- Reviewer: Codex
- [x] Changed user-facing text follows the
  [writing guide](https://github.com/NVIDIA/nemoclaw-community/blob/main/WRITING.md)
  and
  [controlled-word list](https://github.com/NVIDIA/nemoclaw-community/blob/main/.agents/skills/_shared/controlled-words.md).
- [x] A public contributor can understand the changed text without internal
  company context.
- [x] I reviewed any agent-generated text before submission.

## Release And Compliance

- [x] No secrets or credentials are included, including API keys, access tokens,
  passwords, local `.env` files, private certificates, or token caches.
- [x] No nonpublic project names, environment names, hostnames, URLs, ticket
  identifiers, workspace paths, logs, screenshots, or configuration values are
  included.
- [x] Third-party dependency changes are reflected in `THIRD-PARTY-NOTICES`.
  No third-party dependencies changed.
- [x] Public content uses sanitized examples and placeholders instead of private
  values.
- [x] I added my DCO sign-off declaration to this pull request description.

Signed-off-by: XuanWu <xuwu@nvidia.com>