### PR TITLE
docs(memory-driven-chief-of-staff): clarify Quick Start prerequisites, cron recovery, and dashboard scope

### DIFF
--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -533,9 +533,11 @@ export OPENSHELL_SANDBOX_NAME="my-hermes"
 bash scripts/setup-slack.sh
 ```
 
-The script imports `docs/slack_app_manifest.json`, requests user scopes, checks
-the provider type and read-only policy, configures token rotation, and attaches
-the provider to the named sandbox. The required scopes are:
+The script imports
+[docs/slack_app_manifest.json](docs/slack_app_manifest.json), requests user
+scopes, checks the provider type and read-only policy, configures token
+rotation, and attaches the provider to the named sandbox. The required scopes
+are:
 
 ```yaml
 user_scopes:

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -326,13 +326,21 @@ from lives alongside it, at `$HERMES_HOME/workspace/ledger/state.db`.
 
 > **`cron status` shows the gateway running but no scheduled job?** The jobs
 > were never registered — for example if step 4 stopped at the credential
-> check before reaching its `3/3 Registering scheduled jobs` phase. Register
-> them directly; the script is idempotent, so rerunning it only updates
-> existing jobs in place rather than duplicating them:
+> check before reaching its `3/3 Registering scheduled jobs` phase. Do not
+> run `register-jobs.sh` directly to fix that: it checks only the platform
+> and that the profile exists, not that a credential is set, so it would
+> schedule all seven jobs against a profile that fails authentication on
+> every run. Verify the credential first, then rerun the installer, which
+> registers jobs as its own last step once the credential check passes:
 >
 > ```bash
-> bash scripts/register-jobs.sh
+> hermes -p "$PROFILE_NAME" config get model.api_key
+> bash scripts/install.sh
 > ```
