### PR TITLE
fix(memory-driven-chief-of-staff): fix the Install-in-NemoClaw walkthrough end to end

### DIFF
--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -224,14 +224,11 @@ hermes -p "$PROFILE_NAME" config set model.api_key \
 bash scripts/install.sh
 ```
 
-The sentinel is not an upstream API key — it only needs to be non-empty. An
-empty `model.api_key` makes Hermes send the literal string `no-key-required`,
-which a real endpoint rejects; any non-empty value avoids that. The sentinel's
-`sk-`-shaped form is a naming convention for readability, not a format Hermes
-or OpenShell requires — real provider credentials do not all share that shape
-either. OpenShell removes this marker and injects the managed inference
-credential at the egress boundary. Do not copy a real inference key into the
-recipe profile on the supported NemoClaw path.
+The sentinel is not an upstream API key. Hermes requires an `sk-`-prefixed
+value before it sends a request, and OpenShell removes this marker and
+injects the managed inference credential at the egress boundary. Use the
+exact sentinel above rather than another placeholder — do not copy a real
+inference key into the recipe profile on the supported NemoClaw path.
 
 > **Not on NemoClaw, and your endpoint genuinely needs no key?** This opt-out
 > is not a substitute for the rewrite sentinel above — use it only for a
@@ -243,20 +240,40 @@ recipe profile on the supported NemoClaw path.
 
 ### 4. Start and verify the scheduled runtime inside the sandbox
 
-A NemoClaw sandbox runs as a Docker container with no systemd inside it, so
-`gateway install`/`gateway start` refuse there and point you back to
-`gateway run`. Start it in the background so it survives the connect shell
-exiting, then confirm the scheduler picked it up:
+NemoClaw's own supervisor launches and continuously respawns `hermes gateway
+run` for the sandbox's default profile automatically. This recipe installs
+as a separate, named profile (`memory-driven-chief-of-staff`), which that
+supervision does not cover — there is no NemoClaw-managed lifecycle for a
+second named-profile gateway today, so this step starts and tracks it by
+hand. Check first whether it is already running, to avoid starting a second,
+orphaned instance:
+
+```bash
+hermes -p "$PROFILE_NAME" cron status
+```
+
+If it reports the gateway is not running, start it in the background and
+record its PID. Unlike NemoClaw's own gateway, nothing restarts this one
+automatically — if it dies (crash, OOM, sandbox restart), cron stops firing
+until you notice and rerun this:
 
 ```bash
 nohup hermes -p "$PROFILE_NAME" gateway run > /tmp/gateway.log 2>&1 &
+echo $! > /tmp/mdcos-gateway.pid
 disown
 hermes -p "$PROFILE_NAME" cron status
 ```
 
-`cron status` should report the gateway running, its PID, and the next
-scheduled job. If it still reports the gateway is not running, check
-`/tmp/gateway.log` for a startup error.
+`cron status` should now report the gateway running, its PID (matching `cat
+/tmp/mdcos-gateway.pid`), and the next scheduled job. If it still reports not
+running, check `/tmp/gateway.log` for a startup error.
+
+To stop it later:
+
+```bash
+kill "$(cat /tmp/mdcos-gateway.pid)"
+rm -f /tmp/mdcos-gateway.pid
+```
 
 > **Running this outside a NemoClaw sandbox, on a host with systemd?** Any
 > environment without a running systemd — WSL included — still needs the
@@ -282,8 +299,8 @@ are host-side commands and are not available inside the sandbox.
 
 Nothing so far requires a provider — the profile, jobs, and gateway all work
 with an empty store. But an empty store is exactly what you will see if you
-open the dashboard or chat with it next: no messages ingested, nothing to
-rank. Check what is already attached first, from your machine:
+chat with it next: no messages ingested, nothing to rank. Check what is
+already attached first, from your machine:
 
 ```bash
 openshell sandbox provider list my-hermes
