### PR TITLE
fix(catalog): open header links in new tabs

### DIFF
--- a/scripts/build_catalog.py
+++ b/scripts/build_catalog.py
@@ -1912,6 +1912,7 @@ class GeneratedHTMLValidator(HTMLParser):
         self.category_groups: list[dict[str, str]] = []
         self.category_info_controls: list[dict[str, str]] = []
         self.scripts: list[dict[str, str]] = []
+        self.anchors: list[dict[str, str]] = []
         self.links: set[str] = set()
         self.resources: list[str] = []
         self.labels_for: set[str] = set()
@@ -1938,6 +1939,7 @@ class GeneratedHTMLValidator(HTMLParser):
         if tag == "label" and values.get("for"):
             self.labels_for.add(values["for"])
         if tag == "a" and values.get("href"):
+            self.anchors.append(values)
             self.links.add(values["href"])
         if tag in {"iframe", "object", "embed"}:
             self.errors.append(f"Forbidden embedded resource element: {tag}")
@@ -2127,6 +2129,30 @@ def validate_generated_site(
     missing_links = required_links - parser.links
     if missing_links:
         errors.append("Missing required catalog links: " + ", ".join(sorted(missing_links)))
+    new_tab_links = {
+        "https://brev.nvidia.com/launchable/deploy?launchableID=env-3Azt0aYgVNFEuz7opyx3gscmowS": (
+            "Launch NemoClaw on Brev (opens in a new tab)"
+        ),
+        "https://github.com/NVIDIA/nemoclaw-community": (
+            "GitHub repository (opens in a new tab)"
+        ),
+    }
+    for href, expected_label in new_tab_links.items():
+        anchor = next(
+            (item for item in parser.anchors if item.get("href") == href),
+            None,
+        )
+        if anchor is None:
+            errors.append(f"Missing header link: {href}")
+            continue
+        rel = set(anchor.get("rel", "").split())
+        if anchor.get("target") != "_blank" or not {
+            "noopener",
+            "noreferrer",
+        }.issubset(rel):
+            errors.append(f"Header link must open safely in a new tab: {href}")
+        if anchor.get("aria-label") != expected_label:
+            errors.append(f"Header link must announce its new-tab behavior: {href}")
     if "NemoClaw Community support is best-effort" not in site_html:
         errors.append("The catalog support boundary no longer matches SUPPORT.md.")
 

--- a/site/index.template.html
+++ b/site/index.template.html
@@ -27,11 +27,23 @@
           <span class="product-name">NemoClaw Community</span>
         </div>
         <nav class="header-links" aria-label="NemoClaw resources">
-          <a class="repository-link" href="https://brev.nvidia.com/launchable/deploy?launchableID=env-3Azt0aYgVNFEuz7opyx3gscmowS" aria-label="Launch NemoClaw on Brev">
+          <a
+            class="repository-link"
+            href="https://brev.nvidia.com/launchable/deploy?launchableID=env-3Azt0aYgVNFEuz7opyx3gscmowS"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Launch NemoClaw on Brev (opens in a new tab)"
+          >
             <span class="header-link-wide">Launch NemoClaw on Brev</span><span class="header-link-compact">Brev</span>
             <span aria-hidden="true">↗</span>
           </a>
-          <a class="repository-link" href="https://github.com/NVIDIA/nemoclaw-community">
+          <a
+            class="repository-link"
+            href="https://github.com/NVIDIA/nemoclaw-community"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="GitHub repository (opens in a new tab)"
+          >
             <span class="header-link-wide">GitHub repository</span><span class="header-link-compact">GitHub</span>
             <span aria-hidden="true">↗</span>
           </a>


### PR DESCRIPTION
## Summary

- Open the Brev launch and GitHub repository header links in new tabs.
- Prevent the new pages from accessing their opener and announce the behavior to assistive technology.
- Validate both links and their required attributes during the catalog build.

## Testing

- 31 Python catalog tests
- 12 JavaScript catalog tests
- 4 governance tests
- Playwright verification at desktop and mobile widths
- Label taxonomy and 608 SPDX header checks

Signed-off-by: Sam Pastoriza <spastoriza@nvidia.com>