+>
+> Once you know the credential is already set, `bash scripts/register-jobs.sh`
+> on its own is safe to resync job definitions — it is idempotent, so
+> rerunning it updates existing jobs in place rather than duplicating them.
 
 To remove every registered job at once instead of one at a time, see
 [Persistence and reboot behavior](#persistence-and-reboot-behavior).
@@ -344,9 +352,10 @@ hermes gateway stop --profile "$PROFILE_NAME"
 ```
 
 Hermes scopes the stop to the selected profile and checks its recorded runtime
-identity instead of trusting a shell PID file. Stop the gateway before
-[deleting the profile](#persistence-and-reboot-behavior) because removing the
-profile does not stop a process that is already running against it.
+identity instead of trusting a shell PID file. Deleting the profile already
+stops this gateway and its related backends as part of deletion — an
+explicit stop first is not required, but it is harmless and can make
+[teardown](#persistence-and-reboot-behavior) easier to verify.
 
 > **Running this outside a NemoClaw sandbox, on a host with systemd?** Any
 > environment without a running systemd — WSL included — still needs the
@@ -399,47 +408,39 @@ already reachable, with no forwarding step of your own:
 nemohermes my-hermes dashboard-url --quiet
 ```
 
-That dashboard is launched isolated, under its own dedicated `dashboard-home`
-profile, but the isolation is narrower than it sounds: it only walls off the
-pages that follow the profile switcher — **Config, API Keys, Skills, MCP, and
-starting a brand-new chat**. None of those will unify with this recipe's
-profile, with or without a `?profile=` query parameter.
+That dashboard is a **machine-level** surface: a profile switcher lets it
+manage any profile on the sandbox, including this recipe's
+`memory-driven-chief-of-staff`. `--isolated` (used when NemoClaw launches
+this dashboard) changes only how the `hermes dashboard` command routes on
+launch — whether it reuses an already-running shared server or starts its
+own — not what a running dashboard's pages can reach. Selecting this
+recipe's profile, through the switcher or a
+`?profile=memory-driven-chief-of-staff` URL, routes **Config, API Keys,
+Skills, MCP, Models, and Chat** to it — including starting a brand-new chat
+session as it, from the browser. **Sessions** is likewise scoped to whichever
+profile is currently selected, rather than showing every profile at once.
 
-It does **not** wall off three other pages, which are sandbox-wide by design
-and not gated by the switcher or by `--isolated`:
+**Cron** and **Profiles** are the two pages that are not scoped by the
+switcher:
 
-- **Sessions** — every session on the sandbox, across every profile,
-  including `memory-driven-chief-of-staff`'s and its cron-triggered runs.
-  Full-text search covers complete message content; expanding a session
-  loads its full history; **Resume** reopens it as a live chat against
-  *that session's own profile* (not `dashboard-home`); **Export** downloads
-  it as JSON; **Delete**/**Prune** remove it.
-- **Cron** — every registered job across every profile, with its full prompt
-  text, schedule, delivery target, and Pause/Resume/Edit/Trigger-now/Delete.
-- **Profiles** — a management card for every profile, including this one
+- **Cron** defaults to showing every registered job across every profile,
+  with its full prompt text, schedule, delivery target, and
+  Pause/Resume/Edit/Trigger-now/Delete.
+- **Profiles** always lists every profile globally as a management card
   (model, skill count, gateway state, description), with **Rename** and
   **Delete** — deleting from here removes the workspace, store, and memory
   the same as `hermes profile delete` does. See
   [Persistence and reboot behavior](#persistence-and-reboot-behavior).
 
-So the `dashboard-url` forward already gives read — and destructive — access
-to this recipe's session history and cron jobs, whether or not anything else
-in this step is ever run. Hermes uses session auth for this dashboard, so the
-printed URL is a plain link, not a credential, but treat it as sensitive
-regardless: protect access to it through the sandbox's normal session
-controls, and do not expose it publicly.
+So this one forwarded URL already gives you full access to this recipe's
+profile once you select it — chat, config, sessions, plus the always-visible
+cron jobs and destructive profile management — with no extra step. Hermes
+uses session auth for this dashboard, so the printed URL is a plain link, not
+a credential, but treat it as sensitive regardless: protect access to it
+through the sandbox's normal session controls, and do not expose it publicly.
 
-If you don't have that URL handy, or want to confirm the forward is still
-alive, query it directly from your machine instead of rerunning
-`dashboard-url`:
-
-```bash
-openshell forward list
-```
-
-This lists every active port forward for the sandbox, including the
-dashboard's — read the port from there and open `http://127.0.0.1:<port>`
-in a browser.
+If you don't have that URL handy, it is safe to rerun the command above at
+any time.
 
 Prefer the terminal to the browser? This is the verified way to talk to this
 recipe directly, from inside the sandbox — no dashboard, no forwarding,
@@ -845,10 +846,11 @@ for job in data.get("jobs", []):
 done
 ```
 
-Deleting the profile also deletes its workspace, store, and memory — but not
-a gateway process already running against it. If you started one by hand
-(step 5 of Quick Start), stop it with the profile-scoped lifecycle command,
-then delete the profile:
+Deleting the profile also deletes its workspace, store, and memory. Hermes
+already stops the profile's gateway and related backends as part of
+deletion, so a separate stop is not required — but if you started one by
+hand (step 5 of Quick Start), stopping it explicitly first is harmless and
+makes teardown easier to verify:
 
 ```bash
 hermes gateway stop --profile memory-driven-chief-of-staff

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -74,9 +74,9 @@ recipe complements Hermes memory and optional external memory providers.
 - [Memory That Tracks Work, Not Just Preferences](#memory-that-tracks-work-not-just-preferences)
 - [How It Works](#how-it-works)
 - [Quick Start](#quick-start)
+- [Connect Messaging Providers](#connect-messaging-providers)
 - [Offline Walkthrough (No Deployment)](#offline-walkthrough-no-deployment)
 - [Configuration](#configuration)
-- [Connect Messaging Providers](#connect-messaging-providers)
 - [Scheduled Operation](#scheduled-operation)
 - [Data Lifecycle and Privacy](#data-lifecycle-and-privacy)
 - [Troubleshooting and FAQ](#troubleshooting-and-faq)
@@ -138,9 +138,11 @@ code used by scheduled runs.
 
 ## Quick Start
 
-This is the path that ends with a running, scheduled assistant. It assumes an
-existing NemoClaw-managed Hermes sandbox; it does not cover NemoClaw
-onboarding itself.
+This is the path that ends with a running, scheduled assistant. Steps 1
+through 5 are what you run, in order, to get there. Step 6 is optional —
+connect a real Slack or Outlook source instead of leaving the store empty.
+Step 7 runs nothing new; it explains how to look at what steps 1-5 already
+started.
 
 The scheduled jobs run inside a Linux NemoHermes sandbox. Your own computer is
 outside that sandbox and can use any platform supported by NemoHermes.
@@ -154,6 +156,14 @@ This guide uses two command locations:
 | NemoHermes sandbox | The isolated Linux environment where Hermes and the scheduled jobs run | `hermes` |
 <!-- markdownlint-enable MD013 -->
 
+A plain "gateway" in this guide always means Hermes's own `hermes gateway`
+process — the agent-serving process for a profile, started explicitly in
+step 5. That is a different system from the **OpenShell gateway**, the
+daemon that manages this sandbox's provider credentials and refresh-token
+rotation (see [docs/set-up-graph.md](docs/set-up-graph.md) and
+[docs/set-up-slack.md](docs/set-up-slack.md)); this guide always spells that
+one out by name.
+
 The sandbox satisfies the recipe's Linux runtime requirement. The current
 provider setup helpers still require Linux or WSL on your machine; this is a
 helper-script limitation, not a recipe runtime requirement.
@@ -161,11 +171,27 @@ helper-script limitation, not a recipe runtime requirement.
 `scripts/install.sh` always runs inside the sandbox. Your machine is not
 expected to have `hermes` on `PATH`.
 
-### 1. Confirm and inspect a Hermes sandbox from your machine
+### 1. Install prerequisites
 
-If NemoClaw is not installed, follow the upstream
-[NemoClaw setup guide](https://github.com/NVIDIA/NemoClaw) and select Hermes,
-an inference provider, and a model during onboarding.
+This recipe assumes an existing NemoClaw-managed Hermes sandbox; it does not
+cover NemoClaw onboarding itself. If NemoClaw is not installed, follow the
+upstream [NemoClaw setup guide](https://github.com/NVIDIA/NemoClaw) and select
+Hermes, an inference provider, and a model during onboarding. That installer
+also installs `openshell` as part of its own setup — Quick Start uses both
+`nemohermes` and `openshell` on your machine below, and neither needs a
+separate install.
+
+Then, on your machine (not inside the sandbox), clone this repository and
+enter it:
+
+```bash
+git clone https://github.com/NVIDIA/nemoclaw-community.git
+cd nemoclaw-community
+```
+
+The remaining Quick Start steps run from this checkout.
+
+### 2. Confirm and inspect a Hermes sandbox from your machine
 
 ```bash
 nemohermes my-hermes status
@@ -187,9 +213,9 @@ identify which attached provider supplied it. Use a dedicated sandbox or
 detach the conflicting provider before installing or starting the scheduled
 runtime.
 
-### 2. Upload the recipe from your machine
+### 3. Upload the recipe from your machine
 
-Run this from the cloned `nemoclaw-community` repository root.
+Run this from the `nemoclaw-community` checkout from step 1.
 
 ```bash
 nemohermes sandbox upload my-hermes \
@@ -202,7 +228,7 @@ The upload is required: the sandbox cannot see the checkout on your machine.
 After `connect` opens a shell, the remaining commands in this subsection run
 **inside the sandbox**.
 
-### 3. Install the profile and jobs inside the sandbox
+### 4. Install the profile and jobs inside the sandbox
 
 ```bash
 cd /sandbox/memory-driven-chief-of-staff
@@ -238,7 +264,7 @@ inference key into the recipe profile on the supported NemoClaw path.
 > ALLOW_NO_API_KEY=1 bash scripts/install.sh
 > ```
 
-### 4. Start and verify the scheduled runtime inside the sandbox
+### 5. Start and verify the scheduled runtime inside the sandbox
 
 NemoClaw's own supervisor launches and continuously respawns `hermes gateway
 run` for the sandbox's default profile automatically, logging to
@@ -270,9 +296,46 @@ disown
 hermes -p "$PROFILE_NAME" cron status
 ```
 
+Piece by piece: `umask 077` makes the log file the next line creates
+owner-only (`0600`), matching NemoClaw's own gateway log. `nohup … &`
+backgrounds the process and makes it immune to hangup, so it keeps running
+after you disconnect from the sandbox shell. The redirect targets
+`/tmp/mdcos-gateway.log` — named differently from NemoClaw's own
+`/tmp/gateway.log` specifically so the two logs don't collide, since NemoClaw
+already writes its managed profile's gateway output there. `disown` then
+drops the job from the shell's job table too, on top of what `nohup` already
+protects against. The final `cron status` re-runs the same check from above,
+now that the gateway should actually be up.
+
 `cron status` should now report the gateway running and the next scheduled
 job. If it still reports not running, check `/tmp/mdcos-gateway.log` for a
 startup error.
+
+The seven registered jobs drive distinct Hermes skills — intake runs
+`inbound-judging`, review runs `obligation-review`, and there are separate
+`memory-writing`, `memory-repair`, `memory-consolidation`, and
+`preference-update` skills; retention runs no skill at all. See
+[Scheduled Operation](#scheduled-operation) for the full schedule and
+job-to-skill table.
+
+The work wiki those skills write lives inside the sandbox at
+`$HERMES_HOME/workspace/memory/` — concretely
+`/sandbox/.hermes/profiles/$PROFILE_NAME/workspace/memory/` for this recipe's
+default profile name. The obligation ledger the intake and review jobs work
+from lives alongside it, at `$HERMES_HOME/workspace/ledger/state.db`.
+
+> **`cron status` shows the gateway running but no scheduled job?** The jobs
+> were never registered — for example if step 4 stopped at the credential
+> check before reaching its `3/3 Registering scheduled jobs` phase. Register
+> them directly; the script is idempotent, so rerunning it only updates
+> existing jobs in place rather than duplicating them:
+>
+> ```bash
+> bash scripts/register-jobs.sh
+> ```
+
+To remove every registered job at once instead of one at a time, see
+[Persistence and reboot behavior](#persistence-and-reboot-behavior).
 
 To stop it later, use Hermes's profile-scoped lifecycle command:
 
@@ -301,9 +364,9 @@ At this point the schedule works over any rows already in the store. Slack and
 Outlook are independent and optional; each unconfigured collector exits
 successfully and reports that state.
 
-### 5. Connect a messaging provider
+### 6. Connect a messaging provider (optional)
 
-Step 4 leaves you inside the sandbox shell. Exit it (or open a separate
+Step 5 leaves you inside the sandbox shell. Exit it (or open a separate
 terminal on your machine) before continuing — `openshell` and `nemohermes`
 are host-side commands and are not available inside the sandbox.
 
@@ -323,36 +386,68 @@ independent; connect one, both, or skip this step and use the
 [offline fixtures](#offline-walkthrough-no-deployment) instead to see the
 recipe's behavior without connecting anything.
 
-### 6. A note on the web dashboard
+### 7. A note on the web dashboard (reference — nothing to run)
 
-`nemohermes my-hermes dashboard-url --quiet` (from your machine, not inside
-the sandbox) prints a URL for the Hermes dashboard NemoClaw forwards for the
-sandbox by default. That dashboard is launched isolated, under its own
-dedicated profile home, specifically so it does **not** unify with other
-profiles on the sandbox — it will not show this recipe's chat, memory, or
-store, regardless of any `?profile=` query parameter appended to it. Hermes
-uses session auth for this dashboard, so the printed URL is a plain link, not
-a credential. Protect access to the forwarded endpoint through the sandbox's
-normal session controls, and do not expose it publicly.
+Nothing in this step is required to finish Quick Start; it explains what is
+already reachable from steps above and how to look at it.
 
-The verified way to talk to this recipe is the terminal, from inside the
-sandbox:
+From your machine, not inside the sandbox, this prints the URL for the
+Hermes dashboard NemoClaw already forwards for the sandbox by default —
+already reachable, with no forwarding step of your own:
+
+```bash
+nemohermes my-hermes dashboard-url --quiet
+```
+
+That dashboard is launched isolated, under its own dedicated `dashboard-home`
+profile, but the isolation is narrower than it sounds: it only walls off the
+pages that follow the profile switcher — **Config, API Keys, Skills, MCP, and
+starting a brand-new chat**. None of those will unify with this recipe's
+profile, with or without a `?profile=` query parameter.
+
+It does **not** wall off three other pages, which are sandbox-wide by design
+and not gated by the switcher or by `--isolated`:
+
+- **Sessions** — every session on the sandbox, across every profile,
+  including `memory-driven-chief-of-staff`'s and its cron-triggered runs.
+  Full-text search covers complete message content; expanding a session
+  loads its full history; **Resume** reopens it as a live chat against
+  *that session's own profile* (not `dashboard-home`); **Export** downloads
+  it as JSON; **Delete**/**Prune** remove it.
+- **Cron** — every registered job across every profile, with its full prompt
+  text, schedule, delivery target, and Pause/Resume/Edit/Trigger-now/Delete.
+- **Profiles** — a management card for every profile, including this one
+  (model, skill count, gateway state, description), with **Rename** and
+  **Delete** — deleting from here removes the workspace, store, and memory
+  the same as `hermes profile delete` does. See
+  [Persistence and reboot behavior](#persistence-and-reboot-behavior).
+
+So the `dashboard-url` forward already gives read — and destructive — access
+to this recipe's session history and cron jobs, whether or not anything else
+in this step is ever run. Hermes uses session auth for this dashboard, so the
+printed URL is a plain link, not a credential, but treat it as sensitive
+regardless: protect access to it through the sandbox's normal session
+controls, and do not expose it publicly.
+
+If you don't have that URL handy, or want to confirm the forward is still
+alive, query it directly from your machine instead of rerunning
+`dashboard-url`:
+
+```bash
+openshell forward list
+```
+
+This lists every active port forward for the sandbox, including the
+dashboard's — read the port from there and open `http://127.0.0.1:<port>`
+in a browser.
+
+Prefer the terminal to the browser? This is the verified way to talk to this
+recipe directly, from inside the sandbox — no dashboard, no forwarding,
+nothing above needed:
 
 ```bash
 hermes -p memory-driven-chief-of-staff chat
 ```
-
-For a dedicated web view scoped to this one profile instead, run this inside
-the sandbox:
-
-```bash
-hermes -p "$PROFILE_NAME" dashboard --isolated
-```
-
-This starts a server dedicated to this profile rather than routing to the
-shared machine-level one above. It is not forwarded out of the sandbox by
-default; see Hermes's own dashboard documentation for its port and access
-options before exposing it.
 
 ### Things to try
 
@@ -382,6 +477,182 @@ Ask it to ground a claim in evidence rather than answer from general recall:
 And after you correct something (`priority ... low` or `ignore ...` via
 `profile/scripts/correct.py`), ask again without re-explaining the
 correction — it should already be reflected.
+
+## Connect Messaging Providers
+
+Slack and Microsoft Outlook are independent, optional inputs. Configure either
+one or both after installing the recipe and setting any intake exclusions.
+Each setup script requires encrypted sandbox storage and attaches a read-only
+OpenShell provider to the NemoHermes sandbox.
+
+Both setup scripts require `SANDBOX_STORAGE_PATH`: the **host-side** path
+where this sandbox's storage actually lives, not a path inside the sandbox
+and not `$HOME`. Once a connector is attached, real message subjects,
+senders, and bodies land in the store, and that requires the underlying
+volume to be encrypted — a check `require-encrypted-storage.sh` cannot make
+from inside the sandbox, since `HERMES_HOME` there is an overlay filesystem
+with no block device behind it. There is no default: where the sandbox's
+storage actually lives depends on the driver. For the Docker driver, discover
+it with `docker info --format '{{.DockerRootDir}}'` (commonly
+`/var/lib/docker` on a stock install, but not guaranteed — always verify
+rather than assume). See [docs/encrypted-storage.md](docs/encrypted-storage.md)
+for the VM and Kubernetes drivers and how to verify the volume is encrypted.
+
+### Profile configuration
+
+The installer has already created the target profile from
+`profile/distribution.yaml`. Its model block should have this shape:
+
+```yaml
+model:
+  default: "<provider/model>"
+  provider: "<provider>"
+  base_url: "<https-endpoint>"
+  api_key: sk-OPENSHELL-PROXY-REWRITE
+```
+
+The `api_key` value is the non-secret routing marker configured during
+installation. OpenShell replaces it at egress; it is not a credential to rotate
+or hide.
+
+Provider setup now continues on **your machine, outside the sandbox**. The
+current setup helpers require a Linux shell; use WSL on Windows.
+
+### Slack
+
+Slack setup is optional. Complete it only after placing the sandbox storage on
+an encrypted volume; owner-only permissions are access control, not encryption.
+See [docs/encrypted-storage.md](docs/encrypted-storage.md) first.
+
+Run the setup script from the recipe checkout on **your machine**, not inside
+the sandbox. Your machine has `openshell`; the sandbox has `hermes`.
+
+```bash
+export SANDBOX_STORAGE_PATH="<path-containing-sandbox-storage>"
+export OPENSHELL_SANDBOX_NAME="my-hermes"
+bash scripts/setup-slack.sh
+```
+
+The script imports `docs/slack_app_manifest.json`, requests user scopes, checks
+the provider type and read-only policy, configures token rotation, and attaches
+the provider to the named sandbox. The required scopes are:
+
+```yaml
+user_scopes:
+  - im:read
+  - im:history
+  - mpim:read
+  - mpim:history
+  - channels:read
+  - channels:history
+  - users:read
+```
+
+Static user tokens, bot tokens, and app tokens are refused. Attachments are not
+downloaded. Full setup and workspace-admin recovery steps are in
+[docs/set-up-slack.md](docs/set-up-slack.md).
+
+Verify the live collector from your machine through the supported sandbox exec
+path. Replace both placeholders.
+
+```bash
+nemohermes my-hermes exec \
+  --workdir /sandbox/memory-driven-chief-of-staff \
+  -- env HERMES_HOME=/sandbox/.hermes/profiles/memory-driven-chief-of-staff \
+  python3 profile/scripts/ingest_slack.py --recheck
+```
+
+Collector exit codes are stable diagnostics:
+
+| Exit | Meaning |
+| --- | --- |
+| `0` | Fetch succeeded, or Slack is intentionally unconfigured |
+| `1` | Other collector error |
+| `2` | Missing/wrong credential type or unreachable API |
+| `3` | Slack rate limit |
+| `4` | Required Slack scope missing |
+
+### Microsoft Outlook
+
+Outlook intake uses the Microsoft Graph inbox delta API. Register a Microsoft
+Entra application with public-client flows enabled and delegated `Mail.Read`,
+`User.Read`, and `offline_access` permissions. Do not grant application-level
+mail permissions, which would authorize access beyond the signed-in mailbox.
+
+Run the device-code setup from the recipe checkout on your machine:
+
+```bash
+export SANDBOX_STORAGE_PATH="<path-containing-sandbox-storage>"
+export OPENSHELL_SANDBOX_NAME="my-hermes"
+export GRAPH_CLIENT_ID="<entra-application-client-id>"
+export GRAPH_TENANT_ID="<entra-directory-tenant-id>"
+bash scripts/setup-graph.sh
+```
+
+If the script reports that another attached provider already exposes
+`MS_GRAPH_ACCESS_TOKEN`, treat that as a hard stop. Detach the conflicting
+provider or use a dedicated sandbox, then rerun setup. Do not run the Graph
+collector while the credential source is ambiguous.
+
+On the supported path, the OpenShell gateway stores and refreshes the
+delegated credential, and the sandbox receives only an OpenShell placeholder. Confirm
+that the attached provider has type `memory-driven-cos-graph-user` and that its
+exported profile declares `access: read-only` with `enforcement: enforce` before
+running the collector. The initial synchronization covers seven days by default
+and resumes across intake ticks when more pages remain. Configure a different
+`GRAPH_BACKFILL_DAYS` in the profile environment file before the first
+synchronization. See [docs/set-up-graph.md](docs/set-up-graph.md) for the
+application registration, provider inspection, backfill, revocation, and
+recovery steps.
+
+### Link identities across providers
+
+Slack identifies a person by user ID, while email uses an address. The recipe
+never assumes that matching display names belong to the same person. The memory
+job reports likely matches as `identity_candidates`; only the user can confirm
+or reject them.
+
+Run the identity command from your machine through sandbox exec:
+
+```bash
+nemohermes my-hermes exec \
+  --workdir /sandbox/memory-driven-chief-of-staff \
+  -- env HERMES_HOME=/sandbox/.hermes/profiles/memory-driven-chief-of-staff \
+  python3 profile/scripts/link_identity.py same \
+    slack:U01DANA email:dana@example.com
+```
+
+Use `different` instead of `same` to reject a match. Confirmed relationships
+compose across providers. Rejected candidates are not proposed again. If saved
+answers conflict, the recipe reports `identity_conflicts` and changes nothing.
+Existing page names remain stable after identities are linked so that index
+entries and source-backed links do not move.
+
+### Collector failures
+
+When a collector fails, the intake batch records only its name, exit code, and
+error class. It does not place collector output in the model prompt or the
+scheduler log because that output can contain message text or authentication
+material. Run the collector directly to inspect its full error.
+
+Verify the collector from your machine:
+
+```bash
+nemohermes my-hermes exec \
+  --workdir /sandbox/memory-driven-chief-of-staff \
+  -- env HERMES_HOME=/sandbox/.hermes/profiles/memory-driven-chief-of-staff \
+  python3 profile/scripts/ingest_graph.py --recheck
+```
+
+Outlook collector exit codes are:
+
+| Exit | Meaning |
+| --- | --- |
+| `0` | Fetch succeeded, can resume, or Outlook is unconfigured |
+| `1` | Other collector error |
+| `2` | Missing, invalid, or refused credential |
+| `3` | Microsoft Graph rate limit |
+| `4` | Token is not a delegated mailbox token with the required scopes |
 
 ## Offline Walkthrough (No Deployment)
 
@@ -508,169 +779,6 @@ are not supported. Invalid or unknown fields fail closed.
 }
 ```
 
-## Connect Messaging Providers
-
-Slack and Microsoft Outlook are independent, optional inputs. Configure either
-one or both after installing the recipe and setting any intake exclusions.
-Each setup script requires encrypted sandbox storage and attaches a read-only
-OpenShell provider to the NemoHermes sandbox.
-
-### Profile configuration
-
-The installer has already created the target profile from
-`profile/distribution.yaml`. Its model block should have this shape:
-
-```yaml
-model:
-  default: "<provider/model>"
-  provider: "<provider>"
-  base_url: "<https-endpoint>"
-  api_key: sk-OPENSHELL-PROXY-REWRITE
-```
-
-The `api_key` value is the non-secret routing marker configured during
-installation. OpenShell replaces it at egress; it is not a credential to rotate
-or hide.
-
-Provider setup now continues on **your machine, outside the sandbox**. The
-current setup helpers require a Linux shell; use WSL on Windows.
-
-### Slack
-
-Slack setup is optional. Complete it only after placing the sandbox storage on
-an encrypted volume; owner-only permissions are access control, not encryption.
-See [docs/encrypted-storage.md](docs/encrypted-storage.md) first.
-
-Run the setup script from the recipe checkout on **your machine**, not inside
-the sandbox. Your machine has `openshell`; the sandbox has `hermes`.
-
-```bash
-export SANDBOX_STORAGE_PATH="<path-containing-sandbox-storage>"
-export OPENSHELL_SANDBOX_NAME="my-hermes"
-bash scripts/setup-slack.sh
-```
-
-The script imports `docs/slack_app_manifest.json`, requests user scopes, checks
-the provider type and read-only policy, configures token rotation, and attaches
-the provider to the named sandbox. The required scopes are:
-
-```yaml
-user_scopes:
-  - im:read
-  - im:history
-  - mpim:read
-  - mpim:history
-  - channels:read
-  - channels:history
-  - users:read
-```
-
-Static user tokens, bot tokens, and app tokens are refused. Attachments are not
-downloaded. Full setup and workspace-admin recovery steps are in
-[docs/set-up-slack.md](docs/set-up-slack.md).
-
-Verify the live collector from your machine through the supported sandbox exec
-path. Replace both placeholders.
-
-```bash
-nemohermes my-hermes exec \
-  --workdir /sandbox/memory-driven-chief-of-staff \
-  -- env HERMES_HOME=/sandbox/.hermes/profiles/memory-driven-chief-of-staff \
-  python3 profile/scripts/ingest_slack.py --recheck
-```
-
-Collector exit codes are stable diagnostics:
-
-| Exit | Meaning |
-| --- | --- |
-| `0` | Fetch succeeded, or Slack is intentionally unconfigured |
-| `1` | Other collector error |
-| `2` | Missing/wrong credential type or unreachable API |
-| `3` | Slack rate limit |
-| `4` | Required Slack scope missing |
-
-### Microsoft Outlook
-
-Outlook intake uses the Microsoft Graph inbox delta API. Register a Microsoft
-Entra application with public-client flows enabled and delegated `Mail.Read`,
-`User.Read`, and `offline_access` permissions. Do not grant application-level
-mail permissions, which would authorize access beyond the signed-in mailbox.
-
-Run the device-code setup from the recipe checkout on your machine:
-
-```bash
-export SANDBOX_STORAGE_PATH="<path-containing-sandbox-storage>"
-export OPENSHELL_SANDBOX_NAME="my-hermes"
-export GRAPH_CLIENT_ID="<entra-application-client-id>"
-export GRAPH_TENANT_ID="<entra-directory-tenant-id>"
-bash scripts/setup-graph.sh
-```
-
-If the script reports that another attached provider already exposes
-`MS_GRAPH_ACCESS_TOKEN`, treat that as a hard stop. Detach the conflicting
-provider or use a dedicated sandbox, then rerun setup. Do not run the Graph
-collector while the credential source is ambiguous.
-
-On the supported path, the gateway stores and refreshes the delegated
-credential, and the sandbox receives only an OpenShell placeholder. Confirm
-that the attached provider has type `memory-driven-cos-graph-user` and that its
-exported profile declares `access: read-only` with `enforcement: enforce` before
-running the collector. The initial synchronization covers seven days by default
-and resumes across intake ticks when more pages remain. Configure a different
-`GRAPH_BACKFILL_DAYS` in the profile environment file before the first
-synchronization. See [docs/set-up-graph.md](docs/set-up-graph.md) for the
-application registration, provider inspection, backfill, revocation, and
-recovery steps.
-
-### Link identities across providers
-
-Slack identifies a person by user ID, while email uses an address. The recipe
-never assumes that matching display names belong to the same person. The memory
-job reports likely matches as `identity_candidates`; only the user can confirm
-or reject them.
-
-Run the identity command from your machine through sandbox exec:
-
-```bash
-nemohermes my-hermes exec \
-  --workdir /sandbox/memory-driven-chief-of-staff \
-  -- env HERMES_HOME=/sandbox/.hermes/profiles/memory-driven-chief-of-staff \
-  python3 profile/scripts/link_identity.py same \
-    slack:U01DANA email:dana@example.com
-```
-
-Use `different` instead of `same` to reject a match. Confirmed relationships
-compose across providers. Rejected candidates are not proposed again. If saved
-answers conflict, the recipe reports `identity_conflicts` and changes nothing.
-Existing page names remain stable after identities are linked so that index
-entries and source-backed links do not move.
-
-### Collector failures
-
-When a collector fails, the intake batch records only its name, exit code, and
-error class. It does not place collector output in the model prompt or the
-scheduler log because that output can contain message text or authentication
-material. Run the collector directly to inspect its full error.
-
-Verify the collector from your machine:
-
-```bash
-nemohermes my-hermes exec \
-  --workdir /sandbox/memory-driven-chief-of-staff \
-  -- env HERMES_HOME=/sandbox/.hermes/profiles/memory-driven-chief-of-staff \
-  python3 profile/scripts/ingest_graph.py --recheck
-```
-
-Outlook collector exit codes are:
-
-| Exit | Meaning |
-| --- | --- |
-| `0` | Fetch succeeded, can resume, or Outlook is unconfigured |
-| `1` | Other collector error |
-| `2` | Missing, invalid, or refused credential |
-| `3` | Microsoft Graph rate limit |
-| `4` | Token is not a delegated mailbox token with the required scopes |
-
 ## Scheduled Operation
 
 `scripts/register-jobs.sh` is idempotent: it edits jobs with matching names
@@ -715,9 +823,29 @@ JOB_ID="<copy-an-id-from-the-list>"
 hermes -p memory-driven-chief-of-staff cron remove "$JOB_ID"
 ```
 
+There is no single `cron` subcommand that removes every job at once — `cron
+list` prints a table for a person, not machine-readable output. To remove all
+of them, read each job's id from the profile's own job store instead, the same
+file `register-jobs.sh` itself reads to stay idempotent, and remove them in a
+loop:
+
+```bash
+PROFILE_HOME="$(hermes profile show memory-driven-chief-of-staff \
+  | sed -n 's/^Path:[[:space:]]*//p')"
+python3 -c '
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as handle:
+    data = json.load(handle)
+for job in data.get("jobs", []):
+    print(job["id"])
+' "$PROFILE_HOME/cron/jobs.json" | while read -r JOB_ID; do
+  hermes -p memory-driven-chief-of-staff cron remove "$JOB_ID"
+done
+```
+
 Deleting the profile also deletes its workspace, store, and memory — but not
 a gateway process already running against it. If you started one by hand
-(step 4 of Quick Start), stop it with the profile-scoped lifecycle command,
+(step 5 of Quick Start), stop it with the profile-scoped lifecycle command,
 then delete the profile:
 
 ```bash

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/docs/set-up-slack.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/docs/set-up-slack.md
@@ -89,9 +89,16 @@ refuses can cost you the whole install rather than that one scope.
 
 ## 2. Hand it to the gateway
 
-**On the host**, from the recipe root:
+**On the host**, from the recipe root. `SANDBOX_STORAGE_PATH` is required
+every time this script runs — including a `FORCE_REAUTH=1` re-run below —
+because the storage-encryption check in [step 0](#0-encrypted-storage) is
+step 1 of the script itself, before anything else. `OPENSHELL_SANDBOX_NAME`
+defaults to `hermes` if omitted; set it explicitly when your sandbox uses
+another name:
 
 ```bash
+export SANDBOX_STORAGE_PATH="<path-containing-sandbox-storage>"
+export OPENSHELL_SANDBOX_NAME="my-hermes"
 bash scripts/setup-slack.sh
 ```
 
@@ -127,9 +134,12 @@ provider, configures rotation, and attaches it to your sandbox. Attaching works
 on a sandbox that already exists; it does not have to be rebuilt.
 
 To replace the credential later — after regenerating the app's tokens, or if
-the refresh chain broke:
+the refresh chain broke — `SANDBOX_STORAGE_PATH` is still required, for the
+same reason as above:
 
 ```bash
+export SANDBOX_STORAGE_PATH="<path-containing-sandbox-storage>"
+export OPENSHELL_SANDBOX_NAME="my-hermes"
 FORCE_REAUTH=1 bash scripts/setup-slack.sh
 ```
 


### PR DESCRIPTION
## Related Issue

N/A — no linked issue.

## Description

Quick Start's upload step told readers to run it "from the cloned `nemoclaw-community` repository root," but nothing before it told them to clone the repository. This adds an explicit "Install prerequisites" step (git clone plus a pointer to NemoClaw/Hermes onboarding) before the former step 1, renumbering the remaining steps 2-7 and their in-doc cross-references.

Other fixes made while working through the same walkthrough end to end:

- **Cron registration and removal.** Step 5's recovery path is now clearly conditional. If `install.sh` stopped at model or credential validation, readers are told to correct the profile and rerun the installer so its checks pass before jobs are registered; `register-jobs.sh` is only presented as an idempotent resync path after a successful install. "Persistence and reboot behavior" also gains a bulk-removal snippet because `hermes cron` has no remove-all subcommand.
- **Dashboard scope correction.** NemoClaw's default forwarded Hermes dashboard is a machine-level management surface even though NemoClaw launches it with `--isolated`: on the pinned Hermes 0.19 release, that flag changes dashboard launch routing only, not what a running dashboard can reach. The profile switcher, or an explicit `?profile=memory-driven-chief-of-staff` URL, routes Config, API Keys, Skills, MCP, Models, Chat, and Sessions to the selected recipe profile. Sessions shows and searches the selected profile rather than aggregating every profile at once. Cron uses its own profile selector and defaults to all profiles; Profiles is global. The note now describes the resulting read and destructive access accurately.
- **Dashboard URL flow.** The unnecessary per-profile `hermes dashboard --isolated` plus manual OpenShell forwarding walkthrough is removed. Readers use the existing sandbox-scoped `nemohermes my-hermes dashboard-url --quiet` command, which returns Hermes's plain session-auth dashboard URL. The stale `openshell forward list` fallback is removed because that command lists forwards across all sandboxes rather than identifying only this sandbox's dashboard.
- **Profile deletion behavior.** The teardown guidance now reflects pinned Hermes 0.19 behavior: deleting a profile stops its gateway and related backends before removing the profile. An explicit profile-scoped gateway stop is optional and harmless, not required to avoid an orphaned process.
- **Gateway terminology.** "The gateway" meant Hermes's own `hermes gateway` process everywhere in Quick Start except one sentence in the Outlook setup section, which meant the OpenShell gateway instead. The guide now disambiguates the two up front and spells out "OpenShell gateway" where that is what it means.
- Documented where the work wiki and obligation ledger live by default inside the sandbox, and the cron-job-to-skill mapping, both previously unstated in Quick Start.
- Documented what `SANDBOX_STORAGE_PATH` actually names (the host-side volume behind the sandbox's storage) and why it has no default.
- Moved "Connect Messaging Providers" ahead of the offline walkthrough so it follows the Quick Start step that links to it, instead of trailing behind Configuration.
- Marked optional and reference-only Quick Start steps explicitly: step 6 is optional, and step 7 runs nothing required.
- Added `SANDBOX_STORAGE_PATH` to both `setup-slack.sh` examples in `docs/set-up-slack.md` (first run and `FORCE_REAUTH=1`). The script's storage-encryption check runs unconditionally as step 1, before either path, so both examples require the variable. The examples also name the target through `OPENSHELL_SANDBOX_NAME`.
- Linked `docs/slack_app_manifest.json` from the README's Slack setup section instead of leaving it as plain inline code.

Files changed: `examples/recipes/nvidia/memory-driven-chief-of-staff/README.md` and `examples/recipes/nvidia/memory-driven-chief-of-staff/docs/set-up-slack.md`.

## Verification

- [x] `python3 scripts/check_license_headers.py --check`
- [ ] `python3 scripts/check_label_taxonomy.py --check` when governance metadata changes — not applicable; no governance metadata changed
- [x] `git diff --check`
- [x] Relevant example setup or syntax checks — `markdownlint-cli2` on both changed files; the only remaining findings are pre-existing line-length errors untouched by this change (two in the unrelated Catalog Metadata table in `README.md`, and four already present in `docs/set-up-slack.md`)
- [x] Final-head automated checks: DCO, SPDX license headers, example README metadata, maintainer taxonomy, catalog validation, and catalog packaging

## Documentation Writer Review

- [x] Documentation writer review completed for the final changes
- Result: `docs-updated`
- Evidence or justification: `examples/recipes/nvidia/memory-driven-chief-of-staff/README.md` and `examples/recipes/nvidia/memory-driven-chief-of-staff/docs/set-up-slack.md`. The final dashboard claims were verified against current public NVIDIA/NemoClaw and its pinned Hermes v2026.7.20 / 0.19.0 source, including `--isolated` launch routing, switcher and `?profile=` behavior, Sessions scope, Cron and Profiles behavior, profile deletion, and the Hermes `dashboard-url` session-auth flow. The Slack examples were checked against the recipe's setup and encrypted-storage scripts.
- Reviewer: self-reviewed by the author; independently checked during maintainer review at final head `2ddd30bba81a42eb2579695dbf9b94311db92bc1`
- [x] Changed user-facing text follows the writing guide and controlled-word list
- [x] A public contributor can understand the changed text without internal company context
- [x] I reviewed any agent-generated text before submission

## Release And Compliance

- [x] No secrets or credentials are included, including API keys, access tokens, passwords, local `.env` files, private certificates, or token caches.
- [x] No nonpublic project names, environment names, hostnames, URLs, ticket identifiers, workspace paths, logs, screenshots, or configuration values are included.
- [x] Third-party dependency changes are reflected in `THIRD-PARTY-NOTICES`. — not applicable; no dependency changes
- [x] Public content uses sanitized examples and placeholders instead of private values.
- [x] I added my DCO sign-off declaration to this pull request description.

Signed-off-by: XuanWu <xuwu@nvidia.com>