@@ -296,52 +313,29 @@ independent; connect one, both, or skip this step and use the
 [offline fixtures](#offline-walkthrough-no-deployment) instead to see the
 recipe's behavior without connecting anything.
 
-### 6. Chat with it from the web dashboard
+### 6. A note on the web dashboard
 
-This also runs from your machine — if you skipped step 5 and are still
-inside the sandbox shell from step 4, exit it (or open a separate terminal)
-first; `nemohermes` is a host-side command and is not available inside the
-sandbox. NemoClaw forwards a Hermes dashboard for the sandbox by default:
+`nemohermes hermes dashboard-url --quiet` (from your machine, not inside the
+sandbox) prints a URL for the Hermes dashboard NemoClaw forwards for the
+sandbox by default. That dashboard is launched isolated, under its own
+dedicated profile home, specifically so it does **not** unify with other
+profiles on the sandbox — it will not show this recipe's chat, memory, or
+store, regardless of any `?profile=` query parameter appended to it. The
+printed URL also carries a credential in its fragment; treat it like a
+password and use it as printed, not retyped or shared.
 
-```bash
-nemohermes hermes dashboard-url --quiet
-```
-
-This prints the forwarded URL, typically `http://127.0.0.1:18789/`. That
-dashboard is a machine-wide surface serving every profile on the sandbox, not
-just this recipe's — open this profile specifically by appending its name as
-a query parameter:
-
-```text
-http://127.0.0.1:18789/?profile=memory-driven-chief-of-staff
-```
-
-If you are on a remote host, either open a browser inside that same remote
-session, or forward the port to your local machine first:
+The verified way to talk to this recipe is the terminal, from inside the
+sandbox:
 
 ```bash
-ssh -L 18789:127.0.0.1:18789 <user>@<host>
+hermes -p memory-driven-chief-of-staff chat
 ```
 
-The dashboard's chat tab talks to the same live agent, memory, and store as
-`hermes -p memory-driven-chief-of-staff chat` in the terminal — it is a
-different front end, not a separate instance. Session auth is handled
-automatically for a normal browser load; no separate login step is required
-on the supported local-forward path.
-
-Closing the browser tab does not stop it — the dashboard is one shared
-process serving every profile on the sandbox, so it keeps running for the
-others. To actually stop it, reconnect to the sandbox first (`hermes` is not
-on the host's `PATH`, same as every other `hermes` command in this guide):
-
-```bash
-nemohermes hermes connect
-hermes dashboard --status   # see what is running first
-hermes dashboard --stop     # stops every dashboard/serve process on the sandbox
-```
-
-`--stop` is not scoped to this recipe's profile; it shuts down the shared
-dashboard for the whole sandbox.
+A dedicated web view scoped to this one profile is possible through Hermes's
+own `hermes dashboard --isolated`, run from inside the sandbox against this
+profile — but that path (port choice, forwarding it out of the sandbox, and
+its authentication flow) is not walked through end-to-end in this guide; see
+Hermes's own dashboard documentation before relying on it.
 
 ### Things to try
 
@@ -829,11 +823,18 @@ nemohermes my-hermes inference get
 ```
 
 This reports the configured provider and model, but sends no request, so it
-cannot tell you whether the key is valid. `nemohermes my-hermes status`
-cannot either: its reachability check counts HTTP `401`/`403` as
-"reachable," so a wrong key still reports as reachable. The only real proof
-is a successful response to an actual request — the simplest check for this
-recipe, inside the sandbox:
+cannot tell you whether the key is valid. The global `nemohermes status`
+(no sandbox name) cannot either — that reachability check counts HTTP
+`401`/`403` as "reachable." The named-sandbox form does validate it, because
+it sends one real inference request through the stored credential:
+
+```bash
+nemohermes my-hermes status
+```
+
+It reports `unauthorized` when that request is rejected with `401`/`403`.
+For a final, recipe-level confirmation, also try a real chat turn inside the
+sandbox:
 
 ```bash
 hermes -p memory-driven-chief-of-staff chat
@@ -861,7 +862,8 @@ variable name your provider expects (this differs by provider; NemoClaw's
 own credential rotation guide lists them). This updates the registered
 OpenShell provider and normally reuses the existing sandbox; it does not
 touch this recipe's installed profile or its scheduled jobs. Confirm the
-replacement the same way — a real request, not `inference get` or `status`.
+replacement the same way — `nemohermes my-hermes status` or a real request,
+not `inference get` or the global `status`.
 
 ### Jobs are registered but do not run
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -74,7 +74,7 @@ recipe complements Hermes memory and optional external memory providers.
 - [Memory That Tracks Work, Not Just Preferences](#memory-that-tracks-work-not-just-preferences)
 - [How It Works](#how-it-works)
 - [Quick Start](#quick-start)
-- [Install in NemoClaw](#install-in-nemoclaw)
+- [Offline Walkthrough (No Deployment)](#offline-walkthrough-no-deployment)
 - [Configuration](#configuration)
 - [Connect Messaging Providers](#connect-messaging-providers)
 - [Scheduled Operation](#scheduled-operation)
@@ -138,62 +138,9 @@ code used by scheduled runs.
 
 ## Quick Start
 
-This offline walkthrough needs only Python 3.10+ on macOS, Linux, or WSL.
-
-### 1. Clone and enter the recipe
-
-```bash
-git clone https://github.com/NVIDIA/nemoclaw-community.git
-cd nemoclaw-community/examples/recipes/nvidia/memory-driven-chief-of-staff
-```
-
-### 2. Create isolated local state and run the walkthrough
-
-```bash
-export RECIPE_TMP_HOME="$(mktemp -d)"
-export HERMES_HOME="$RECIPE_TMP_HOME"
-python3 profile/scripts/walkthrough.py --fixtures fixtures
-```
-
-The command prints seven stages and exits with status `0`. The important
-outcomes are:
-
-- eight messages are ingested and two are skipped;
-- six obligations remain open;
-- exactly three memory-gated obligations enter `high`;
-- an urgent deadline unrelated to the user's chosen work stays in `medium`;
-- a user pin and ignore survive a later recorded review;
-- the memory checker is shown succeeding and failing on a deliberate defect.
-
-### 3. Prove fixture ingestion is idempotent
-
-Use a new profile home because the walkthrough has already populated the first
-one.
-
-```bash
-export RECIPE_TMP_HOME_2="$(mktemp -d)"
-export HERMES_HOME="$RECIPE_TMP_HOME_2"
-python3 profile/scripts/load_fixtures.py --fixtures fixtures
-python3 profile/scripts/load_fixtures.py --fixtures fixtures
-```
-
-The first loader run reports `"added": 8`; the second reports `"added": 0`.
-
-### 4. Inspect or correct state
-
-Replace the placeholder with a source identifier printed by the walkthrough.
-
-```bash
-python3 profile/scripts/memory_check.py
-python3 profile/scripts/correct.py priority msg-priorities-match low
-python3 profile/scripts/correct.py ignore msg-cc-only
-python3 profile/scripts/correct.py unignore msg-cc-only
-```
-
-Repeated corrections are no-ops. Corrections against completed or incompatible
-rows exit with status `3` and explain the required state transition.
-
-## Install in NemoClaw
+This is the path that ends with a running, scheduled assistant. It assumes an
+existing NemoClaw-managed Hermes sandbox; it does not cover NemoClaw
+onboarding itself.
 
 The scheduled jobs run inside a Linux NemoHermes sandbox. Your own computer is
 outside that sandbox and can use any platform supported by NemoHermes.
@@ -247,7 +194,7 @@ Run this from the cloned `nemoclaw-community` repository root.
 ```bash
 nemohermes sandbox upload my-hermes \
   examples/recipes/nvidia/memory-driven-chief-of-staff \
-  /sandbox/memory-driven-chief-of-staff
+  /sandbox
 nemohermes my-hermes connect
 ```
 
@@ -277,35 +224,217 @@ hermes -p "$PROFILE_NAME" config set model.api_key \
 bash scripts/install.sh
 ```
 
-The sentinel is not an upstream API key. Hermes requires an `sk-` value before
-it sends a request, and OpenShell removes this marker and injects the managed
-inference credential at the egress boundary. Do not copy a real inference key
-into the recipe profile on the supported NemoClaw path.
+The sentinel is not an upstream API key — it only needs to be non-empty. An
+empty `model.api_key` makes Hermes send the literal string `no-key-required`,
+which a real endpoint rejects; any non-empty value avoids that. The sentinel's
+`sk-`-shaped form is a naming convention for readability, not a format Hermes
+or OpenShell requires — real provider credentials do not all share that shape
+either. OpenShell removes this marker and injects the managed inference
+credential at the egress boundary. Do not copy a real inference key into the
+recipe profile on the supported NemoClaw path.
 
-Use the explicit opt-out only for a genuinely keyless, non-NemoClaw endpoint;
-it is not a substitute for the rewrite sentinel.
-
-```bash
-ALLOW_NO_API_KEY=1 bash scripts/install.sh
-```
+> **Not on NemoClaw, and your endpoint genuinely needs no key?** This opt-out
+> is not a substitute for the rewrite sentinel above — use it only for a
+> genuinely keyless, non-NemoClaw endpoint.
+>
+> ```bash
+> ALLOW_NO_API_KEY=1 bash scripts/install.sh
+> ```
 
 ### 4. Start and verify the scheduled runtime inside the sandbox
 
+A NemoClaw sandbox runs as a Docker container with no systemd inside it, so
+`gateway install`/`gateway start` refuse there and point you back to
+`gateway run`. Start it in the background so it survives the connect shell
+exiting, then confirm the scheduler picked it up:
+
 ```bash
-hermes -p "$PROFILE_NAME" gateway install
-hermes -p "$PROFILE_NAME" gateway start
+nohup hermes -p "$PROFILE_NAME" gateway run > /tmp/gateway.log 2>&1 &
+disown
 hermes -p "$PROFILE_NAME" cron status
 ```
 
-On WSL without systemd, keep the gateway in the foreground instead.
+`cron status` should report the gateway running, its PID, and the next
+scheduled job. If it still reports the gateway is not running, check
+`/tmp/gateway.log` for a startup error.
 
-```bash
-hermes -p "$PROFILE_NAME" gateway run
-```
+> **Running this outside a NemoClaw sandbox, on a host with systemd?** Any
+> environment without a running systemd — WSL included — still needs the
+> foreground command above. Only where systemd is actually running does
+> `gateway install` register it as a persistent service instead. See
+> [Persistence and reboot behavior](#persistence-and-reboot-behavior) for the
+> trade-off against `gateway run`.
+>
+> ```bash
+> hermes -p "$PROFILE_NAME" gateway install
+> hermes -p "$PROFILE_NAME" gateway start
+> ```
 
 At this point the schedule works over any rows already in the store. Slack and
 Outlook are independent and optional; each unconfigured collector exits
 successfully and reports that state.
+
+### 5. Connect a messaging provider
+
+Step 4 leaves you inside the sandbox shell. Exit it (or open a separate
+terminal on your machine) before continuing — `openshell` and `nemohermes`
+are host-side commands and are not available inside the sandbox.
+
+Nothing so far requires a provider — the profile, jobs, and gateway all work
+with an empty store. But an empty store is exactly what you will see if you
+open the dashboard or chat with it next: no messages ingested, nothing to
+rank. Check what is already attached first, from your machine:
+
+```bash
+openshell sandbox provider list my-hermes
+```
+
+If nothing there exposes `SLACK_USER_TOKEN` or `MS_GRAPH_ACCESS_TOKEN`,
+connect one now — see [Connect Messaging Providers](#connect-messaging-providers)
+below for the full Slack and Outlook setup. Both are optional and
+independent; connect one, both, or skip this step and use the
+[offline fixtures](#offline-walkthrough-no-deployment) instead to see the
+recipe's behavior without connecting anything.
+
+### 6. Chat with it from the web dashboard
+
+This also runs from your machine — if you skipped step 5 and are still
+inside the sandbox shell from step 4, exit it (or open a separate terminal)
+first; `nemohermes` is a host-side command and is not available inside the
+sandbox. NemoClaw forwards a Hermes dashboard for the sandbox by default:
+
+```bash
+nemohermes hermes dashboard-url --quiet
+```
+
+This prints the forwarded URL, typically `http://127.0.0.1:18789/`. That
+dashboard is a machine-wide surface serving every profile on the sandbox, not
+just this recipe's — open this profile specifically by appending its name as
+a query parameter:
+
+```text
+http://127.0.0.1:18789/?profile=memory-driven-chief-of-staff
+```
+
+If you are on a remote host, either open a browser inside that same remote
+session, or forward the port to your local machine first:
+
+```bash
+ssh -L 18789:127.0.0.1:18789 <user>@<host>
+```
+
+The dashboard's chat tab talks to the same live agent, memory, and store as
+`hermes -p memory-driven-chief-of-staff chat` in the terminal — it is a
+different front end, not a separate instance. Session auth is handled
+automatically for a normal browser load; no separate login step is required
+on the supported local-forward path.
+
+Closing the browser tab does not stop it — the dashboard is one shared
+process serving every profile on the sandbox, so it keeps running for the
+others. To actually stop it, reconnect to the sandbox first (`hermes` is not
+on the host's `PATH`, same as every other `hermes` command in this guide):
+
+```bash
+nemohermes hermes connect
+hermes dashboard --status   # see what is running first
+hermes dashboard --stop     # stops every dashboard/serve process on the sandbox
+```
+
+`--stop` is not scoped to this recipe's profile; it shuts down the shared
+dashboard for the whole sandbox.
+
+### Things to try
+
+Once real data is flowing, ask it the questions from the top of this
+document:
+
+> **What changed on this project since yesterday?**
+>
+> **Which conversations need a decision, response, or follow-up from me?**
+>
+> **What are the most important items on my todo list today?**
+>
+> **What should I know about this person or project, and how does it connect
+> to my work?**
+
+Then push on the ranking itself — this is where the intent gate shows up:
+
+- "Why is this ranked above that?"
+- "What's urgent right now that I haven't actually chosen to work on?"
+
+Ask it to ground a claim in evidence rather than answer from general recall:
+
+- "What should I know about [a real colleague]? How does it connect to my
+  current work?"
+- "What did [someone] say this week?"
+
+And after you correct something (`priority ... low` or `ignore ...` via
+`profile/scripts/correct.py`), ask again without re-explaining the
+correction — it should already be reflected.
+
+## Offline Walkthrough (No Deployment)
+
+This does not deploy the recipe or produce a running assistant. It runs the
+decision logic — ranking, the intent gate, correction durability, memory
+self-checks — entirely on your own machine against recorded fixtures, with no
+NemoClaw, no sandbox, no credentials, and no network access. Use it to verify
+the recipe's behavior before investing in a real deployment, or skip straight
+to [Quick Start](#quick-start) above if you already have a sandbox ready.
+
+It needs only Python 3.10+ on macOS, Linux, or WSL.
+
+### 1. Clone and enter the recipe
+
+```bash
+git clone https://github.com/NVIDIA/nemoclaw-community.git
+cd nemoclaw-community/examples/recipes/nvidia/memory-driven-chief-of-staff
+```
+
+### 2. Create isolated local state and run the walkthrough
+
+```bash
+export RECIPE_TMP_HOME="$(mktemp -d)"
+export HERMES_HOME="$RECIPE_TMP_HOME"
+python3 profile/scripts/walkthrough.py --fixtures fixtures
+```
+
+The command prints seven stages and exits with status `0`. The important
+outcomes are:
+
+- eight messages are ingested and two are skipped;
+- six obligations remain open;
+- exactly three memory-gated obligations enter `high`;
+- an urgent deadline unrelated to the user's chosen work stays in `medium`;
+- a user pin and ignore survive a later recorded review;
+- the memory checker is shown succeeding and failing on a deliberate defect.
+
+### 3. Prove fixture ingestion is idempotent
+
+Use a new profile home because the walkthrough has already populated the first
+one.
+
+```bash
+export RECIPE_TMP_HOME_2="$(mktemp -d)"
+export HERMES_HOME="$RECIPE_TMP_HOME_2"
+python3 profile/scripts/load_fixtures.py --fixtures fixtures
+python3 profile/scripts/load_fixtures.py --fixtures fixtures
+```
+
+The first loader run reports `"added": 8`; the second reports `"added": 0`.
+
+### 4. Inspect or correct state
+
+Replace the placeholder with a source identifier printed by the walkthrough.
+
+```bash
+python3 profile/scripts/memory_check.py
+python3 profile/scripts/correct.py priority msg-priorities-match low
+python3 profile/scripts/correct.py ignore msg-cc-only
+python3 profile/scripts/correct.py unignore msg-cc-only
+```
+
+Repeated corrections are no-ops. Corrections against completed or incompatible
+rows exit with status `3` and explain the required state transition.
 
 ## Configuration
 
@@ -689,6 +818,51 @@ bash scripts/install.sh
 The sentinel is a non-secret routing marker. Do not use
 `ALLOW_NO_API_KEY=1` for a NemoClaw-managed inference route.
 
+### How do I check whether my API key actually works, and replace it if not?
+
+The real key does not live in this recipe's profile — the sentinel above is
+not a credential. Check and rotate it at the NemoClaw/OpenShell layer, from
+your machine, not inside the sandbox:
+
+```bash
+nemohermes my-hermes inference get
+```
+
+This reports the configured provider and model, but sends no request, so it
+cannot tell you whether the key is valid. `nemohermes my-hermes status`
+cannot either: its reachability check counts HTTP `401`/`403` as
+"reachable," so a wrong key still reports as reachable. The only real proof
+is a successful response to an actual request — the simplest check for this
+recipe, inside the sandbox:
+
+```bash
+hermes -p memory-driven-chief-of-staff chat
+```
+
+A real reply means the key works; an authentication error means it does not.
+
+If it is wrong, replace it from your machine — do not edit the recipe
+profile's `model.api_key`, which only ever holds the non-secret rewrite
+sentinel. Export the replacement under the environment variable name your
+configured provider expects, then rerun onboarding for the existing sandbox:
+
+```bash
+printf 'New inference API key: ' >&2
+IFS= read -r -s PROVIDER_API_KEY_VAR_NAME
+printf '\n' >&2
+export PROVIDER_API_KEY_VAR_NAME
+nemohermes onboard --name my-hermes \
+  --non-interactive --yes --yes-i-accept-third-party-software
+unset PROVIDER_API_KEY_VAR_NAME
+```
+
+`PROVIDER_API_KEY_VAR_NAME` above is a placeholder — substitute the actual
+variable name your provider expects (this differs by provider; NemoClaw's
+own credential rotation guide lists them). This updates the registered
+OpenShell provider and normally reuses the existing sandbox; it does not
+touch this recipe's installed profile or its scheduled jobs. Confirm the
+replacement the same way — a real request, not `inference get` or `status`.
+
 ### Jobs are registered but do not run
 
 Registration does not start the scheduler. Check the gateway and cron status.
@@ -699,7 +873,7 @@ hermes -p memory-driven-chief-of-staff cron status
 ```
 
 Install and start the service, or use the foreground command shown in
-[Install in NemoClaw](#install-in-nemoclaw).
+[Quick Start](#quick-start).
 
 ### A collector reports `unconfigured`
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -245,10 +245,11 @@ run` for the sandbox's default profile automatically, logging to
 `/tmp/gateway.log` under a `0600` file it owns. This recipe installs as a
 separate, named profile (`memory-driven-chief-of-staff`), which that
 supervision does not cover — there is no NemoClaw-managed lifecycle for a
-second named-profile gateway today, so this step starts and tracks it by
-hand, deliberately kept isolated from the managed one: a distinct log path,
-and identity checked before anything is killed. Check first whether it is
-already running, to avoid starting a second, orphaned instance:
+second named-profile gateway today, so this step starts it manually. Hermes
+records runtime state for the named profile, and its profile-scoped stop
+command validates that runtime identity before it signals the process. The
+separate log path below avoids colliding with the managed gateway's log. Check
+first whether the named-profile gateway is already running:
 
 ```bash
 hermes -p "$PROFILE_NAME" cron status
@@ -256,38 +257,33 @@ hermes -p "$PROFILE_NAME" cron status
 
 If it reports the gateway is not running, start it in the background,
 logging to its own path — reusing `/tmp/gateway.log` would collide with
-NemoClaw's managed one — and record its PID. Unlike NemoClaw's own gateway,
-nothing restarts this one automatically — if it dies (crash, OOM, sandbox
-restart), cron stops firing until you notice and rerun this:
+NemoClaw's managed one — and make the new log owner-only. Unlike NemoClaw's
+own gateway, nothing restarts this one automatically. If it dies because of a
+crash, an out-of-memory event, or a sandbox restart, cron stops firing until
+you rerun this command:
 
 ```bash
-nohup hermes -p "$PROFILE_NAME" gateway run \
+umask 077
+nohup hermes gateway run --profile "$PROFILE_NAME" \
   > /tmp/mdcos-gateway.log 2>&1 &
-echo $! > /tmp/mdcos-gateway.pid
 disown
 hermes -p "$PROFILE_NAME" cron status
 ```
 
-`cron status` should now report the gateway running, its PID (matching `cat
-/tmp/mdcos-gateway.pid`), and the next scheduled job. If it still reports not
-running, check `/tmp/mdcos-gateway.log` for a startup error.
+`cron status` should now report the gateway running and the next scheduled
+job. If it still reports not running, check `/tmp/mdcos-gateway.log` for a
+startup error.
 
-To stop it later, confirm the recorded PID is still this gateway before
-killing it — a reused or stale PID file could otherwise point at an
-unrelated process:
+To stop it later, use Hermes's profile-scoped lifecycle command:
 
 ```bash
-GW_PID="$(cat /tmp/mdcos-gateway.pid 2>/dev/null || true)"
-if [[ -n "$GW_PID" ]] && ps -p "$GW_PID" -o args= | grep -q "gateway run"; then
-  kill "$GW_PID"
-else
-  echo "No matching gateway process for PID $GW_PID; not killing anything." >&2
-fi
-rm -f /tmp/mdcos-gateway.pid
+hermes gateway stop --profile "$PROFILE_NAME"
 ```
 
-Stop the gateway this way before [deleting the profile](#persistence-and-reboot-behavior)
-— removing the profile does not stop a process running against it.
+Hermes scopes the stop to the selected profile and checks its recorded runtime
+identity instead of trusting a shell PID file. Stop the gateway before
+[deleting the profile](#persistence-and-reboot-behavior) because removing the
+profile does not stop a process that is already running against it.
 
 > **Running this outside a NemoClaw sandbox, on a host with systemd?** Any
 > environment without a running systemd — WSL included — still needs the
@@ -297,8 +293,8 @@ Stop the gateway this way before [deleting the profile](#persistence-and-reboot-
 > trade-off against `gateway run`.
 >
 > ```bash
-> hermes -p "$PROFILE_NAME" gateway install
-> hermes -p "$PROFILE_NAME" gateway start
+> hermes gateway install --profile "$PROFILE_NAME"
+> hermes gateway start --profile "$PROFILE_NAME"
 > ```
 
 At this point the schedule works over any rows already in the store. Slack and
@@ -336,8 +332,8 @@ dedicated profile home, specifically so it does **not** unify with other
 profiles on the sandbox — it will not show this recipe's chat, memory, or
 store, regardless of any `?profile=` query parameter appended to it. Hermes
 uses session auth for this dashboard, so the printed URL is a plain link, not
-a credential; it is still an unauthenticated-looking URL that grants access
-to whoever holds it, so avoid sharing it over an insecure channel.
+a credential. Protect access to the forwarded endpoint through the sandbox's
+normal session controls, and do not expose it publicly.
 
 The verified way to talk to this recipe is the terminal, from inside the
 sandbox:
@@ -721,10 +717,11 @@ hermes -p memory-driven-chief-of-staff cron remove "$JOB_ID"
 
 Deleting the profile also deletes its workspace, store, and memory — but not
 a gateway process already running against it. If you started one by hand
-(step 4 of Quick Start), stop it first using the identity-checked kill
-sequence there, then delete the profile:
+(step 4 of Quick Start), stop it with the profile-scoped lifecycle command,
+then delete the profile:
 
 ```bash
+hermes gateway stop --profile memory-driven-chief-of-staff
 hermes profile delete memory-driven-chief-of-staff
 ```
 
@@ -894,7 +891,7 @@ not `inference get` or the global `status`.
 Registration does not start the scheduler. Check the gateway and cron status.
 
 ```bash
-hermes -p memory-driven-chief-of-staff gateway status
+hermes gateway status --profile memory-driven-chief-of-staff
 hermes -p memory-driven-chief-of-staff cron status
 ```
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -241,24 +241,28 @@ inference key into the recipe profile on the supported NemoClaw path.
 ### 4. Start and verify the scheduled runtime inside the sandbox
 
 NemoClaw's own supervisor launches and continuously respawns `hermes gateway
-run` for the sandbox's default profile automatically. This recipe installs
-as a separate, named profile (`memory-driven-chief-of-staff`), which that
+run` for the sandbox's default profile automatically, logging to
+`/tmp/gateway.log` under a `0600` file it owns. This recipe installs as a
+separate, named profile (`memory-driven-chief-of-staff`), which that
 supervision does not cover — there is no NemoClaw-managed lifecycle for a
 second named-profile gateway today, so this step starts and tracks it by
-hand. Check first whether it is already running, to avoid starting a second,
-orphaned instance:
+hand, deliberately kept isolated from the managed one: a distinct log path,
+and identity checked before anything is killed. Check first whether it is
+already running, to avoid starting a second, orphaned instance:
 
 ```bash
 hermes -p "$PROFILE_NAME" cron status
 ```
 
-If it reports the gateway is not running, start it in the background and
-record its PID. Unlike NemoClaw's own gateway, nothing restarts this one
-automatically — if it dies (crash, OOM, sandbox restart), cron stops firing
-until you notice and rerun this:
+If it reports the gateway is not running, start it in the background,
+logging to its own path — reusing `/tmp/gateway.log` would collide with
+NemoClaw's managed one — and record its PID. Unlike NemoClaw's own gateway,
+nothing restarts this one automatically — if it dies (crash, OOM, sandbox
+restart), cron stops firing until you notice and rerun this:
 
 ```bash
-nohup hermes -p "$PROFILE_NAME" gateway run > /tmp/gateway.log 2>&1 &
+nohup hermes -p "$PROFILE_NAME" gateway run \
+  > /tmp/mdcos-gateway.log 2>&1 &
 echo $! > /tmp/mdcos-gateway.pid
 disown
 hermes -p "$PROFILE_NAME" cron status
@@ -266,14 +270,24 @@ hermes -p "$PROFILE_NAME" cron status
 
 `cron status` should now report the gateway running, its PID (matching `cat
 /tmp/mdcos-gateway.pid`), and the next scheduled job. If it still reports not
-running, check `/tmp/gateway.log` for a startup error.
+running, check `/tmp/mdcos-gateway.log` for a startup error.
 
-To stop it later:
+To stop it later, confirm the recorded PID is still this gateway before
+killing it — a reused or stale PID file could otherwise point at an
+unrelated process:
 
 ```bash
-kill "$(cat /tmp/mdcos-gateway.pid)"
+GW_PID="$(cat /tmp/mdcos-gateway.pid 2>/dev/null || true)"
+if [[ -n "$GW_PID" ]] && ps -p "$GW_PID" -o args= | grep -q "gateway run"; then
+  kill "$GW_PID"
+else
+  echo "No matching gateway process for PID $GW_PID; not killing anything." >&2
+fi
 rm -f /tmp/mdcos-gateway.pid
 ```
+
+Stop the gateway this way before [deleting the profile](#persistence-and-reboot-behavior)
+— removing the profile does not stop a process running against it.
 
 > **Running this outside a NemoClaw sandbox, on a host with systemd?** Any
 > environment without a running systemd — WSL included — still needs the
@@ -315,14 +329,15 @@ recipe's behavior without connecting anything.
 
 ### 6. A note on the web dashboard
 
-`nemohermes hermes dashboard-url --quiet` (from your machine, not inside the
-sandbox) prints a URL for the Hermes dashboard NemoClaw forwards for the
+`nemohermes my-hermes dashboard-url --quiet` (from your machine, not inside
+the sandbox) prints a URL for the Hermes dashboard NemoClaw forwards for the
 sandbox by default. That dashboard is launched isolated, under its own
 dedicated profile home, specifically so it does **not** unify with other
 profiles on the sandbox — it will not show this recipe's chat, memory, or
-store, regardless of any `?profile=` query parameter appended to it. The
-printed URL also carries a credential in its fragment; treat it like a
-password and use it as printed, not retyped or shared.
+store, regardless of any `?profile=` query parameter appended to it. Hermes
+uses session auth for this dashboard, so the printed URL is a plain link, not
+a credential; it is still an unauthenticated-looking URL that grants access
+to whoever holds it, so avoid sharing it over an insecure channel.
 
 The verified way to talk to this recipe is the terminal, from inside the
 sandbox:
@@ -331,11 +346,17 @@ sandbox:
 hermes -p memory-driven-chief-of-staff chat
 ```
 
-A dedicated web view scoped to this one profile is possible through Hermes's
-own `hermes dashboard --isolated`, run from inside the sandbox against this
-profile — but that path (port choice, forwarding it out of the sandbox, and
-its authentication flow) is not walked through end-to-end in this guide; see
-Hermes's own dashboard documentation before relying on it.
+For a dedicated web view scoped to this one profile instead, run this inside
+the sandbox:
+
+```bash
+hermes -p "$PROFILE_NAME" dashboard --isolated
+```
+
+This starts a server dedicated to this profile rather than routing to the
+shared machine-level one above. It is not forwarded out of the sandbox by
+default; see Hermes's own dashboard documentation for its port and access
+options before exposing it.
 
 ### Things to try
 
@@ -698,7 +719,10 @@ JOB_ID="<copy-an-id-from-the-list>"
 hermes -p memory-driven-chief-of-staff cron remove "$JOB_ID"
 ```
 
-Deleting the profile also deletes its workspace, store, and memory.
+Deleting the profile also deletes its workspace, store, and memory — but not
+a gateway process already running against it. If you started one by hand
+(step 4 of Quick Start), stop it first using the identity-checked kill
+sequence there, then delete the profile:
 
 ```bash
 hermes profile delete memory-driven-chief-of-staff


### PR DESCRIPTION
## Summary

Reproduced the documented "Install in NemoClaw" walkthrough live on a real NemoClaw sandbox and fixed every step that broke or misled along the way. Revised twice more in response to maintainer review (see review history for what changed each round — this description reflects the current head, `d600571`).

- **sandbox upload**: the documented destination already contained the recipe's own directory name, and `openshell sandbox upload` nests a directory source under its own basename (matches `scp -r`/`cp -r`) — every first-time run landed the recipe one level too deep and the next step's `cd` could never find `scripts/install.sh`. Upload to the parent directory instead.
- **Quick Start vs. the offline walkthrough**: the offline fixture walkthrough was titled "Quick Start" and placed before the real deployment section, even though it never produces a running assistant. Swapped the labels and order to match what each section actually does, added an explicit "this does not deploy anything" note, and updated the table of contents and the one in-doc cross-reference.
- **the `sk-` sentinel**: kept the exact managed sentinel requirement (`sk-OPENSHELL-PROXY-REWRITE`) — Hermes requires an `sk-`-prefixed value before it sends a request, confirmed against `hermes-managed-route.ts`.
- **gateway lifecycle for the named profile**: NemoClaw's supervisor covers only the sandbox's default profile, so this recipe still starts its separate named-profile gateway manually. The manual start now uses Hermes's supported command-first profile syntax, writes to a separate owner-only log, and relies on Hermes's profile-scoped runtime state. Teardown uses the native profile-scoped `gateway stop` command instead of a shell PID file or raw signal. The gateway remains unsupervised and must be restarted after a crash or sandbox restart.
- **web dashboard**: the forwarded `dashboard-url` dashboard is launched with `--isolated` against a dedicated `HERMES_DASHBOARD_HOME` specifically so it does not unify with other profiles — confirmed against `start.sh`, it cannot show this recipe's chat/memory/store via `?profile=` or any other means. The doc now states that plainly, fixed the `my-hermes`/`hermes` placeholder inconsistency, dropped an inaccurate claim that the URL carries a `#token=` credential fragment (verified against `dashboard-url-command.ts`: Hermes uses session auth, not OpenClaw's `url_token` scheme, so the URL is plain — still worth not sharing carelessly), and points to `hermes -p ... chat` as the verified path plus the actual command for a profile-scoped view, `hermes -p "$PROFILE_NAME" dashboard --isolated`.
- **connect a messaging provider**: added the missing step between starting the gateway and using the recipe — check what is already attached, and point to the full Slack/Outlook setup, since an empty store means nothing to look at.
- **API key correctness**: added a Troubleshooting entry distinguishing "configured" from "actually works." The named-sandbox `nemohermes <sandbox> status` sends a real inference request and reports `unauthorized` on 401/403 (confirmed against the current `credential-rotation.mdx`, which splits this from the reachability-only global `status`); `inference get` reports configuration only. Also covers how to rotate a wrong key without touching the recipe's own `model.api_key` sentinel.
- Set the remaining special-case commands apart as blockquotes so they read as conditional, not sequential, matching the callout style already used elsewhere in this README.
- Added a "Things to try" list of example chat prompts after the terminal/dashboard step.

No command content changed outside what is described above.

## Test plan

- [x] Reproduced the upload-path bug and the original gateway install/start refusal live on a real NemoClaw sandbox; verified the corrected commands work.
- [x] Verified the `sk-` sentinel requirement, `no-key-required` fallback, and `--isolated` dashboard semantics against `hermes-agent` and NemoClaw source.
- [x] Verified `inference.local` routing, the named-vs-global `status` distinction, dashboard auth scheme (`session` vs. `url_token`), dashboard isolation (`--isolated` + dedicated `HERMES_DASHBOARD_HOME`), the managed gateway's `/tmp/gateway.log` ownership, and dynamic dashboard port resolution — all against NemoClaw source at the exact commit cited in review (`9b8c0511`, confirmed as `origin/main` tip).
- [x] Checked all in-doc anchors (table of contents and cross-references) resolve after the section rename/reorder.
- [x] `python3 scripts/check_license_headers.py --check` passes.
- [x] `git diff --check` clean.

## DCO

Signed-off-by: XuanWu <xuwu@nvidia.com>