### PR TITLE
fix(memory-driven-chief-of-staff): stop the contract contradicting the checker

### DIFF
--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -1000,7 +1000,7 @@ cd ../..
 test "$fail" -eq 0
 ```
 
-Expected result: every file ends with `OK`, the fourteen files report 610 tests
+Expected result: every file ends with `OK`, the fourteen files report 628 tests
 in total, and the final line is `failed=0`. Do not shorten the loop with an
 early break; running every module is part of the documented check.
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -1000,7 +1000,7 @@ cd ../..
 test "$fail" -eq 0
 ```
 
-Expected result: every file ends with `OK`, the fourteen files report 632 tests
+Expected result: every file ends with `OK`, the fourteen files report 636 tests
 in total, and the final line is `failed=0`. Do not shorten the loop with an
 early break; running every module is part of the documented check.
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -1000,7 +1000,7 @@ cd ../..
 test "$fail" -eq 0
 ```
 
-Expected result: every file ends with `OK`, the fourteen files report 636 tests
+Expected result: every file ends with `OK`, the fourteen files report 640 tests
 in total, and the final line is `failed=0`. Do not shorten the loop with an
 early break; running every module is part of the documented check.
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -1000,7 +1000,7 @@ cd ../..
 test "$fail" -eq 0
 ```
 
-Expected result: every file ends with `OK`, the fourteen files report 628 tests
+Expected result: every file ends with `OK`, the fourteen files report 632 tests
 in total, and the final line is `failed=0`. Do not shorten the loop with an
 early break; running every module is part of the documented check.
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/schema.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/schema.md
@@ -301,7 +301,7 @@ updated: YYYY-MM-DD
 ```
 
 Sections, in this order: `## People` · `## Projects` · `## Patterns` ·
-`## Goals` · `## Attention`. One line per page: a relative link, then a
+`## Concepts` · `## Goals` · `## Attention`. One line per page: a relative link, then a
 half-line of what it holds and why someone would open it.
 
 An index entry pointing at a missing page, or a page with no index entry, is a

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/memory_check.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/memory_check.py
@@ -41,6 +41,30 @@ REQUIRED_FIELDS = {
 }
 INDEX_REQUIRED = ("type", "updated")
 
