### PR TITLE
fix(governance): close DCO and catalog validation gaps

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -40,18 +40,22 @@ jobs:
 
           normalized_body="$(printf '%s\n' "$PR_BODY" | tr -d '\r')"
 
-          if ! printf '%s\n' "$normalized_body" \
-            | grep -Eq '^Signed-off-by:[[:space:]]+.+[[:space:]]+<[^<>]+>$'; then
-            echo "::error::PR description must contain a DCO sign-off line."
-            echo "::error::Expected format: Signed-off-by: Your Name <your-email@example.com>"
+          has_valid_signoff() {
+            grep -E '^Signed-off-by:[[:space:]]+[^<>]+[[:space:]]+<[^<>[:space:]@]+@[^<>[:space:]@]+>$' \
+              | grep -Eiv '<[^<>[:space:]@]+@example\.(com|net|org)>$' \
+              | grep -Eiv '^Signed-off-by:[[:space:]]+(Your([[:space:]]+Real)?[[:space:]]+Name|Full[[:space:]]+Name)[[:space:]]+<' \
+              > /dev/null
+          }
+
+          placeholder='Signed-off-by: Your Real Name <your-email@example.com>'
+          if printf '%s\n' "$placeholder" | has_valid_signoff; then
+            echo "::error::DCO placeholder regression check failed."
             exit 1
           fi
 
-          if ! printf '%s\n' "$normalized_body" \
-            | grep -E '^Signed-off-by:[[:space:]]+.+[[:space:]]+<[^<>]+>$' \
-            | grep -Eiv '^Signed-off-by:[[:space:]]+Your Name[[:space:]]+<your[.-]email@example\.com>$' \
-            > /dev/null; then
-            echo "::error::Replace the example DCO sign-off with your own name and email address."
+          if ! printf '%s\n' "$normalized_body" | has_valid_signoff; then
+            echo "::error::PR description must contain your valid DCO sign-off."
+            echo "::error::Replace all example names and addresses with your own name and email."
             exit 1
           fi
 

--- a/scripts/tests/test_build_catalog.py
+++ b/scripts/tests/test_build_catalog.py
@@ -113,6 +113,22 @@ class CatalogBuildTests(unittest.TestCase):
             len(entries),
         )
 
+    def test_new_empty_example_cannot_bypass_catalog_discovery(self) -> None:
+        root = self._fixture_root()
+        readme = (
+            root
+            / "examples"
+            / "recipes"
+            / "community"
+            / "empty-example"
+            / "README.md"
+        )
+        readme.parent.mkdir(parents=True)
+        readme.write_text("", encoding="utf-8")
+
+        with self.assertRaisesRegex(CatalogError, "Example README is empty"):
+            load_catalog(root)
+
     def test_path_derives_kind_and_recipe_provenance(self) -> None:
         entry = load_catalog(self._fixture_root())[0]
 


### PR DESCRIPTION
## Related Issue

No linked issue.

## Description

- Reject DCO sign-offs that retain template names or IANA-reserved example email domains.
- Embed a regression check for `Your Real Name <your-email@example.com>` in the DCO workflow.
- Lock in catalog discovery behavior with a test proving that an empty README in a new canonical example directory fails validation.
- Keep the generated README catalog as the authoritative output introduced by #148.

## Verification

- [x] `python3 scripts/check_license_headers.py --check`
- [x] `python3 scripts/check_label_taxonomy.py --check`
- [x] `git diff --check`
- [x] 24 catalog build tests
- [x] 11 catalog interaction tests
- [x] Catalog metadata and generated-source validation
- [x] Agentic AI Learning Path validator
- [x] Exact DCO workflow script tested with valid sign-offs, the reported placeholder, placeholder names, reserved example domains, malformed email addresses, and mixed placeholder-plus-valid input

## Documentation Writer Review

- [x] Documentation writer review completed for the final changes
- Result: `no-docs-needed`
- Evidence or justification: The contributor contract already states that example DCO values are invalid. This change enforces that documented rule and clarifies the workflow error without changing contributor steps.
- Reviewer: Codex documentation review
- [x] Changed user-facing text follows the writing guide and controlled-word list.
- [x] A public contributor can understand the changed text without internal company context.
- [x] I reviewed any agent-generated text before submission.

## Release And Compliance

- [x] No secrets or credentials are included.
- [x] No nonpublic project names, environment names, hostnames, URLs, ticket identifiers, workspace paths, logs, screenshots, or configuration values are included.
- [x] No third-party dependency changes are included.
- [x] Public content uses sanitized examples and placeholders.
- [x] I added my DCO sign-off declaration to this pull request description.

Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>