+# Page types the schema writes as a folder rather than a file, spelled
+# `<type>/<slug>/` in its own headings. Only these have sidecars, and only
+# here does a file that is not the page get skipped — an earlier form of this
+# skipped every nested file whose name did not match its folder, which made a
+# page nested anywhere else invisible to every check rather than merely
+# unindexed.
+FOLDER_SHAPED = frozenset({"projects"})
+
+# What the schema says a folder-shaped page's directory contains besides the
+# page itself. Named, because the schema names them:
+#
+#     projects/<slug>/
+#     ├── <slug>.md        # the current picture
+#     ├── log.md           # append-only history
+#     └── log.archive.md   # created when log.md rotates
+#
+# Reading "anything not named after the folder" as a sidecar instead is what
+# an earlier form of this did, and it deleted a real page from every check:
+# a project page written as `overview.md` reported nothing at all — no
+# missing field, no bad value, no broken link — where before it reported
+# four. A file here that is neither the page nor one of these is treated as
+# a page, so it is reported rather than swallowed.
+DECLARED_SIDECARS = frozenset({"log.md", "log.archive.md"})
+
 # Fields whose value must come from a fixed set, again from schema.md.
 ENUMS = {
     "importance": {"high", "medium", "low"},
@@ -95,10 +119,31 @@ def _pages(root: Path) -> list[Path]:
     Names beginning with a dot or `._` are not pages. The second form is an
     AppleDouble sidecar, which a macOS archive carries along and which is
     binary despite ending in `.md` — reading it as text is how this was found.
+
+    A folder-shaped page type holds one page and any number of sidecars, and
+    the page is the file named after its folder. `projects/<slug>/` carries
+    `<slug>.md` plus `log.md` and, once it rotates, `log.archive.md`. The
+    archive was treated as a page and so was reported `unindexed` and
+    `missing-frontmatter` for as long as it existed — a permanent pair of
+    findings produced by following the schema, on a file that is an
+    append-only history and is not supposed to carry frontmatter at all.
+    Naming the archive here would have fixed that one file and left the next
+    sidecar to rediscover it, so the rule is structural instead.
     """
-    return sorted(p for p in root.rglob("*.md")
-                  if p.name not in {"schema.md", "log.md", "index.md"}
-                  and not p.name.startswith("."))
+    def is_page(path: Path) -> bool:
+        if path.name.startswith(".") or path.name in {
+                "schema.md", "log.md", "index.md"}:
+            return False
+        parts = path.relative_to(root).parts
+        if parts[0] not in FOLDER_SHAPED or len(parts) < 3:
+            return True
+        # Inside a folder-shaped type: the page, plus the sidecars the schema
+        # declares. Anything else is checked, because a file here that is
+        # neither is far more likely to be a page under the wrong name than a
+        # sidecar nobody documented.
+        return path.name not in DECLARED_SIDECARS
+
+    return sorted(p for p in root.rglob("*.md") if is_page(p))
 
 
 def check_index(root: Path) -> list[Finding]:
@@ -120,6 +165,26 @@ def check_index(root: Path) -> list[Finding]:
         if not target.exists():
             findings.append(Finding("index-dangling", "index.md",
                                     f"entry points at missing {target.name}"))
+
+    # A section per validated page type, so there is somewhere to file the
+    # first page of each.
+    #
+    # This is the half of a schema change that a seed cannot deliver.
+    # `bootstrap` copies in what is missing and never overwrites — correctly,
+    # because the index is the user's — so a memory installed before a page
+    # type was added keeps the sections it was created with, and the people
+    # most likely to have content are exactly the people who never receive
+    # the new one. The seed is right for a fresh install and this is what
+    # reaches the rest.
+    present = set(re.findall(r"^##\s+(\w+)", index_text, re.M))
+    for kind in sorted({_page_type(p, root) for p in _pages(root)} - {None}):
+        heading = kind.capitalize()
+        if heading not in present:
+            findings.append(Finding(
+                "index-section-missing", "index.md",
+                f"pages of type {kind}/ exist and there is no `## {heading}`"
+                " section to file them under, so their entries have nowhere"
+                " to go"))
     return findings
 
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/memory_check.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/memory_check.py
@@ -170,6 +170,26 @@ _INDEX_RANK = {kind.capitalize(): i for i, kind in enumerate(REQUIRED_FIELDS)}
 
 HEADING = re.compile(r"^##[ \t]+(\w+)[ \t]*\n", re.M)
 
+# A fenced block (```...```) or an HTML comment can quote what a section or
+# an entry looks like without being one — documentation showing the shape of
+# an index, not the index itself. Blanked to spaces rather than deleted, so
+# every character offset `_index_sections` and `LINK.finditer` compute stays
+# valid against the original text; newlines are kept so `re.M` anchors still
+# land on the right lines.
+FENCED_CODE = re.compile(r"^```[^\n]*\n.*?\n```[ \t]*$", re.M | re.S)
+HTML_COMMENT = re.compile(r"<!--.*?-->", re.S)
+
+
+def _blank(match: re.Match) -> str:
+    return "".join(ch if ch == "\n" else " " for ch in match.group(0))
+
+
+def _strip_non_content(text: str) -> str:
+    """Blank fenced code blocks and HTML comments before scanning for
+    headings or links, so a sample heading or link quoted inside one can no
+    longer be mistaken for real index content."""
+    return HTML_COMMENT.sub(_blank, FENCED_CODE.sub(_blank, text))
+
 
 def _index_sections(text: str) -> list[tuple[str, int, int]]:
     """Ordered `(heading, body_start, body_end)` spans.
@@ -197,21 +217,28 @@ def check_index(root: Path) -> list[Finding]:
     if index_text is None:
         return [Finding("unreadable", "index.md", "not valid UTF-8 text")]
 
-    sections = _index_sections(index_text)
+    # Fenced code and HTML comments can quote what a heading or a link looks
+    # like without being real index content; scan the blanked copy so a
+    # sample can never satisfy these checks. Character offsets are unchanged
+    # by blanking, so they still line up with `sections`' spans below.
+    scan_text = _strip_non_content(index_text)
+    sections = _index_sections(scan_text)
     present = {heading for heading, _, _ in sections}
 
-    # Every linked target, and which section's span its own link line falls
-    # inside — a link can be present in the document and still not be filed
-    # where it belongs. The first occurrence wins when a target is linked
-    # more than once.
+    # Every linked target, and which section's span each of its occurrences
+    # falls inside — a link can be present in the document and still not be
+    # filed where it belongs. Every occurrence is kept, not just the first:
+    # a target linked once correctly and once from the wrong section is
+    # still a misfiled entry, and checking only the first occurrence missed
+    # exactly that duplicate.
     listed: set[Path] = set()
-    filed_under: dict[Path, str | None] = {}
-    for match in LINK.finditer(index_text):
+    filed_under: dict[Path, list[str | None]] = {}
+    for match in LINK.finditer(scan_text):
         target = (index.parent / match.group(1)).resolve()
         listed.add(target)
         heading = next((h for h, start, end in sections
                         if start <= match.start() < end), None)
-        filed_under.setdefault(target, heading)
+        filed_under.setdefault(target, []).append(heading)
 
     for page in _pages(root):
         rel = str(page.relative_to(root))
@@ -222,8 +249,9 @@ def check_index(root: Path) -> list[Finding]:
             continue
         kind = _page_type(page, root)
         expected = kind.capitalize() if kind else None
-        if expected in _INDEX_RANK and filed_under.get(target) != expected:
-            actual = filed_under.get(target) or "no section"
+        occurrences = filed_under.get(target, [])
+        if expected in _INDEX_RANK and any(h != expected for h in occurrences):
+            actual = next(h for h in occurrences if h != expected) or "no section"
             findings.append(Finding(
                 "index-misfiled", rel,
                 f"linked under `## {actual}` instead of its own"

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/memory_check.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/memory_check.py
@@ -21,7 +21,22 @@ from datetime import date, datetime, timedelta
 from pathlib import Path
 
 FRONTMATTER = re.compile(r"\A---\n(.*?)\n---\n", re.S)
-LINK = re.compile(r"\[[^\]]*\]\(([^)]+\.md)\)")
+# Bare Markdown link destinations cannot contain whitespace, controls, angle
+# brackets, or parentheses. Keeping this grammar shared between entry and
+# link checks prevents a malformed destination from being normalized by
+# `Path.resolve()` onto a real page and falsely treated as navigable.
+LINK_TARGET = r"([^\s()<>\x00-\x1f\x7f]+\.md)"
+# Labels may be empty and may contain CommonMark backslash escapes. An escaped
+# closing bracket is consumed as label content, so it cannot be mistaken for
+# the delimiter that starts the destination.
+INDEX_LINK_LABEL = r"(?:\\[^\r\n]|[^\[\]\\\r\n])*"
+PAGE_LINK_LABEL = r"(?:\\.|[^\[\]\\])*"
+# Memory-page prose may wrap a link label over a soft line ending. Index
+# entries are one physical line by contract and use the narrower pattern.
+LINK = re.compile(
+    r"\[" + PAGE_LINK_LABEL + r"\]\(" + LINK_TARGET + r"\)", re.S)
+INDEX_LINK = re.compile(
+    r"\[" + INDEX_LINK_LABEL + r"\]\(" + LINK_TARGET + r"\)")
 FOOTNOTE = re.compile(r"\^\[[^\]]+\]")
 INFERRED = re.compile(r"\(inferred\)", re.I)
 
@@ -168,41 +183,415 @@ def _pages(root: Path) -> list[Path]:
 # second constant that could drift from the first.
 _INDEX_RANK = {kind.capitalize(): i for i, kind in enumerate(REQUIRED_FIELDS)}
 
-HEADING = re.compile(r"^##[ \t]+(\w+)[ \t]*\n", re.M)
+# `index.md` is data, not an arbitrary Markdown article. Parse the two
+# top-level constructs its contract names rather than searching all source
+# text for link-shaped strings. The accepted entry forms deliberately remain
+# broad: the schema requires a relative link first, but does not require a
+# particular list marker or description separator.
+HEADING_LINE = re.compile(r"^ {0,3}##[ \t]+(\w+)[ \t]*$")
+BARE_ENTRY_LINE = re.compile(
+    r"^ {0,3}\[" + INDEX_LINK_LABEL + r"\]\(" + LINK_TARGET + r"\).*$")
+MARKED_ENTRY_LINE = re.compile(
+    r"^( {0,3})([-+*]|[0-9]{1,9}[.)])([ \t]+)"
+    r"\[" + INDEX_LINK_LABEL + r"\]\(" + LINK_TARGET + r"\).*$")
+LIST_ITEM = re.compile(
+    r"^( {0,3})([-+*]|[0-9]{1,9}[.)])([ \t]+|$)")
+BLOCK_QUOTE = re.compile(r"^ {0,3}>")
+FENCE_LINE = re.compile(r"^ {0,3}(`{3,}|~{3,})([^\r\n]*)$")
+COMMENT_BLOCK = re.compile(r"^ {0,3}<!--")
+# A small contract checker must not guess where an arbitrary raw HTML block
+# ends. Any top-level line beginning with an HTML-like opener is therefore
+# ambiguous unless it is a positively recognized URI/email autolink. Literal
+# comparisons such as ``latency < 5`` are ordinary text. HTML comments are
+# handled separately before this guard.
+HTML_LIKE_LINE = re.compile(r"^ {0,3}(?:</?[A-Za-z]|<\?|<!)")
+HTML_LIKE_TOKEN = re.compile(r"(?:</?[A-Za-z]|<\?|<!)")
+AUTOLINK_LINE = re.compile(
+    r"^ {0,3}<(?:(?:[A-Za-z][A-Za-z0-9+.-]{1,31}:[^ <>]*)|"
+    r"(?:[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@"
+    r"[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?))>")
+AUTOLINK_TOKEN = re.compile(AUTOLINK_LINE.pattern.removeprefix(r"^ {0,3}"))
 
-# A fenced block (```...```) or an HTML comment can quote what a section or
-# an entry looks like without being one — documentation showing the shape of
-# an index, not the index itself. Blanked to spaces rather than deleted, so
-# every character offset `_index_sections` and `LINK.finditer` compute stays
-# valid against the original text; newlines are kept so `re.M` anchors still
-# land on the right lines.
-FENCED_CODE = re.compile(r"^```[^\n]*\n.*?\n```[ \t]*$", re.M | re.S)
-HTML_COMMENT = re.compile(r"<!--.*?-->", re.S)
+
+@dataclass(frozen=True)
+class _ParsedIndex:
+    headings: tuple[str, ...]
+    entries: tuple[tuple[str, str | None], ...]
+    links: tuple[str, ...]
+    error: str | None = None
 
 
-def _blank(match: re.Match) -> str:
-    return "".join(ch if ch == "\n" else " " for ch in match.group(0))
+def _indent_width(line: str, initial: int = 0) -> int:
+    """Leading indentation in Markdown columns (tabs stop every four)."""
+    width = initial
+    for ch in line:
+        if ch == " ":
+            width += 1
+        elif ch == "\t":
+            width += 4 - (width % 4)
+        else:
+            break
+    return width
 
 
-def _strip_non_content(text: str) -> str:
-    """Blank fenced code blocks and HTML comments before scanning for
-    headings or links, so a sample heading or link quoted inside one can no
-    longer be mistaken for real index content."""
-    return HTML_COMMENT.sub(_blank, FENCED_CODE.sub(_blank, text))
+def _list_content_indent(match: re.Match) -> int:
+    """The continuation indentation established by a list marker."""
+    marker_end = match.end(2)
+    width_after_padding = _indent_width(match.group(3), marker_end)
+    padding = width_after_padding - marker_end
+    return marker_end + (padding if 1 <= padding <= 4 else 1)
 
 
-def _index_sections(text: str) -> list[tuple[str, int, int]]:
-    """Ordered `(heading, body_start, body_end)` spans.
+def _list_marker_kind(match: re.Match) -> str:
+    marker = match.group(2)
+    return marker if marker in "-+*" else marker[-1]
 
-    A section's body is the text between its own heading line and the next
-    `## ` heading, or the end of the file for the last one — the range an
-    entry's link has to fall inside to count as filed under that heading,
-    rather than merely present somewhere in the document.
+
+def _list_marker_interrupts_paragraph(match: re.Match) -> bool:
+    """Whether this list marker may interrupt a CommonMark paragraph."""
+    marker = match.group(2)
+    return not marker[0].isdigit() or int(marker[:-1]) == 1
+
+
+def _entry_target(line: str) -> str | None:
+    """Return a schema entry target without accepting list-item code.
+
+    CommonMark permits one to four columns of padding between a list marker
+    and its inline content. Five or more makes the apparent link an indented
+    code block, so it cannot be an index entry.
     """
-    matches = list(HEADING.finditer(text))
-    return [(m.group(1), m.end(),
-             matches[i + 1].start() if i + 1 < len(matches) else len(text))
-            for i, m in enumerate(matches)]
+    bare = BARE_ENTRY_LINE.match(line)
+    if bare:
+        return bare.group(1)
+    marked = MARKED_ENTRY_LINE.match(line)
+    if not marked:
+        return None
+    marker_end = marked.end(2)
+    padding = _indent_width(marked.group(3), marker_end) - marker_end
+    return marked.group(4) if 1 <= padding <= 4 else None
+
+
+def _raw_html_or_ambiguous(line: str) -> bool:
+    return bool(HTML_LIKE_LINE.match(line) and not AUTOLINK_LINE.match(line))
+
+
+def _definite_block_start(line: str) -> bool:
+    """A construct that cannot be a lazy paragraph continuation."""
+    item = LIST_ITEM.match(line)
+    return bool(HEADING_LINE.match(line) or FENCE_LINE.match(line)
+                or COMMENT_BLOCK.match(line)
+                or (item and _list_marker_interrupts_paragraph(item))
+                or _raw_html_or_ambiguous(line))
+
+
+def _inline_content(line: str) -> tuple[str, str | None]:
+    """Blank same-line code spans and comments before reading links.
+
+    A comment that begins in ordinary inline content and does not close on
+    that line is valid enough Markdown to be ambiguous to this deliberately
+    small parser. Report that ambiguity instead of allowing a later line to
+    be mistaken for top-level index data. Backslash-escaped markers and
+    markers inside a closed code span remain literal.
+    """
+    visible = list(line)
+    i = 0
+    while i < len(line):
+        if line[i] == "\\" and i + 1 < len(line):
+            visible[i] = " "
+            visible[i + 1] = " "
+            i += 2
+            continue
+        if line[i] == "`":
+            end = i + 1
+            while end < len(line) and line[end] == "`":
+                end += 1
+            marker = line[i:end]
+            close = -1
+            candidate = end
+            while candidate < len(line):
+                candidate = line.find("`", candidate)
+                if candidate < 0:
+                    break
+                run_end = candidate + 1
+                while run_end < len(line) and line[run_end] == "`":
+                    run_end += 1
+                if run_end - candidate == len(marker):
+                    close = candidate
+                    break
+                candidate = run_end
+            if close >= 0:
+                for pos in range(i, close + len(marker)):
+                    visible[pos] = " "
+                i = close + len(marker)
+                continue
+            return line, "a multiline or unmatched code span obscures structure"
+        if line.startswith("<!--", i):
+            close = line.find("-->", i + 4)
+            if close < 0:
+                return line, "a multiline inline HTML comment obscures structure"
+            close += 3
+            for pos in range(i, close):
+                visible[pos] = " "
+            i = close
+            continue
+        if line[i] == "<":
+            autolink = AUTOLINK_TOKEN.match(line, i)
+            if autolink:
+                for pos in range(i, autolink.end()):
+                    visible[pos] = " "
+                i = autolink.end()
+                continue
+            if HTML_LIKE_TOKEN.match(line, i):
+                return line, "inline HTML or an angle marker obscures structure"
+        i += 1
+    return "".join(visible), None
+
+
+def _parse_index(text: str) -> _ParsedIndex:
+    """Read the top-level headings and entries in an index safely.
+
+    Fences and comments are interpreted only after a line is known to be at
+    top level. That matters for an installed, user-owned index: a fence or
+    comment marker inside a list example, block quote, inline code span, or
+    indented code block must not hide real content that follows its container.
+    If a lazy continuation or raw HTML makes top-level ownership ambiguous,
+    parsing fails closed so repair cannot add duplicate entries from a partial
+    view of the file.
+    """
+    lines = text.splitlines()
+    headings: list[str] = []
+    entries: list[tuple[str, str | None]] = []
+    links: list[str] = []
+    current_heading: str | None = None
+    fence_char: str | None = None
+    fence_length = 0
+    in_comment = False
+    in_indented_code = False
+    list_indent: int | None = None
+    list_marker_indent = 0
+    list_marker_kind: str | None = None
+    list_saw_blank = False
+    quote_may_continue = False
+    paragraph_may_continue = False
+
+    # YAML frontmatter is not index content.
+    frontmatter_end = 0
+    frontmatter = FRONTMATTER.match(text)
+    if frontmatter:
+        frontmatter_end = text[:frontmatter.end()].count("\n")
+
+    i = 0
+    while i < len(lines):
+        line = lines[i].rstrip("\r")
+        if i < frontmatter_end:
+            i += 1
+            continue
+
+        if fence_char is not None:
+            close = FENCE_LINE.match(line)
+            if close:
+                marker, trailing = close.groups()
+                if (marker[0] == fence_char and len(marker) >= fence_length
+                        and not trailing.strip(" \t")):
+                    fence_char = None
+                    fence_length = 0
+            i += 1
+            continue
+
+        if in_comment:
+            if "-->" in line:
+                in_comment = False
+            i += 1
+            continue
+
+        if in_indented_code:
+            if not line.strip() or _indent_width(line) >= 4:
+                i += 1
+                continue
+            in_indented_code = False
+            continue
+
+        if list_indent is not None:
+            if not line.strip():
+                list_saw_blank = True
+                i += 1
+                continue
+            indent = _indent_width(line)
+            sibling = LIST_ITEM.match(line)
+            if list_saw_blank:
+                if indent >= list_indent:
+                    if INDEX_LINK.search(line):
+                        return _ParsedIndex(
+                            tuple(headings), tuple(entries), tuple(links),
+                            "a visible link is nested in a list container")
+                    i += 1
+                    continue
+                list_indent = None
+                continue
+            if sibling and _indent_width(sibling.group(1)) <= list_marker_indent:
+                if (_list_marker_kind(sibling) == list_marker_kind
+                        or _list_marker_interrupts_paragraph(sibling)):
+                    list_indent = None
+                    continue
+                if INDEX_LINK.search(line):
+                    return _ParsedIndex(
+                        tuple(headings), tuple(entries), tuple(links),
+                        "a link-shaped line may be a lazy list continuation")
+                i += 1
+                continue
+            if indent >= list_indent:
+                if INDEX_LINK.search(line):
+                    return _ParsedIndex(
+                        tuple(headings), tuple(entries), tuple(links),
+                        "a visible link is nested in a list container")
+                i += 1
+                continue
+            if _definite_block_start(line) or list_saw_blank:
+                list_indent = None
+                continue
+            if INDEX_LINK.search(line):
+                return _ParsedIndex(
+                    tuple(headings), tuple(entries), tuple(links),
+                    "a visible link may be a lazy list continuation")
+            # Ordinary lazy paragraph continuation remains inside the item.
+            i += 1
+            continue
+
+        if BLOCK_QUOTE.match(line):
+            if INDEX_LINK.search(line):
+                return _ParsedIndex(
+                    tuple(headings), tuple(entries), tuple(links),
+                    "a visible link is nested in a block quote")
+            quote_may_continue = True
+            i += 1
+            continue
+        if quote_may_continue:
+            if not line.strip():
+                quote_may_continue = False
+                i += 1
+                continue
+            if _definite_block_start(line):
+                quote_may_continue = False
+                continue
+            if INDEX_LINK.search(line):
+                return _ParsedIndex(
+                    tuple(headings), tuple(entries), tuple(links),
+                    "a visible link may be a lazy block quote continuation")
+            i += 1
+            continue
+
+        if paragraph_may_continue:
+            if not line.strip():
+                paragraph_may_continue = False
+                i += 1
+                continue
+            item = LIST_ITEM.match(line)
+            if item and not _list_marker_interrupts_paragraph(item):
+                visible_line, inline_error = _inline_content(line)
+                if inline_error:
+                    return _ParsedIndex(
+                        tuple(headings), tuple(entries), tuple(links),
+                        inline_error)
+                if INDEX_LINK.search(visible_line):
+                    return _ParsedIndex(
+                        tuple(headings), tuple(entries), tuple(links),
+                        "a link-shaped line may continue a paragraph")
+                i += 1
+                continue
+            if _raw_html_or_ambiguous(line):
+                return _ParsedIndex(
+                    tuple(headings), tuple(entries), tuple(links),
+                    "raw HTML may continue a paragraph")
+            if (HEADING_LINE.match(line) or FENCE_LINE.match(line)
+                    or COMMENT_BLOCK.match(line) or BLOCK_QUOTE.match(line)
+                    or (item and _list_marker_interrupts_paragraph(item))):
+                paragraph_may_continue = False
+                continue
+            # A bare link first on its physical line remains an accepted
+            # schema entry. Other ordinary source continues the paragraph.
+            if not _entry_target(line):
+                visible_line, inline_error = _inline_content(line)
+                if inline_error:
+                    return _ParsedIndex(
+                        tuple(headings), tuple(entries), tuple(links),
+                        inline_error)
+                links.extend(INDEX_LINK.findall(visible_line))
+                i += 1
+                continue
+            paragraph_may_continue = False
+
+        if _indent_width(line) >= 4:
+            in_indented_code = True
+            i += 1
+            continue
+
+        fence = FENCE_LINE.match(line)
+        if fence:
+            marker, info = fence.groups()
+            if marker[0] == "~" or "`" not in info:
+                fence_char = marker[0]
+                fence_length = len(marker)
+                i += 1
+                continue
+
+        if COMMENT_BLOCK.match(line):
+            in_comment = "-->" not in line
+            i += 1
+            continue
+
+        if _raw_html_or_ambiguous(line):
+            return _ParsedIndex(tuple(headings), tuple(entries), tuple(links),
+                                "raw HTML can hide index structure")
+
+        visible_line, inline_error = _inline_content(line)
+        if inline_error:
+            return _ParsedIndex(tuple(headings), tuple(entries), tuple(links),
+                                inline_error)
+
+        # Structural tokens must begin at their original source position.
+        # Masking an earlier code span or comment must not turn the spaces it
+        # leaves behind into the permitted indentation before a heading/link.
+        heading = HEADING_LINE.match(line)
+        if heading:
+            current_heading = heading.group(1)
+            headings.append(current_heading)
+            i += 1
+            continue
+
+        target = _entry_target(line)
+        if target:
+            entries.append((target, current_heading))
+            links.extend(INDEX_LINK.findall(visible_line))
+            item = LIST_ITEM.match(line)
+            if item:
+                list_marker_indent = _indent_width(item.group(1))
+                list_marker_kind = _list_marker_kind(item)
+                list_indent = _list_content_indent(item)
+                list_saw_blank = False
+            i += 1
+            continue
+
+        item = LIST_ITEM.match(line)
+        if item:
+            # A non-entry list item is a container. Its indented children may
+            # contain examples, but they cannot declare top-level index data.
+            if INDEX_LINK.search(visible_line):
+                return _ParsedIndex(
+                    tuple(headings), tuple(entries), tuple(links),
+                    "a list item contains a link that is not an index entry")
+            list_marker_indent = _indent_width(item.group(1))
+            list_marker_kind = _list_marker_kind(item)
+            list_indent = _list_content_indent(item)
+            list_saw_blank = False
+            i += 1
+            continue
+
+        links.extend(INDEX_LINK.findall(visible_line))
+        if line.strip():
+            paragraph_may_continue = True
+        i += 1
+
+    return _ParsedIndex(tuple(headings), tuple(entries), tuple(links))
 
 
 def check_index(root: Path) -> list[Finding]:
@@ -217,13 +606,13 @@ def check_index(root: Path) -> list[Finding]:
     if index_text is None:
         return [Finding("unreadable", "index.md", "not valid UTF-8 text")]
 
-    # Fenced code and HTML comments can quote what a heading or a link looks
-    # like without being real index content; scan the blanked copy so a
-    # sample can never satisfy these checks. Character offsets are unchanged
-    # by blanking, so they still line up with `sections`' spans below.
-    scan_text = _strip_non_content(index_text)
-    sections = _index_sections(scan_text)
-    present = {heading for heading, _, _ in sections}
+    parsed = _parse_index(index_text)
+    if parsed.error:
+        return [Finding(
+            "index-unparseable", "index.md",
+            "cannot verify top-level structure safely: " + parsed.error
+            + "; preserve the file and make no automatic index repair")]
+    present = set(parsed.headings)
 
     # Every linked target, and which section's span each of its occurrences
     # falls inside — a link can be present in the document and still not be
@@ -233,11 +622,9 @@ def check_index(root: Path) -> list[Finding]:
     # exactly that duplicate.
     listed: set[Path] = set()
     filed_under: dict[Path, list[str | None]] = {}
-    for match in LINK.finditer(scan_text):
-        target = (index.parent / match.group(1)).resolve()
+    for relative, heading in parsed.entries:
+        target = (index.parent / relative).resolve()
         listed.add(target)
-        heading = next((h for h, start, end in sections
-                        if start <= match.start() < end), None)
         filed_under.setdefault(target, []).append(heading)
 
     for page in _pages(root):
@@ -286,7 +673,7 @@ def check_index(root: Path) -> list[Finding]:
     # already precedes it in the file — a set of heading names cannot see
     # this, only their positions relative to each other can.
     furthest_rank, furthest_heading = -1, None
-    for heading, _, _ in sections:
+    for heading in parsed.headings:
         rank = _INDEX_RANK.get(heading)
         if rank is None:
             continue
@@ -304,7 +691,7 @@ def check_index(root: Path) -> list[Finding]:
 def check_links(root: Path) -> list[Finding]:
     """Relative links between pages resolve."""
     findings: list[Finding] = []
-    for page in _pages(root) + [root / "index.md"]:
+    for page in _pages(root):
         if not page.exists():
             continue
         text = _read(page)
@@ -316,6 +703,22 @@ def check_links(root: Path) -> list[Finding]:
             if not (page.parent / target).resolve().exists():
                 findings.append(Finding("broken-link", str(page.relative_to(root)),
                                         f"link to {target} does not resolve"))
+
+    # Index links use the same parse as index structure. Scanning its raw
+    # source here would reintroduce false findings for fenced and commented
+    # examples that `check_index` correctly excludes. If parsing failed,
+    # `check_index` already reports the authoritative fail-closed finding.
+    index = root / "index.md"
+    if index.exists():
+        text = _read(index)
+        if text is not None:
+            parsed = _parse_index(text)
+            if not parsed.error:
+                for target in parsed.links:
+                    if not (index.parent / target).resolve().exists():
+                        findings.append(Finding(
+                            "broken-link", "index.md",
+                            f"link to {target} does not resolve"))
     return findings
 
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/memory_check.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/memory_check.py
@@ -63,7 +63,20 @@ FOLDER_SHAPED = frozenset({"projects"})
 # missing field, no bad value, no broken link — where before it reported
 # four. A file here that is neither the page nor one of these is treated as
 # a page, so it is reported rather than swallowed.
+#
+# Exemption is by *position*, not by name alone: a file only counts as one of
+# these if it sits at the exact depth the schema puts it at,
+# `projects/<slug>/log.md`. A name match anywhere else — `patterns/log.md`,
+# `projects/<slug>/nested/log.archive.md` — is a page under a reserved name,
+# not the sidecar the schema means, and is checked like any other page.
 DECLARED_SIDECARS = frozenset({"log.md", "log.archive.md"})
+
+# What the schema writes at the memory root besides the pages themselves: the
+# entry point, the append-only job log, and the schema document, were it ever
+# placed inside the live memory. Exempt only as the root's own direct child —
+# `log.md` two directories down is not this file, it is a reserved name
+# collision.
+ROOT_SPECIALS = frozenset({"schema.md", "index.md", "log.md"})
 
 # Fields whose value must come from a fixed set, again from schema.md.
 ENUMS = {
@@ -131,23 +144,50 @@ def _pages(root: Path) -> list[Path]:
     sidecar to rediscover it, so the rule is structural instead.
     """
     def is_page(path: Path) -> bool:
-        if path.name.startswith(".") or path.name in {
-                "schema.md", "log.md", "index.md"}:
+        if path.name.startswith("."):
             return False
         parts = path.relative_to(root).parts
-        if parts[0] not in FOLDER_SHAPED or len(parts) < 3:
-            return True
-        # Inside a folder-shaped type: the page, plus the sidecars the schema
-        # declares. Anything else is checked, because a file here that is
-        # neither is far more likely to be a page under the wrong name than a
-        # sidecar nobody documented.
-        return path.name not in DECLARED_SIDECARS
+        if len(parts) == 1:
+            return parts[0] not in ROOT_SPECIALS
+        # Inside a folder-shaped type, at exactly the depth the schema puts a
+        # sidecar: the page, plus the sidecars the schema declares. Anything
+        # else — including a reserved name at any other depth — is checked,
+        # because it is far more likely to be a page under the wrong name or
+        # in the wrong place than a sidecar nobody documented.
+        if (len(parts) == 3 and parts[0] in FOLDER_SHAPED
+                and path.name in DECLARED_SIDECARS):
+            return False
+        return True
 
     return sorted(p for p in root.rglob("*.md") if is_page(p))
 
 
+# Sections, in schema order. `REQUIRED_FIELDS`'s own key order already
+# matches `schema.md`'s "Sections, in this order" list (a test compares
+# them), so a page type's rank is looked up here rather than kept in a
+# second constant that could drift from the first.
+_INDEX_RANK = {kind.capitalize(): i for i, kind in enumerate(REQUIRED_FIELDS)}
+
+HEADING = re.compile(r"^##[ \t]+(\w+)[ \t]*\n", re.M)
+
+
+def _index_sections(text: str) -> list[tuple[str, int, int]]:
+    """Ordered `(heading, body_start, body_end)` spans.
+
+    A section's body is the text between its own heading line and the next
+    `## ` heading, or the end of the file for the last one — the range an
+    entry's link has to fall inside to count as filed under that heading,
+    rather than merely present somewhere in the document.
+    """
+    matches = list(HEADING.finditer(text))
+    return [(m.group(1), m.end(),
+             matches[i + 1].start() if i + 1 < len(matches) else len(text))
+            for i, m in enumerate(matches)]
+
+
 def check_index(root: Path) -> list[Finding]:
-    """Every page is indexed and every index entry resolves."""
+    """Every page is indexed, every entry resolves, and each is filed under
+    its own type's section, which appears where `schema.md` orders it."""
     index = root / "index.md"
     findings: list[Finding] = []
     if not index.exists():
@@ -156,11 +196,39 @@ def check_index(root: Path) -> list[Finding]:
     index_text = _read(index)
     if index_text is None:
         return [Finding("unreadable", "index.md", "not valid UTF-8 text")]
-    listed = {(index.parent / t).resolve() for t in LINK.findall(index_text)}
+
+    sections = _index_sections(index_text)
+    present = {heading for heading, _, _ in sections}
+
+    # Every linked target, and which section's span its own link line falls
+    # inside — a link can be present in the document and still not be filed
+    # where it belongs. The first occurrence wins when a target is linked
+    # more than once.
+    listed: set[Path] = set()
+    filed_under: dict[Path, str | None] = {}
+    for match in LINK.finditer(index_text):
+        target = (index.parent / match.group(1)).resolve()
+        listed.add(target)
+        heading = next((h for h, start, end in sections
+                        if start <= match.start() < end), None)
+        filed_under.setdefault(target, heading)
+
     for page in _pages(root):
-        if page.resolve() not in listed:
-            findings.append(Finding("unindexed", str(page.relative_to(root)),
+        rel = str(page.relative_to(root))
+        target = page.resolve()
+        if target not in listed:
+            findings.append(Finding("unindexed", rel,
                                     "page has no entry in index.md"))
+            continue
+        kind = _page_type(page, root)
+        expected = kind.capitalize() if kind else None
+        if expected in _INDEX_RANK and filed_under.get(target) != expected:
+            actual = filed_under.get(target) or "no section"
+            findings.append(Finding(
+                "index-misfiled", rel,
+                f"linked under `## {actual}` instead of its own"
+                f" `## {expected}` section"))
+
     for target in sorted(listed):
         if not target.exists():
             findings.append(Finding("index-dangling", "index.md",
@@ -176,7 +244,6 @@ def check_index(root: Path) -> list[Finding]:
     # most likely to have content are exactly the people who never receive
     # the new one. The seed is right for a fresh install and this is what
     # reaches the rest.
-    present = set(re.findall(r"^##\s+(\w+)", index_text, re.M))
     for kind in sorted({_page_type(p, root) for p in _pages(root)} - {None}):
         heading = kind.capitalize()
         if heading not in present:
@@ -185,6 +252,24 @@ def check_index(root: Path) -> list[Finding]:
                 f"pages of type {kind}/ exist and there is no `## {heading}`"
                 " section to file them under, so their entries have nowhere"
                 " to go"))
+
+    # Order, independent of whether every section is present. A heading that
+    # exists is still wrong if the schema puts it earlier than one that
+    # already precedes it in the file — a set of heading names cannot see
+    # this, only their positions relative to each other can.
+    furthest_rank, furthest_heading = -1, None
+    for heading, _, _ in sections:
+        rank = _INDEX_RANK.get(heading)
+        if rank is None:
+            continue
+        if rank < furthest_rank:
+            findings.append(Finding(
+                "index-out-of-order", "index.md",
+                f"`## {heading}` comes after `## {furthest_heading}`, but"
+                f" schema.md orders it before `## {furthest_heading}`"))
+        else:
+            furthest_rank, furthest_heading = rank, heading
+
     return findings
 
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/ranking.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/ranking.py
@@ -7,7 +7,7 @@ The model decides ORDER (which row matters more) because that needs judgment.
 This module decides TIER (who gets high / medium / low) because that is
 arithmetic, and arithmetic in a prompt is advisory rather than enforced.
 
-Rules mirror the production system this recipe is adapted from:
+The rules this module enforces:
 
   * hard caps: at most 10 rows at `high`, at most 10 at `medium`
   * `high` is intent-gated: a row reaches it only if the user has signalled

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/select_memory.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/select_memory.py
@@ -548,16 +548,25 @@ def evidence(conn, since: str) -> dict[str, object]:
         for who in group:
             rows += conn.execute(
                 "SELECT source, event_at, addressing,"
-                "       substr(COALESCE(subject, body), 1, 200)"
+                "       substr(subject, 1, 200), substr(body, 1, 200)"
                 "  FROM items WHERE source = ? AND sender_key = ?"
                 "    AND event_at >= ?"
                 "  ORDER BY event_at DESC LIMIT ?",
                 (who.source, who.key, since, MAX_INTERACTIONS)).fetchall()
         rows.sort(key=lambda r: r[1] or "", reverse=True)
+        # Subject and body are kept apart rather than folded into one field
+        # with `COALESCE(subject, body)`: a mail with a subject hides its
+        # body behind it that way, and the body is exactly where a name and a
+        # request are likely to be. Slack has no subject and always carries
+        # `None` here; the empty string that produces is the correct reading,
+        # not a gap to paper over.
         interactions[mark] = [
             {"when": (event_at or "")[:10], "source": source,
-             "addressing": addressing, "text": " ".join((text or "").split())}
-            for source, event_at, addressing, text in rows[:MAX_INTERACTIONS]]
+             "addressing": addressing,
+             "subject": " ".join((subject or "").split()),
+             "body": " ".join((body or "").split())}
+            for source, event_at, addressing, subject, body
+            in rows[:MAX_INTERACTIONS]]
 
     return {"people": chosen, "interactions": interactions,
             "shared_display_name": shared,

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/select_memory.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/select_memory.py
@@ -44,8 +44,9 @@ from _db import ensure_store, write_txn
 # How many exchanges before somebody is worth a page.
 #
 # One message is an event, not a relationship. Two is the smallest number that
-# distinguishes a correspondent from a notification, and it is the threshold
-# the production system this recipe is adapted from uses.
+# distinguishes a correspondent from a notification. `schema.md` reasons the
+# same way about `concepts/` — one occurrence is noise, two earns a page —
+# though it counts distinct sources there rather than messages.
 PEOPLE_THRESHOLD = 2
 
 # How far back the evidence window reaches. The store holds more; the point of
@@ -102,12 +103,9 @@ def bounded_days(name: str, default: int) -> int:
 def seed_root():
     """The packaged pages a fresh memory starts from.
 
-    Shipped as files rather than assembled in code, the way the production
-    system this recipe is adapted from does it: its Stage-0 bootstrap copies
-    packaged seed pages into the workspace, idempotently and without
-    overwriting, and logs that it did. A page written by string concatenation
-    at runtime is a second, invisible copy of the schema that drifts from
-    `schema.md` the first time either changes.
+    Shipped as files rather than assembled in code. A page written by string
+    concatenation at runtime is a second, invisible copy of the schema that
+    drifts from `schema.md` the first time either changes.
     """
     return Path(__file__).resolve().parent.parent / "seed"
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_memory_check.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_memory_check.py
@@ -181,6 +181,71 @@ class TestTheContractDoesNotContradictTheChecker(unittest.TestCase):
         self.assertIn("unindexed", self.kinds(),
                       "an undeclared file in a project folder was swallowed")
 
+    def test_a_reserved_name_at_the_wrong_depth_is_still_checked(self):
+        """The exemption is positional, not just nominal.
+
+        A file merely named `log.md`, outside the root and outside a
+        project folder's own top level, shares a sidecar's name without
+        being in the position the schema puts one there. `patterns/log.md`
+        and a project sidecar nested one level deeper than the schema
+        allows both used to disappear from every check by name alone.
+        """
+        (self.root / "patterns").mkdir()
+        (self.root / "patterns" / "log.md").write_text(
+            "scratch\n", encoding="utf-8")
+        unindexed = {f.path for f in check_index(self.root)
+                    if f.kind == "unindexed"}
+        self.assertIn("patterns/log.md", unindexed,
+                      "a file merely named log.md, not the memory root's own,"
+                      " was swallowed")
+
+        nested = self.root / "projects" / "billing_migration" / "nested"
+        nested.mkdir()
+        (nested / "log.archive.md").write_text("scratch\n", encoding="utf-8")
+        unindexed = {f.path for f in check_index(self.root)
+                    if f.kind == "unindexed"}
+        self.assertIn("projects/billing_migration/nested/log.archive.md",
+                      unindexed,
+                      "a sidecar name nested deeper than the schema puts one"
+                      " was swallowed")
+
+    def test_a_page_linked_under_the_wrong_section_is_found(self):
+        """A link merely present in the document is not the same as filed
+        where it belongs.
+
+        A concept page linked under `## People`, with an empty `## Concepts`
+        heading added after `## Attention`, used to pass: heading presence
+        and link presence were each checked without regard to where either
+        one actually sat.
+        """
+        (self.root / "concepts").mkdir(exist_ok=True)
+        (self.root / "concepts" / "cutover.md").write_text(
+            "---\ntype: concept\nupdated: 2026-08-20\n---\n\n# Cutover\n",
+            encoding="utf-8")
+        index = self.root / "index.md"
+        original = index.read_text(encoding="utf-8")
+
+        misfiled = original.replace(
+            "## People\n",
+            "## People\n\n- [Cutover](concepts/cutover.md) — the window\n",
+            1).rstrip() + "\n\n## Concepts\n"
+        index.write_text(misfiled, encoding="utf-8")
+        found = {f.kind for f in check_all(self.root, self.TODAY)}
+        self.assertIn("index-misfiled", found)
+        self.assertIn("index-out-of-order", found)
+
+        # Filed under its own section, in schema order, both clear.
+        fixed = original.replace(
+            "## Attention",
+            "## Concepts\n\n- [Cutover](concepts/cutover.md) — the window\n"
+            "\n## Attention", 1)
+        index.write_text(fixed, encoding="utf-8")
+        after = {f.kind for f in check_all(self.root, self.TODAY)}
+        self.assertNotIn("index-misfiled", after)
+        self.assertNotIn("index-out-of-order", after)
+        self.assertNotIn("index-section-missing", after)
+        self.assertNotIn("unindexed", after)
+
     def test_a_project_page_under_the_wrong_name_is_still_checked(self):
         """The shape that most needs reporting, and the one the first rule
         was silent about. `projects/` has no writer, so these pages come from
@@ -296,11 +361,16 @@ class TestTheContractDoesNotContradictTheChecker(unittest.TestCase):
 
         Reported rather than rewritten: the repair job adds the heading,
         which is the path that already exists for a memory that has drifted
-        from its contract.
+        from its contract. Added where `schema.md` orders it, not merely
+        appended — `## Concepts` after `## Attention` clears
+        `index-section-missing` and fails `index-out-of-order` instead, which
+        is not a repair.
         """
         # The shipped fixture index is already the "before" state: it was
         # written when the order had no `## Concepts`, which is the same
-        # position every installed memory is in.
+        # position every installed memory is in. `## Attention` is the only
+        # existing section that schema order puts after `## Concepts`, so
+        # that is where the heading belongs.
         index = self.root / "index.md"
         self.assertNotIn("## Concepts", index.read_text(encoding="utf-8"))
         (self.root / "concepts").mkdir(exist_ok=True)
@@ -312,12 +382,15 @@ class TestTheContractDoesNotContradictTheChecker(unittest.TestCase):
         self.assertIn("index-section-missing", found)
 
         index.write_text(
-            index.read_text(encoding="utf-8").rstrip()
-            + "\n\n## Concepts\n\n- [Cutover](concepts/cutover.md) — the"
-              " window\n", encoding="utf-8")
+            index.read_text(encoding="utf-8").replace(
+                "## Attention",
+                "## Concepts\n\n- [Cutover](concepts/cutover.md) — the"
+                " window\n\n## Attention", 1), encoding="utf-8")
         after = {f.kind for f in check_all(self.root, self.TODAY)}
         self.assertNotIn("index-section-missing", after)
         self.assertNotIn("unindexed", after)
+        self.assertNotIn("index-out-of-order", after)
+        self.assertNotIn("index-misfiled", after)
 
     def test_bootstrap_does_not_reach_an_existing_index(self):
         """Stated as a fact this file depends on rather than a wish.

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_memory_check.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_memory_check.py
@@ -246,6 +246,82 @@ class TestTheContractDoesNotContradictTheChecker(unittest.TestCase):
         self.assertNotIn("index-section-missing", after)
         self.assertNotIn("unindexed", after)
 
+    def test_a_fenced_or_commented_sample_index_entry_is_not_real_content(self):
+        """A code fence or an HTML comment can quote what a heading or a
+        link looks like without making it real index content — a reader
+        showing an example is not the same as filing the entry.
+        """
+        (self.root / "concepts").mkdir(exist_ok=True)
+        (self.root / "concepts" / "cutover.md").write_text(
+            "---\ntype: concept\nupdated: 2026-08-20\n---\n\n# Cutover\n",
+            encoding="utf-8")
+        index = self.root / "index.md"
+        original = index.read_text(encoding="utf-8")
+
+        decorated = original.rstrip() + (
+            "\n\n```markdown\n## Concepts\n```\n"
+            "\n<!-- example: [Cutover](concepts/cutover.md) -->\n")
+        index.write_text(decorated, encoding="utf-8")
+
+        found = {f.kind for f in check_all(self.root, self.TODAY)}
+        self.assertIn("index-section-missing", found,
+                      "a heading quoted inside a code fence satisfied the check")
+        self.assertIn("unindexed", found,
+                      "a link quoted inside an HTML comment satisfied the check")
+
+    def test_a_duplicate_misfiled_link_is_found_even_after_a_correct_one(self):
+        """A target linked twice — once correctly, once from the wrong
+        section — is still a misfiled entry. Checking only the first
+        occurrence, in document order, missed exactly this duplicate: the
+        correct one came first and hid the wrong one that followed it.
+        """
+        (self.root / "concepts").mkdir(exist_ok=True)
+        (self.root / "concepts" / "cutover.md").write_text(
+            "---\ntype: concept\nupdated: 2026-08-20\n---\n\n# Cutover\n",
+            encoding="utf-8")
+        index = self.root / "index.md"
+        original = index.read_text(encoding="utf-8")
+
+        # Correctly filed under a fresh ## Concepts section (which comes
+        # before ## Attention in document order), then duplicated under
+        # ## Attention — the first, correct occurrence would hide the
+        # second if only the first were checked.
+        doubled = original.replace(
+            "## Attention",
+            "## Concepts\n\n- [Cutover](concepts/cutover.md) — the window\n"
+            "\n## Attention", 1)
+        doubled = doubled.replace(
+            "## Attention\n",
+            "## Attention\n\n- [Cutover, again](concepts/cutover.md) —"
+            " duplicate\n", 1)
+        index.write_text(doubled, encoding="utf-8")
+
+        found = {f.kind for f in check_all(self.root, self.TODAY)}
+        self.assertIn("index-misfiled", found,
+                      "a correct first occurrence hid a misfiled duplicate")
+
+    def test_index_section_missing_and_misfiled_fire_together_for_the_same_type(self):
+        """When a page's type has no section yet but the page is already
+        linked somewhere else, both findings fire together — that pairing
+        is what tells the repair job to move the existing entry rather than
+        leave the new section empty.
+        """
+        (self.root / "concepts").mkdir(exist_ok=True)
+        (self.root / "concepts" / "cutover.md").write_text(
+            "---\ntype: concept\nupdated: 2026-08-20\n---\n\n# Cutover\n",
+            encoding="utf-8")
+        index = self.root / "index.md"
+        index.write_text(
+            index.read_text(encoding="utf-8").replace(
+                "## People\n",
+                "## People\n\n- [Cutover](concepts/cutover.md) — the"
+                " window\n", 1),
+            encoding="utf-8")
+
+        found = {f.kind for f in check_all(self.root, self.TODAY)}
+        self.assertIn("index-section-missing", found)
+        self.assertIn("index-misfiled", found)
+
     def test_a_project_page_under_the_wrong_name_is_still_checked(self):
         """The shape that most needs reporting, and the one the first rule
         was silent about. `projects/` has no writer, so these pages come from
@@ -550,6 +626,17 @@ class TestNoInstructionAsksAnUnanswerableQuestion(unittest.TestCase):
         reasonably try to infer it."""
         text = self.SKILL.read_text(encoding="utf-8")
         self.assertIn("inbound messages only", text)
+
+    def test_the_third_rule_does_not_compare_against_an_unsupplied_identity(self):
+        """"Names the user" asked the agent to check a message's text
+        against the user's own name or address, and the selector supplies
+        neither per interaction — there is nothing to compare the text
+        against. The rule is bound to `addressing` and the message's own
+        text only, the same discipline the other two rules already follow.
+        """
+        block = self.rules_block().lower()
+        self.assertNotIn("interactions you were given names the user", block)
+        self.assertIn("gives you no\n  name or address for the user to compare", block)
 
 
 class TestPersonIdentityIsChecked(unittest.TestCase):

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_memory_check.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_memory_check.py
@@ -38,9 +38,17 @@ class TestInvariants(unittest.TestCase):
 
     def test_a_broken_link_is_found(self):
         p = self.root / "people" / "dana_okoro.md"
-        p.write_text(p.read_text("utf-8").replace(
+        original = p.read_text("utf-8")
+        p.write_text(original.replace(
             "../projects/billing_migration/billing_migration.md",
             "../projects/gone/gone.md"), encoding="utf-8")
+        self.assertIn("broken-link", self.kinds(check_links(self.root)))
+
+        # CommonMark permits a soft line ending inside link text. Page prose
+        # is not constrained to the index's one-entry-per-line shape.
+        p.write_text(original + (
+            "\n[See the missing\nproject](../projects/gone/gone.md)\n"),
+            encoding="utf-8")
         self.assertIn("broken-link", self.kinds(check_links(self.root)))
 
     def test_a_page_past_its_decay_window_is_reported_not_corrected(self):
@@ -269,6 +277,307 @@ class TestTheContractDoesNotContradictTheChecker(unittest.TestCase):
         self.assertIn("unindexed", found,
                       "a link quoted inside an HTML comment satisfied the check")
 
+        # All three are valid Markdown fences. The first implementation only
+        # recognized an unindented run of exactly three backticks, so each of
+        # these could put a fake section and entry in the schema's exact order
+        # and make the checker certify an index with no navigable content.
+        variants = (
+            ("tilde", "~~~markdown", "~~~"),
+            ("indented", "   ```markdown", "   ```"),
+            ("longer backtick", "````markdown", "````"),
+        )
+        for name, opener, closer in variants:
+            with self.subTest(fence=name):
+                decorated = original.replace(
+                    "## Attention",
+                    f"Fence sample:\n{opener}\n## Concepts\n"
+                    "- [Cutover](concepts/cutover.md) — the window\n"
+                    f"{closer}\n\n## Attention",
+                    1)
+                index.write_text(decorated, encoding="utf-8")
+                found = {f.kind for f in check_all(self.root, self.TODAY)}
+                self.assertIn(
+                    "index-section-missing", found,
+                    f"a heading quoted inside a {name} fence satisfied the check")
+                self.assertIn(
+                    "unindexed", found,
+                    f"a link quoted inside a {name} fence satisfied the check")
+
+        # A fence nested in another Markdown container keeps that container's
+        # source prefix. Its links are not top-level index entries even when a
+        # real section heading exists outside the sample.
+        containers = (
+            ("block quote",
+             "> ```markdown\n> - [Cutover](concepts/cutover.md)\n> ```"),
+            ("list item",
+             "- Example only:\n  ```markdown\n"
+             "  - [Cutover](concepts/cutover.md)\n  ```"),
+        )
+        for name, sample in containers:
+            with self.subTest(container=name):
+                decorated = original.replace(
+                    "## Attention",
+                    "## Concepts\n\n" + sample + "\n\n## Attention",
+                    1)
+                index.write_text(decorated, encoding="utf-8")
+                found = {f.kind for f in check_all(self.root, self.TODAY)}
+                self.assertIn(
+                    "index-unparseable", found,
+                    f"a link in a {name} container was silently certified")
+
+        # Fence markers inside a comment are not fences. If the two constructs
+        # are stripped in separate passes, this unmatched marker can hide the
+        # real section and entry that follow the comment.
+        decorated = original.replace(
+            "## Attention",
+            "<!-- quoted fence:\n```\n-->\n\n"
+            "## Concepts\n\n- [Cutover](concepts/cutover.md) — the window\n\n"
+            "## Attention",
+            1)
+        index.write_text(decorated, encoding="utf-8")
+        found = {f.kind for f in check_all(self.root, self.TODAY)}
+        self.assertNotIn("index-section-missing", found)
+        self.assertNotIn("unindexed", found)
+
+        # The inverse ordering matters too: an unmatched comment marker inside
+        # a fence is code, not the start of a comment that consumes real index
+        # content after the closing fence.
+        decorated = original.replace(
+            "## Attention",
+            "```markdown\n<!--\n```\n\n"
+            "## Concepts\n\n- [Cutover](concepts/cutover.md) — the window\n\n"
+            "## Attention",
+            1)
+        index.write_text(decorated, encoding="utf-8")
+        found = {f.kind for f in check_all(self.root, self.TODAY)}
+        self.assertNotIn("index-section-missing", found)
+        self.assertNotIn("unindexed", found)
+
+        # Like an unclosed fence, an unclosed HTML comment runs through EOF.
+        # A fake section and entry inside it cannot satisfy the checker.
+        decorated = original.rstrip() + (
+            "\n\n<!-- sample\n## Concepts\n"
+            "- [Cutover](concepts/cutover.md) — the window\n")
+        index.write_text(decorated, encoding="utf-8")
+        found = {f.kind for f in check_all(self.root, self.TODAY)}
+        self.assertIn("index-section-missing", found)
+        self.assertIn("unindexed", found)
+
+        # Masking inline code must preserve source position: content after a
+        # visible code span is not suddenly a line-start heading or entry.
+        decorated = original.replace(
+            "## Attention",
+            "`x`## Concepts\n`x`- [Cutover](concepts/cutover.md)\n\n"
+            "## Attention", 1)
+        index.write_text(decorated, encoding="utf-8")
+        found = {f.kind for f in check_all(self.root, self.TODAY)}
+        self.assertIn("index-section-missing", found)
+        self.assertIn("unindexed", found)
+
+    def test_schema_permitted_index_entry_spellings_stay_accepted(self):
+        """The checker must not turn parser hardening into a migration.
+
+        The schema requires a relative link first, not a particular bullet or
+        separator. Existing user-owned indexes may therefore use any of these
+        spellings, all of which the earlier source-link scan accepted.
+        """
+        (self.root / "concepts").mkdir(exist_ok=True)
+        (self.root / "concepts" / "cutover.md").write_text(
+            "---\ntype: concept\nupdated: 2026-08-20\n---\n\n# Cutover\n",
+            encoding="utf-8")
+        index = self.root / "index.md"
+        original = index.read_text(encoding="utf-8")
+        forms = (
+            "[Cutover](concepts/cutover.md) — the window",
+            "[](concepts/cutover.md) — an empty but valid label",
+            "[Cutover\\*](concepts/cutover.md) — an escaped label character",
+            "- [Cutover](concepts/cutover.md) — the window",
+            "-    [Cutover](concepts/cutover.md) — four columns of padding",
+            "1. [Cutover](concepts/cutover.md) — the window",
+            "   + [Cutover](concepts/cutover.md) — the window",
+            "[Cutover](concepts/cutover.md): the window",
+        )
+        for entry in forms:
+            with self.subTest(entry=entry):
+                index.write_text(original.replace(
+                    "## Attention",
+                    f"## Concepts\n\n{entry}\n\n## Attention", 1),
+                    encoding="utf-8")
+                kinds = {f.kind for f in check_index(self.root)}
+                self.assertFalse(
+                    kinds & {"unindexed", "index-misfiled",
+                             "index-section-missing", "index-unparseable"})
+
+        # Five columns after a list marker make the apparent link indented
+        # code, not inline list content. It must not certify a navigable entry.
+        index.write_text(original.replace(
+            "## Attention",
+            "## Concepts\n\n-     [Cutover](concepts/cutover.md)\n\n"
+            "## Attention", 1), encoding="utf-8")
+        self.assertEqual(
+            [f.kind for f in check_index(self.root)], ["index-unparseable"])
+
+        # Bare destinations containing whitespace are not Markdown links;
+        # path normalization must not let them alias the real page.
+        for whitespace in (" ", "\t"):
+            with self.subTest(destination_whitespace=repr(whitespace)):
+                index.write_text(original.replace(
+                    "## Attention",
+                    "## Concepts\n\n- [Cutover](ghost" + whitespace
+                    + "/../concepts/cutover.md)\n\n## Attention", 1),
+                    encoding="utf-8")
+                self.assertIn(
+                    "unindexed", {f.kind for f in check_index(self.root)})
+
+        # Escaping the apparent label closer means CommonMark does not render
+        # this source as the link the simple shape superficially resembles.
+        index.write_text(original.replace(
+            "## Attention",
+            "## Concepts\n\n- [Cutover\\](concepts/cutover.md)\n\n"
+            "## Attention", 1), encoding="utf-8")
+        self.assertIn("unindexed",
+                      {f.kind for f in check_index(self.root)})
+
+    def test_container_literals_cannot_change_top_level_index_state(self):
+        """A nested unclosed construct ends with its Markdown container.
+
+        In particular it must neither certify a fake entry nor consume a real,
+        dedented section and entry that follow it.
+        """
+        (self.root / "concepts").mkdir(exist_ok=True)
+        (self.root / "concepts" / "cutover.md").write_text(
+            "---\ntype: concept\nupdated: 2026-08-20\n---\n\n# Cutover\n",
+            encoding="utf-8")
+        index = self.root / "index.md"
+        original = index.read_text(encoding="utf-8")
+        samples = (
+            "- Example only:\n  ```markdown\n"
+            "  - [Cutover](concepts/cutover.md)\n",
+            "> ```markdown\n> <!--\n"
+            "> - [Cutover](concepts/cutover.md)\n> ```\n",
+            "    <!-- literal in indented code\n",
+            "A literal marker: `<!--`\n",
+            "An escaped marker: \\<!--\n",
+            "Latency < 5 ms and affinity <3 are ordinary text.\n",
+        )
+        for position, sample in enumerate(samples):
+            with self.subTest(sample=sample.splitlines()[0]):
+                index.write_text(original.replace(
+                    "## Attention",
+                    sample + "\n## Concepts\n\n"
+                    "- [Cutover](concepts/cutover.md) — the window\n\n"
+                    "## Attention", 1), encoding="utf-8")
+                kinds = {f.kind for f in check_index(self.root)}
+                if position < 2:
+                    self.assertEqual(kinds, {"index-unparseable"})
+                else:
+                    self.assertFalse(
+                        kinds & {"unindexed", "index-section-missing",
+                                 "index-unparseable"})
+
+        # An ordered marker other than 1 cannot interrupt a paragraph. These
+        # apparent entries are lazy continuations of the preceding container,
+        # so the subset parser must refuse to guess that they are top-level.
+        lazy_samples = (
+            "> sample paragraph\n2. [Cutover](concepts/cutover.md)",
+            "- sample paragraph\n2. [Cutover](concepts/cutover.md)",
+            "ordinary paragraph\n2. [Cutover](concepts/cutover.md)",
+            "<https://example.com>\n2. [Cutover](concepts/cutover.md)",
+            "ordinary paragraph\n2. text <?pi\n"
+            "[Cutover](concepts/cutover.md)\n?>",
+            "ordinary paragraph\n2. text <!--\n"
+            "[Cutover](concepts/cutover.md)\n-->",
+        )
+        for sample in lazy_samples:
+            with self.subTest(lazy=sample.splitlines()[0]):
+                index.write_text(original.replace(
+                    "## Attention",
+                    "## Concepts\n\n" + sample + "\n\n## Attention", 1),
+                    encoding="utf-8")
+                self.assertEqual(
+                    [f.kind for f in check_index(self.root)],
+                    ["index-unparseable"])
+
+    def test_ambiguous_raw_html_fails_closed(self):
+        """Unsupported raw HTML cannot supply apparently valid index data.
+
+        Returning only the parse finding prevents unattended repair from
+        adding or moving entries based on a partial view of a user-owned file.
+        """
+        (self.root / "concepts").mkdir(exist_ok=True)
+        (self.root / "concepts" / "cutover.md").write_text(
+            "---\ntype: concept\nupdated: 2026-08-20\n---\n\n# Cutover\n",
+            encoding="utf-8")
+        index = self.root / "index.md"
+        original = index.read_text(encoding="utf-8")
+        raw_openers = (
+            "<div>",
+            "<script>not markdown",
+            '<x-note data-x="a>b">',
+            "Intro <?pi",
+            'Intro <span title="',
+        )
+        for opener in raw_openers:
+            with self.subTest(opener=opener):
+                index.write_text(original.replace(
+                    "## Attention",
+                    f"{opener}\n## Concepts\n"
+                    "- [Cutover](concepts/cutover.md) — sample only\n\n"
+                    "## Attention", 1), encoding="utf-8")
+                findings = check_index(self.root)
+                self.assertEqual(
+                    [f.kind for f in findings], ["index-unparseable"])
+                self.assertIn(
+                    "make no automatic index repair", findings[0].detail)
+
+    def test_noncontent_index_links_do_not_report_as_broken(self):
+        """Link validation and structural validation use the same view."""
+        index = self.root / "index.md"
+        original = index.read_text(encoding="utf-8")
+        index.write_text(original + (
+            "\n```markdown\n- [Gone](people/gone.md)\n```\n"
+            "\n<!--\n- [Also gone](people/also-gone.md)\n-->\n"),
+            encoding="utf-8")
+        self.assertNotIn("broken-link", self.kinds(check_links(self.root)))
+
+        # Markdown-looking characters inside a URI autolink remain part of
+        # that autolink; they are not a second, relative Markdown link.
+        index.write_text(original + (
+            "\nSee <http:x[Gone](people/gone.md)>\n"), encoding="utf-8")
+        self.assertNotIn("broken-link", self.kinds(check_links(self.root)))
+
+        index.write_text(original + (
+            "\nLiteral: \\[Gone](people/gone.md)\n"), encoding="utf-8")
+        self.assertNotIn("broken-link", self.kinds(check_links(self.root)))
+
+        # Visible links in unsupported containers cannot disappear from link
+        # validation. The structural parser fails closed instead of silently
+        # treating them like fenced/commented examples.
+        index.write_text(index.read_text(encoding="utf-8") + (
+            "\n- Notes:\n  - [Gone](people/gone.md)\n"),
+            encoding="utf-8")
+        self.assertEqual(
+            [f.kind for f in check_index(self.root)], ["index-unparseable"])
+
+        # A blank line does not end a list item when the following content is
+        # still indented to that item's content column.
+        for nested in ("  [Gone](people/gone.md)",
+                       "  - [Gone](people/gone.md)"):
+            with self.subTest(nested=nested):
+                index.write_text(
+                    "## People\n\n- [Dana](people/dana_okoro.md)\n\n"
+                    + nested + "\n", encoding="utf-8")
+                self.assertEqual(
+                    [f.kind for f in check_index(self.root)],
+                    ["index-unparseable"])
+
+        # A visible link in ordinary prose is not an index entry, but it still
+        # participates in the check that every navigable relative link exists.
+        index.write_text(original + (
+            "\nA note continues here with [Gone](people/gone.md).\n"),
+            encoding="utf-8")
+        self.assertIn("broken-link", self.kinds(check_links(self.root)))
+
     def test_a_duplicate_misfiled_link_is_found_even_after_a_correct_one(self):
         """A target linked twice — once correctly, once from the wrong
         section — is still a misfiled entry. Checking only the first
@@ -467,6 +776,18 @@ class TestTheContractDoesNotContradictTheChecker(unittest.TestCase):
         self.assertNotIn("unindexed", after)
         self.assertNotIn("index-out-of-order", after)
         self.assertNotIn("index-misfiled", after)
+
+        # The scheduled repair agent must be told to perform the same complete
+        # repair this test just demonstrated. `index-section-missing` can pair
+        # with `unindexed` rather than `index-misfiled` when no entry exists at
+        # all; guidance that discusses only the latter leaves the new section
+        # empty and the page unreachable.
+        repair = (HERE.parents[1] / "profile" / "skills" / "memory-repair"
+                  / "SKILL.md").read_text(encoding="utf-8")
+        start = repair.index("2. **Index sections.**")
+        section = repair[start:repair.index("\n3. **Links resolve.**", start)]
+        self.assertIn("`index-misfiled`", section)
+        self.assertIn("`unindexed`", section)
 
     def test_bootstrap_does_not_reach_an_existing_index(self):
         """Stated as a fact this file depends on rather than a wish.

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_memory_check.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_memory_check.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 HERE = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(HERE))
+import memory_check  # noqa: E402
 from memory_check import check_all, check_ceilings, check_decay, check_frontmatter, check_identity, check_index, check_links, check_provenance  # noqa: E402
 
 FIXTURES = HERE.parents[1] / "fixtures" / "memory"
@@ -119,6 +120,363 @@ class TestInvariants(unittest.TestCase):
         second = [str(f) for f in check_all(self.root, self.today)]
         self.assertEqual(first, second)
         self.assertTrue(first, "the fixture was supposed to be dirty")
+
+
+class TestTheContractDoesNotContradictTheChecker(unittest.TestCase):
+    """Three places where following the schema produced a finding.
+
+    Each was reachable from a correct memory, which is what made them worth
+    fixing before anything is built on this checker: a later phase that says
+    "checks pass" is worth less when two of the findings are permanent and
+    were caused by obeying the contract.
+    """
+
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp()) / "memory"
+        shutil.copytree(FIXTURES, self.root)
+
+    # The fixture's `stale` finding comes from a seed deliberately dated
+    # 1970-01-01, so it holds at any date — but the other pages carry real
+    # dates and would start decaying as the calendar moves past them. Pinning
+    # keeps this file measuring the change rather than the day it runs.
+    TODAY = date(2026, 8, 20)
+
+    def kinds(self, findings=None):
+        return sorted(f.kind for f in
+                      (findings or check_all(self.root, self.TODAY)))
+
+    def test_the_fixture_memory_is_clean_apart_from_the_stale_seed(self):
+        """The baseline this file measures against. `current_priorities.md`
+        ships dated 1970-01-01 on purpose so the first repair run has work."""
+        self.assertEqual(self.kinds(), ["stale"])
+
+    def test_a_rotated_project_log_produces_no_finding(self):
+        """`schema.md` requires log.md to rotate into log.archive.md at 1000
+        entries. Before this, doing so left `unindexed` and
+        `missing-frontmatter` reported for as long as the archive existed —
+        two permanent findings caused by following the contract, on a file
+        that is an append-only history and carries no frontmatter by design.
+        """
+        archive = self.root / "projects" / "billing_migration" / "log.archive.md"
+        archive.write_text("- 2026-01-01 an older entry\n", encoding="utf-8")
+        self.assertEqual(self.kinds(), ["stale"])
+
+    def test_only_the_sidecars_the_schema_declares_are_exempt(self):
+        """The exemption is a list, and it is the schema's list.
+
+        Reading "anything not named after the folder" as a sidecar was the
+        first attempt, and it deleted a real page from every check: a project
+        page written as `overview.md` reported nothing — no missing field, no
+        bad value, no broken link — where the code it replaced reported four.
+        A file in a project folder that is neither the page nor a declared
+        sidecar is far more likely to be a page under the wrong name than a
+        sidecar nobody wrote down.
+        """
+        folder = self.root / "projects" / "billing_migration"
+        (folder / "log.archive.md").write_text("- older\n", encoding="utf-8")
+        self.assertEqual(self.kinds(), ["stale"])
+
+        (folder / "notes.md").write_text(
+            "scratch\n", encoding="utf-8")
+        self.assertIn("unindexed", self.kinds(),
+                      "an undeclared file in a project folder was swallowed")
+
+    def test_a_project_page_under_the_wrong_name_is_still_checked(self):
+        """The shape that most needs reporting, and the one the first rule
+        was silent about. `projects/` has no writer, so these pages come from
+        a person — which is exactly where a name mismatch comes from."""
+        folder = self.root / "projects" / "onboarding_revamp"
+        folder.mkdir(parents=True)
+        (folder / "overview.md").write_text(
+            "---\nname: Onboarding revamp\npriority: URGENT\nrole: owner\n"
+            "---\n\n# Onboarding revamp\n\n## Resources\n\n"
+            "- [gone](../../people/nobody.md)\n", encoding="utf-8")
+        found = self.kinds()
+        for kind in ("unindexed", "missing-field", "bad-value", "broken-link"):
+            with self.subTest(kind=kind):
+                self.assertIn(kind, found)
+
+    def test_the_declared_sidecars_are_the_ones_the_schema_lists(self):
+        """Two statements of one rule, so they are compared rather than
+        trusted to stay together."""
+        recipe = HERE.parents[1]
+        block = re.search(r"projects/<slug>/\n(.*?)```",
+                          (recipe / "profile" / "schema.md").read_text(
+                              encoding="utf-8"), re.S).group(1)
+        listed = set(re.findall(r"([\w.]+\.md)", block)) - {"<slug>.md"}
+        self.assertEqual(listed, set(memory_check.DECLARED_SIDECARS))
+
+    def test_the_page_inside_a_folder_type_is_still_checked(self):
+        """The exemption must not swallow the page it sits beside."""
+        page = (self.root / "projects" / "billing_migration"
+                / "billing_migration.md")
+        page.write_text(re.sub(r"^name:.*\n", "", page.read_text(),
+                               count=1, flags=re.M), encoding="utf-8")
+        self.assertIn("missing-field", self.kinds())
+
+    def test_a_page_nested_in_a_flat_type_is_still_checked(self):
+        """The exemption is for folder-shaped types and nothing else.
+
+        A first attempt read "nested and not named after its folder" as the
+        definition of a sidecar. That skipped a page nested anywhere — and
+        skipping is worse than the defect it replaced, because an unindexed
+        page is reported while an unchecked one is silent. Measured: a
+        `patterns/sub/x.md` missing every required field produced no finding
+        at all.
+        """
+        nested = self.root / "patterns" / "sub"
+        nested.mkdir(parents=True)
+        (nested / "work_habits.md").write_text(
+            "---\ntype: pattern\n---\n\n# No updated, no decay\n",
+            encoding="utf-8")
+        found = self.kinds()
+        self.assertIn("missing-field", found)
+        self.assertIn("unindexed", found)
+
+    def test_only_the_types_the_schema_writes_as_folders_have_sidecars(self):
+        """`FOLDER_SHAPED` is the whole exemption, and the schema names its
+        members by spelling them `<type>/<slug>/` in their own headings."""
+        recipe = HERE.parents[1]
+        headings = re.findall(r"^### \w[\w ]*\(`([a-z_]+)/(<slug>/)?`\)",
+                              (recipe / "profile" / "schema.md").read_text(
+                                  encoding="utf-8"), re.M)
+        foldered = {name for name, slug in headings if slug}
+        self.assertEqual(foldered, set(memory_check.FOLDER_SHAPED))
+
+    def test_a_concept_page_can_be_indexed(self):
+        """`concepts/` is one of the six page types and had no section in the
+        index order, so the first one written was `unindexed` on arrival with
+        nowhere to put the entry that would clear it.
+
+        Written against the index the recipe ships rather than one this test
+        composes. Appending a section here would pass whatever the seed says,
+        which is the shape of test that let the defect exist: `check_index`
+        resolves links and never reads a heading, so only the shipped file
+        can answer whether there is somewhere to put the entry.
+        """
+        recipe = HERE.parents[1]
+        index = self.root / "index.md"
+        index.write_text(
+            (recipe / "profile" / "seed" / "index.md").read_text(
+                encoding="utf-8"), encoding="utf-8")
+        (self.root / "concepts").mkdir(exist_ok=True)
+        (self.root / "concepts" / "cutover.md").write_text(
+            "---\ntype: concept\nupdated: 2026-08-20\n---\n\n"
+            "# Cutover\n\nThe window a migration runs in.\n",
+            encoding="utf-8")
+
+        # Every other page is now unindexed too, because the seed indexes
+        # none of the fixture's pages. The concept page is the one under test.
+        unindexed = {f.path for f in check_all(self.root, self.TODAY)
+                     if f.kind == "unindexed"}
+        self.assertIn("concepts/cutover.md", unindexed)
+
+        section = re.search(r"^## Concepts\n", index.read_text(encoding="utf-8"),
+                            re.M)
+        self.assertIsNotNone(
+            section, "the shipped index has no section to file a concept under")
+        index.write_text(
+            index.read_text(encoding="utf-8").replace(
+                "## Concepts\n",
+                "## Concepts\n\n- [Cutover](concepts/cutover.md) — the window\n",
+                1), encoding="utf-8")
+        self.assertNotIn("concepts/cutover.md",
+                         {f.path for f in check_all(self.root, self.TODAY)
+                          if f.kind == "unindexed"})
+
+    def test_an_already_installed_memory_is_told_what_it_is_missing(self):
+        """The half of a schema change a seed cannot deliver.
+
+        `bootstrap` copies in what is missing and never overwrites, which is
+        right — the index belongs to the user. It also means a memory created
+        before a page type was added keeps the sections it was created with,
+        so adding `## Concepts` to `profile/seed/index.md` reaches new
+        installs and nobody else. The people most likely to have content are
+        exactly the ones who would never receive it.
+
+        Reported rather than rewritten: the repair job adds the heading,
+        which is the path that already exists for a memory that has drifted
+        from its contract.
+        """
+        # The shipped fixture index is already the "before" state: it was
+        # written when the order had no `## Concepts`, which is the same
+        # position every installed memory is in.
+        index = self.root / "index.md"
+        self.assertNotIn("## Concepts", index.read_text(encoding="utf-8"))
+        (self.root / "concepts").mkdir(exist_ok=True)
+        (self.root / "concepts" / "cutover.md").write_text(
+            "---\ntype: concept\nupdated: 2026-08-20\n---\n\n# Cutover\n",
+            encoding="utf-8")
+
+        found = {f.kind for f in check_all(self.root, self.TODAY)}
+        self.assertIn("index-section-missing", found)
+
+        index.write_text(
+            index.read_text(encoding="utf-8").rstrip()
+            + "\n\n## Concepts\n\n- [Cutover](concepts/cutover.md) — the"
+              " window\n", encoding="utf-8")
+        after = {f.kind for f in check_all(self.root, self.TODAY)}
+        self.assertNotIn("index-section-missing", after)
+        self.assertNotIn("unindexed", after)
+
+    def test_bootstrap_does_not_reach_an_existing_index(self):
+        """Stated as a fact this file depends on rather than a wish.
+
+        If bootstrap ever did overwrite, the check above would be redundant
+        and this test would say so by failing.
+        """
+        import os
+        import select_memory
+        home = Path(tempfile.mkdtemp())
+        previous = os.environ.get("HERMES_HOME")
+        os.environ["HERMES_HOME"] = str(home)
+        try:
+            mem = select_memory.memory_root()
+            mem.mkdir(parents=True, exist_ok=True)
+            (mem / "index.md").write_text(
+                "---\ntype: index\nupdated: 2026-08-01\n---\n\n"
+                "# Memory\n\n## People\n", encoding="utf-8")
+            (mem / "log.md").write_text("# Log\n", encoding="utf-8")
+            select_memory.bootstrap(mem)
+            self.assertNotIn("## Concepts",
+                             (mem / "index.md").read_text(encoding="utf-8"))
+        finally:
+            if previous is None:
+                os.environ.pop("HERMES_HOME", None)
+            else:
+                os.environ["HERMES_HOME"] = previous
+
+    def test_a_type_with_no_pages_yet_is_not_a_finding(self):
+        """An empty section is not owed until there is something to file.
+
+        Requiring one for every validated type reported three findings on the
+        shipped fixture, which is noise a user cannot clear by doing anything
+        right.
+        """
+        self.assertNotIn("index-section-missing", self.kinds())
+
+    def test_the_index_order_and_the_shipped_seed_agree(self):
+        """They are two statements of one rule, and the seed is what a fresh
+        install actually gets."""
+        recipe = HERE.parents[1]
+        order = re.search(r"Sections, in this order: (.+?)\.",
+                          (recipe / "profile" / "schema.md").read_text(
+                              encoding="utf-8"), re.S).group(1)
+        declared = re.findall(r"## (\w+)", order)
+        shipped = re.findall(r"^## (\w+)",
+                             (recipe / "profile" / "seed" / "index.md").read_text(
+                                 encoding="utf-8"), re.M)
+        self.assertEqual(declared, shipped)
+        # Derived rather than named, so the next page type that gains a
+        # required-fields entry and no index section fails here too.
+        typed = {k.capitalize() for k in memory_check.REQUIRED_FIELDS}
+        self.assertEqual(
+            typed - set(declared), set(),
+            "a validated page type has no section to be indexed under")
+
+
+class TestNoInstructionAsksAnUnanswerableQuestion(unittest.TestCase):
+    """The store holds inbound messages only.
+
+    `memory-writing` told the agent to write a page when the user "has
+    exchanged messages with them in both directions", and not to write one for
+    "senders the user never replies to". Neither can be evaluated: the mail
+    collector reads the inbox and the Slack one drops every message the user
+    wrote, so the outbound half is not in the store. Both rules degraded
+    silently — and the admission clause that was lost is the one that best
+    separates a colleague from a system that only sends notifications.
+    """
+
+    SKILL = (HERE.parents[1] / "profile" / "skills" / "memory-writing"
+             / "SKILL.md")
+
+    # Anything that presumes the user's own traffic. Spellings, not concepts,
+    # so this is a floor and not a proof — see the test below it, which is
+    # the one that reads the evidence rather than the words.
+    OUTBOUND = ("both directions", "never replies", "the user replied",
+                "user's reply", "replied to", "user sent", "user wrote",
+                "sent by the user", "responded to them")
+
+    def rules_block(self):
+        """The admission rules, which is where an unanswerable test does
+        damage. Prose elsewhere may legitimately discuss what is missing."""
+        text = self.SKILL.read_text(encoding="utf-8")
+        start = text.index("Write a page when:")
+        return text[start:text.index("\n## ", start)]
+
+    def test_no_admission_rule_depends_on_what_the_user_sent(self):
+        block = self.rules_block().lower()
+        for phrase in self.OUTBOUND:
+            with self.subTest(phrase=phrase):
+                self.assertNotIn(phrase, block)
+
+    def test_the_rules_only_name_values_the_store_can_hold(self):
+        """The property the phrase list above only approximates.
+
+        The defect was a rule about data that does not exist. A phrase list
+        catches the two spellings that shipped; this catches the class, by
+        checking that every `addressing` value the rules reason about is one
+        the schema permits and the normalizer produces. A rule about
+        `addressing: urgent` would be exactly as unanswerable as a rule about
+        replies, and would read just as plausibly.
+        """
+        recipe = HERE.parents[1]
+        allowed = set(re.findall(
+            r"addressing\s+TEXT CHECK \(addressing IN \(([^)]+)\)",
+            (recipe / "profile" / "scripts" / "schema.sql").read_text(
+                encoding="utf-8"))[0].replace("'", "").split(","))
+        allowed = {v.strip() for v in allowed}
+        self.assertEqual(allowed, {"direct", "mentioned", "broadcast"})
+
+        quoted = set(re.findall(r"`(\w+)`", self.rules_block()))
+        # Only the ones that look like an addressing value are in scope; the
+        # rules may quote other things.
+        used = quoted & (allowed | {"urgent", "reply", "replied", "sent",
+                                    "outbound", "answered"})
+        self.assertTrue(used, "the rules stopped naming any addressing value")
+        self.assertLessEqual(used, allowed,
+                             f"rules reason about values the store cannot"
+                             f" hold: {sorted(used - allowed)}")
+
+    def test_the_rules_say_direct_is_not_sufficient_on_its_own(self):
+        """Mail yields only `direct` or `broadcast` — `mentioned` is Slack's.
+
+        So on the mail side the rewrite is a To-versus-not test, and a
+        machine that addresses the user by name passes it exactly as a
+        colleague does. The old rules excluded that traffic twice over; the
+        new ones have to say so themselves rather than rely on a value mail
+        never produces.
+        """
+        recipe = HERE.parents[1]
+        graph = re.search(r"def graph_message_to_item.*?\n    return \{",
+                          (recipe / "profile" / "scripts" / "normalize.py"
+                           ).read_text(encoding="utf-8"), re.S).group(0)
+        produced = set(re.findall(r'addressing = "(\w+)"', graph))
+        self.assertEqual(produced, {"direct", "broadcast"},
+                         "mail's addressing values changed; the caveat in the"
+                         " skill was written against these")
+
+        text = self.SKILL.read_text(encoding="utf-8")
+        self.assertIn("never `mentioned`", text)
+        self.assertIn("necessary condition", text)
+        self.assertIn("Anything automated, whatever its `addressing`",
+                      self.rules_block())
+
+    def test_the_replacement_uses_a_field_the_selector_supplies(self):
+        """`addressing` is on every interaction the selector hands over, so
+        the agent can answer with it. A rule is only as good as the evidence
+        the payload carries."""
+        text = self.SKILL.read_text(encoding="utf-8")
+        self.assertIn("addressing", text)
+        selector = (HERE.parents[1] / "profile" / "scripts"
+                    / "select_memory.py").read_text(encoding="utf-8")
+        self.assertIn('"addressing": addressing', selector)
+
+    def test_the_limitation_is_stated_rather_than_left_implicit(self):
+        """An agent that does not know the outbound half is missing will
+        reasonably try to infer it."""
+        text = self.SKILL.read_text(encoding="utf-8")
+        self.assertIn("inbound messages only", text)
 
 
 class TestPersonIdentityIsChecked(unittest.TestCase):

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_select_memory.py
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/scripts/tests/test_select_memory.py
@@ -219,6 +219,40 @@ class TestWhoIsWorthAsking(SelectorCase):
                              select_memory.MAX_INTERACTIONS)
 
 
+class TestSubjectDoesNotHideTheBody(SelectorCase):
+    """`subject` and `body` reach the writer as two fields, not one picked by
+    `COALESCE(subject, body)`.
+
+    A generic reply subject is present on nearly every mail in a thread, so
+    coalescing let it win every time and hid a body that might be the only
+    place a name and a request actually appear.
+    """
+
+    def test_a_generic_subject_does_not_hide_the_body(self):
+        self.add("Dana Okoro", days_ago=1, subject="RE: sync",
+                 body="Dana here — could you approve the budget by Friday?")
+        self.add("Dana Okoro", days_ago=2, subject="RE: sync", body="b2")
+        lines = self.report()["interactions"]["dana_okoro"]
+        bodies = {line["body"] for line in lines}
+        self.assertIn(
+            "Dana here — could you approve the budget by Friday?", bodies,
+            "the body carrying the actual request was missing from the"
+            " payload")
+        self.assertTrue(all(line["subject"] == "RE: sync" for line in lines))
+
+    def test_a_row_with_no_subject_still_carries_its_body(self):
+        """Slack rows store `subject: NULL`; the empty string that produces
+        must not be mistaken for a missing body."""
+        self.add("Dana Okoro", days_ago=1, source="slack", subject=None,
+                 body="could you approve the budget?")
+        self.add("Dana Okoro", days_ago=2, source="slack", subject=None,
+                 body="b2")
+        lines = self.report()["interactions"]["dana_okoro"]
+        self.assertTrue(any(line["body"] == "could you approve the budget?"
+                            for line in lines))
+        self.assertTrue(all(line["subject"] == "" for line in lines))
+
+
 class TestIdentityIsStable(SelectorCase):
     """A page name is a durable identity, so two people must never share one."""
 
@@ -602,7 +636,11 @@ class TestAPersonIsWhoTheyAreNotWhatTheyAreCalled(SelectorCase):
             "receivedDateTime": iso(days_ago),
             "from": {"emailAddress": {"name": name, "address": address}},
             "toRecipients": [{"emailAddress": {"address": "user@example.com"}}],
-            "subject": body, "bodyPreview": body, "isRead": False,
+            # `body` nests under `content`, the shape Graph actually returns
+            # and the only one `graph_message_to_item` reads; `bodyPreview`
+            # is a real Graph field too, but not this one, and setting only
+            # it left every synthetic message's stored body silently NULL.
+            "subject": body, "body": {"content": body}, "isRead": False,
         }
         item = normalize.graph_message_to_item(msg, "user@example.com")
         with sqlite3.connect(self.db) as conn:
@@ -638,7 +676,7 @@ class TestAPersonIsWhoTheyAreNotWhatTheyAreCalled(SelectorCase):
                         body=f"second{n}")
         found = self.report()
         for mark, seen in found["interactions"].items():
-            texts = {line["text"] for line in seen}
+            texts = {line["body"] for line in seen}
             self.assertTrue(
                 all(x.startswith("first") for x in texts)
                 or all(x.startswith("second") for x in texts),
@@ -757,7 +795,11 @@ class TestConfirmingALinkDoesNotStrandAPage(SelectorCase):
             "receivedDateTime": iso(days_ago),
             "from": {"emailAddress": {"name": name, "address": address}},
             "toRecipients": [{"emailAddress": {"address": "user@example.com"}}],
-            "subject": body, "bodyPreview": body, "isRead": False,
+            # `body` nests under `content`, the shape Graph actually returns
+            # and the only one `graph_message_to_item` reads; `bodyPreview`
+            # is a real Graph field too, but not this one, and setting only
+            # it left every synthetic message's stored body silently NULL.
+            "subject": body, "body": {"content": body}, "isRead": False,
         }
         with sqlite3.connect(self.db) as conn:
             normalize.insert_items(
@@ -819,7 +861,7 @@ class TestConfirmingALinkDoesNotStrandAPage(SelectorCase):
         found = self.report()
         person = found["people"][0]
         self.assertEqual(person["messages"], 4)
-        texts = {line["text"] for line in found["interactions"][person["slug"]]}
+        texts = {line["body"] for line in found["interactions"][person["slug"]]}
         self.assertTrue(any(x.startswith("mail") for x in texts), texts)
         self.assertTrue(any(x.startswith("slack") for x in texts), texts)
 
@@ -936,7 +978,11 @@ class TestUpgradingDoesNotSplitAPerson(SelectorCase):
             "receivedDateTime": iso(days_ago),
             "from": {"emailAddress": {"name": name, "address": address}},
             "toRecipients": [{"emailAddress": {"address": "user@example.com"}}],
-            "subject": body, "bodyPreview": body, "isRead": False,
+            # `body` nests under `content`, the shape Graph actually returns
+            # and the only one `graph_message_to_item` reads; `bodyPreview`
+            # is a real Graph field too, but not this one, and setting only
+            # it left every synthetic message's stored body silently NULL.
+            "subject": body, "body": {"content": body}, "isRead": False,
         }
         item = normalize.graph_message_to_item(msg, "user@example.com")
         with sqlite3.connect(self.db) as conn:

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/seed/index.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/seed/index.md
@@ -15,6 +15,8 @@ at a page that does not exist, as a defect to fix.
 
 ## Patterns
 
+## Concepts
+
 ## Goals
 
 ## Attention

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/skills/memory-repair/SKILL.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/skills/memory-repair/SKILL.md
@@ -40,14 +40,22 @@ quickly.
    points at a page that exists. Resolve a mismatch in the direction that
    loses nothing: add the missing entry rather than delete the page, and
    remove an entry only when its target is genuinely gone.
-2. **Links resolve.** Every relative link between pages lands somewhere. A
+2. **Index sections.** `index-section-missing` means a validated page type
+   has no `## Section` to be filed under, so the first page of that type
+   would be reported unindexed with no entry that could clear it. Add the
+   heading in the order `schema.md` fixes, and add nothing else — an empty
+   section is the correct state until a page of that type exists. This is
+   what reaches a memory installed before the type was added: the seed only
+   supplies a fresh install, and bootstrap never overwrites an index the
+   user owns.
+3. **Links resolve.** Every relative link between pages lands somewhere. A
    broken link to a person becomes a stub page with `importance: low`; a
    broken link to anything else is removed and noted. Record which you chose.
-3. **Frontmatter completeness.** Every page carries the keys its type
+4. **Frontmatter completeness.** Every page carries the keys its type
    requires. A missing `updated` is filled from the newest dated content on
    the page, never from today — today would assert a freshness the page has
    not earned.
-4. **Person identity.** Every people page carries a `source_key`, and no two
+5. **Person identity.** Every people page carries a `source_key`, and no two
    carry the same one. **Never derive one from the page.** For
    `missing-identity`, take the value from the memory job's `source_key` for
    that person and write it in; if the selector does not name them, leave the
@@ -60,15 +68,15 @@ quickly.
    the victim in the first. The memory job knows: it reports the pages a
    confirmed link has joined, under `merge_into_slug`. Leave this to that
    job.
-5. **Decay windows.** Any page past its `decay` window is flagged as stale in
+6. **Decay windows.** Any page past its `decay` window is flagged as stale in
    the log. **Do not delete it and do not silently refresh the date.** A page
    marked stale is still useful; a page whose date was quietly bumped is a
    lie.
-6. **Provenance.** Claims on `patterns/` pages carry a footnote or an
+7. **Provenance.** Claims on `patterns/` pages carry a footnote or an
    `(inferred)` marker. A page with neither is flagged. Never invent a
    footnote to satisfy the check — an unsupported claim should be visible, not
    dressed up.
-7. **Section ceilings.** Pages past the limits in the schema's growth-control
+8. **Section ceilings.** Pages past the limits in the schema's growth-control
    table are reported for the consolidation job. Repair does not compact;
    those are different jobs on purpose, because compaction needs judgment and
    repair should be safe enough to run unattended.

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/skills/memory-repair/SKILL.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/skills/memory-repair/SKILL.md
@@ -48,10 +48,14 @@ quickly.
    has no `## Section` to be filed under, so the first page of that type
    would be reported unindexed with no entry that could clear it. Add the
    heading in the position `schema.md` fixes — immediately before whichever
-   required section, already present, comes next in that order — and add
-   nothing else: an empty section is the correct state until a page of that
-   type exists. This is what reaches a memory installed before the type was
-   added: the seed only supplies a fresh install, and bootstrap never
+   required section, already present, comes next in that order. Check
+   whether `index-misfiled` also fired for a page of this type: if it did,
+   that page already has an entry, filed under whatever section existed
+   before this one did — move it into the section you just added rather than
+   leaving the new section empty. Only when no `index-misfiled` finding names
+   this type is an empty section the correct state, and only until a page of
+   that type exists. This is what reaches a memory installed before the type
+   was added: the seed only supplies a fresh install, and bootstrap never
    overwrites an index the user owns.
    `index-out-of-order` means a `## Section` heading exists but not where
    `schema.md` puts it relative to the others. Move the heading — and

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/skills/memory-repair/SKILL.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/skills/memory-repair/SKILL.md
@@ -43,20 +43,20 @@ quickly.
    remove an entry only when its target is genuinely gone; for
    `index-misfiled`, **move** the existing line into its own type's section
    rather than adding a second entry — the page already has one, it is just
-   filed under the wrong heading.
+   filed under the wrong heading. For `index-unparseable`, preserve the index,
+   report the ambiguity, and make no index edits: the checker deliberately
+   withholds derived findings when it cannot prove which content is top-level.
 2. **Index sections.** `index-section-missing` means a validated page type
    has no `## Section` to be filed under, so the first page of that type
    would be reported unindexed with no entry that could clear it. Add the
    heading in the position `schema.md` fixes — immediately before whichever
-   required section, already present, comes next in that order. Check
-   whether `index-misfiled` also fired for a page of this type: if it did,
-   that page already has an entry, filed under whatever section existed
-   before this one did — move it into the section you just added rather than
-   leaving the new section empty. Only when no `index-misfiled` finding names
-   this type is an empty section the correct state, and only until a page of
-   that type exists. This is what reaches a memory installed before the type
-   was added: the seed only supplies a fresh install, and bootstrap never
-   overwrites an index the user owns.
+   required section, already present, comes next in that order. Then reconcile
+   every page of that type in the same pass: move each existing entry named by
+   `index-misfiled`, and add an entry for each page named by `unindexed`. Do
+   not leave the section empty: this finding is emitted only because at least
+   one page of the type already exists. This is what reaches a memory installed
+   before the type was added: the seed only supplies a fresh install, and
+   bootstrap never overwrites an index the user owns.
    `index-out-of-order` means a `## Section` heading exists but not where
    `schema.md` puts it relative to the others. Move the heading — and
    everything filed under it — to its correct position; do not add a second

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/skills/memory-repair/SKILL.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/skills/memory-repair/SKILL.md
@@ -36,18 +36,27 @@ drifts.
 Cheap and mechanical first, so a run that is going to find nothing finds it
 quickly.
 
-1. **Index against filesystem.** Every page has an index entry and every entry
-   points at a page that exists. Resolve a mismatch in the direction that
-   loses nothing: add the missing entry rather than delete the page, and
-   remove an entry only when its target is genuinely gone.
+1. **Index against filesystem.** Every page has an index entry, every entry
+   points at a page that exists, and each entry sits under the `## Section`
+   for its own page type. Resolve a mismatch in the direction that loses
+   nothing: for `unindexed`, add the missing entry; for `index-dangling`,
+   remove an entry only when its target is genuinely gone; for
+   `index-misfiled`, **move** the existing line into its own type's section
+   rather than adding a second entry — the page already has one, it is just
+   filed under the wrong heading.
 2. **Index sections.** `index-section-missing` means a validated page type
    has no `## Section` to be filed under, so the first page of that type
    would be reported unindexed with no entry that could clear it. Add the
-   heading in the order `schema.md` fixes, and add nothing else — an empty
-   section is the correct state until a page of that type exists. This is
-   what reaches a memory installed before the type was added: the seed only
-   supplies a fresh install, and bootstrap never overwrites an index the
-   user owns.
+   heading in the position `schema.md` fixes — immediately before whichever
+   required section, already present, comes next in that order — and add
+   nothing else: an empty section is the correct state until a page of that
+   type exists. This is what reaches a memory installed before the type was
+   added: the seed only supplies a fresh install, and bootstrap never
+   overwrites an index the user owns.
+   `index-out-of-order` means a `## Section` heading exists but not where
+   `schema.md` puts it relative to the others. Move the heading — and
+   everything filed under it — to its correct position; do not add a second
+   heading for the same section.
 3. **Links resolve.** Every relative link between pages lands somewhere. A
    broken link to a person becomes a stub page with `importance: low`; a
    broken link to anything else is removed and noted. Record which you chose.

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/skills/memory-writing/SKILL.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/skills/memory-writing/SKILL.md
@@ -202,7 +202,10 @@ Write a page when:
   `mentioned` — this person writes to the user rather than past them, or
 - They are in the user's reporting chain, where the memory already records
   it, or
-- They are addressed by name and asked for something.
+- One of the interactions you were given names the user and asks the user
+  for something, in that message's own `subject` or `body` — not in anything
+  you infer about whether the user answered — and that interaction's
+  `addressing` is `direct` or `mentioned`.
 
 Do **not** write a page for:
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/skills/memory-writing/SKILL.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/skills/memory-writing/SKILL.md
@@ -202,10 +202,12 @@ Write a page when:
   `mentioned` — this person writes to the user rather than past them, or
 - They are in the user's reporting chain, where the memory already records
   it, or
-- One of the interactions you were given names the user and asks the user
-  for something, in that message's own `subject` or `body` — not in anything
-  you infer about whether the user answered — and that interaction's
-  `addressing` is `direct` or `mentioned`.
+- One of the interactions you were given has `addressing` at `direct` or
+  `mentioned`, and that message's own `subject` or `body` — not anything you
+  infer about whether the user answered — asks for something. Judge only
+  whether the message itself contains a request; the selector gives you no
+  name or address for the user to compare the text against, so do not judge
+  whether the message names the user.
 
 Do **not** write a page for:
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/skills/memory-writing/SKILL.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/profile/skills/memory-writing/SKILL.md
@@ -172,18 +172,48 @@ titled pages and needs a sentence telling them which colleague this is. Their
 messages are already separated for you; `interactions` is keyed by page slug,
 not by name.
 
+**The store holds inbound messages only.** Neither collector keeps what the
+user sent: the mail connector reads the inbox and nothing else, and the Slack
+one drops every message the user wrote. So you cannot see whether they
+replied, and you must not infer it — an answer you cannot check is worse here
+than an absence you can.
+
+What you are given instead is `addressing` on each interaction. It describes
+how the **user** was treated by that message, not how its sender was: a mail
+naming the user as a To recipient, or a direct message, is `direct`; an
+@-mention in a channel is `mentioned`; being copied, or reading a channel
+post, is `broadcast`. It says the sender aimed the message at the user. It
+says nothing about whether the user answered.
+
+It is also coarser for mail than for Slack. Mail yields `direct` or
+`broadcast` and never `mentioned`, so on the mail side this is a
+To-versus-not test and not much more — a machine that addresses the user by
+name scores the same as a colleague who writes to them. `direct` is a
+necessary condition for a page and not a sufficient one; the exclusions below
+still have to be applied to everything that passes it.
+
+Judge on the interactions you were handed and no more. They are that
+person's most recent and they are capped, so a claim about *all* of
+somebody's messages is one you are not holding the evidence for.
+
 Write a page when:
 
-- The user has exchanged messages with them in both directions, or
-- They are in the user's reporting chain, or
+- At least two of the interactions you were given are `direct` or
+  `mentioned` — this person writes to the user rather than past them, or
+- They are in the user's reporting chain, where the memory already records
+  it, or
 - They are addressed by name and asked for something.
 
 Do **not** write a page for:
 
-- Senders the user never replies to, however frequent.
-- Mailing lists, digests, and broadcast announcements.
-- Anything the selector's evidence shows as one-directional notification
-  traffic, even if it carries a human name.
+- Senders whose interactions here are all `broadcast`, however many there
+  are.
+- Anything automated, whatever its `addressing`. A ticket system, a build,
+  an alert and a calendar notice all reach the user by name and none of them
+  is a working relationship.
+- Mailing lists, digests, and announcements.
+- Anything the selector's evidence shows as notification traffic, even if it
+  carries a human name.
 
 `importance` is about working proximity, not seniority — the schema says so
 and it is easy to get backwards. Somebody whose silence would block the user's
@@ -269,11 +299,9 @@ People pages and the two attention pages. That is the whole scope, and the
 schema's writer table says the same thing so the two cannot drift.
 
 `projects/`, `patterns/` and `concepts/` have no writer at all yet. They are
-not excluded on principle — the production system this recipe is adapted from
-writes project pages from ingested mail, under an admission contract strict
-enough to be worth adopting rather than working around. They are simply not
-in this job, and a page type with no writer is worth naming as such rather
-than leaving a reader to infer it from silence.
+not excluded on principle — they are simply not in this job, and a page type
+with no writer is worth naming as such rather than leaving a reader to infer
+it from silence. Where that work is planned is tracked in issue #156.
 
 `goals/` is different: see below.
 


### PR DESCRIPTION
## Related Issue

Related: #156 — this is Phase A of the A–G plan.

Phases B–G remain design and implementation work tracked in #156.

## Description

This makes the memory contract, checker, repair guidance, and selector evidence agree before later phases rely on them.

- **Scope special files to their documented locations.** Root-only files are exempt only at the memory root, and project sidecars only as direct children of `projects/<slug>/`. Reserved names elsewhere remain normal pages and are checked.
- **Make index validation reflect navigable structure.** The checker validates section order, requires each entry under its page type, detects every duplicate/misfiled occurrence, and ignores fenced or commented examples. The final parser preserves the installed entry spellings allowed by the schema and fails closed on ambiguous Markdown rather than deriving unsafe automatic repairs. Index and ordinary page link validation retain their distinct one-line/prose behavior.
- **Repair installed indexes completely.** When a validated page type has no section, repair creates the heading in schema order, moves every misfiled entry, and adds every unindexed page. It never leaves the new section empty or edits an index the checker cannot parse safely.
- **Use only admission evidence the selector supplies.** People admission now depends on `addressing`, `subject`, and `body`; subject and body remain separate so a generic subject cannot hide a request in the body. The rule no longer asks the agent to infer an unsupplied user identity or outbound history.
- **Replace circular rationale comments.** The affected thresholds and packaging choices now explain their local invariant instead of pointing to an unavailable comparison.

No dependency or third-party-content changes are included.

## Verification

- [x] `python3 scripts/check_license_headers.py --check` — 609 files
- [x] `python3 scripts/check_label_taxonomy.py --check` — 63 labels
- [x] `git diff --check`
- [x] `python3 -m py_compile profile/scripts/memory_check.py`
- [x] Focused memory-check suite — 58 tests
- [x] Full recipe suite — 640 tests across fourteen modules
- [x] `python3 scripts/build_catalog.py --validate-metadata` — 18 examples
- [x] `python3 scripts/build_catalog.py --check` — 18 examples across 7 browse groups
- [x] Repository Python scripts suite — 36 tests
- [x] Catalog Node suite — 12 tests
- [x] Independent final-head review reproduced the reported failures before the fixes and found no remaining merge blocker

## Documentation Writer Review

- [x] Documentation writer review completed for the final changes
- Result: `docs-updated`
- Evidence or justification: `profile/skills/memory-writing/SKILL.md` uses only selector-supplied evidence; `profile/skills/memory-repair/SKILL.md` documents complete and fail-closed index repair; `profile/schema.md` and `profile/seed/index.md` agree on section order; `README.md` reports the final test count.
- Reviewer: self-reviewed by the author; independently checked during maintainer review at final head `eba0f9285cbab03bd92c8768b6f1f0aa87d49f56`
- [x] Changed user-facing text follows the writing guide and controlled-word list.
- [x] A public contributor can understand the changed text without internal company context.
- [x] Agent-assisted text was reviewed before submission.

## Release And Compliance

- [x] No secrets or credentials are included, including API keys, access tokens, passwords, local `.env` files, private certificates, or token caches.
- [x] No nonpublic project names, environment names, hostnames, URLs, ticket identifiers, workspace paths, logs, screenshots, or configuration values are included.
- [x] No third-party dependency or notice change is required.
- [x] Public content uses sanitized examples and placeholders instead of private values.
- [x] I added my DCO sign-off declaration to this pull request description.

Signed-off-by: Xuan Wu <xuwu@nvidia.com>