### PR TITLE
feat(catalog): surface stack and maintenance status

### DIFF
--- a/.agents/skills/nemoclaw-community-contributor-examples/references/example-taxonomy.md
+++ b/.agents/skills/nemoclaw-community-contributor-examples/references/example-taxonomy.md
@@ -65,11 +65,21 @@ contribution came from. It does not encode every way a reader may discover the
 example.
 
 Record the one primary industry, any accepted cross-cutting collection, and an
-optional upstream project in the standardized catalog block at the top of the
-example's root `README.md`.
+optional upstream project in the standardized catalog block in the example's
+root `README.md`.
 Use the exact emoji-and-title values documented in
 [`CONTRIBUTING.md`](../../../../CONTRIBUTING.md#catalog-metadata). Industry does
-not change kind, provenance, support, or maturity.
+not change kind, provenance, support, or maturity. `Lifecycle` and `Reviewed`
+are optional maintenance metadata; omission means an active example whose age
+comes from committed activity.
+
+Every example also declares NemoClaw, harness, and OpenShell values in that
+table. They are fallbacks, not proof. The catalog confirms them only from the
+small set of root runtime conventions documented in
+[`CONTRIBUTING.md`](../../../../CONTRIBUTING.md#runtime-stack-discovery). An
+exact reviewed NemoClaw release may supply its stock harness and OpenShell
+versions. Custom layouts remain `Unconfirmed`, `Unpinned`, or `Unknown` until
+standardized; these labels do not mean unsupported or broken.
 
 `Hackathon` and `Build-a-Claw` are collections, not artifact kinds or
 provenance. A collection entry that is a reusable workflow remains a recipe

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,9 +18,15 @@ on:
       - ".agents/skills/nemoclaw-community-contributor-examples/references/example-taxonomy.md"
       - "examples/**"
       - "scripts/build_catalog.py"
+      - "scripts/catalog-maintenance.json"
+      - "scripts/catalog_maintenance.py"
+      - "scripts/example_stack_facts.py"
+      - "scripts/nemoclaw-release-contracts.json"
       - "scripts/fetch_catalog_assets.py"
       - "scripts/catalog-requirements.txt"
       - "scripts/tests/test_build_catalog.py"
+      - "scripts/tests/test_catalog_maintenance.py"
+      - "scripts/tests/test_example_stack_facts.py"
       - "scripts/tests/catalog.test.mjs"
       - "site/**"
   push:
@@ -37,11 +43,19 @@ on:
       - ".agents/skills/nemoclaw-community-contributor-examples/references/example-taxonomy.md"
       - "examples/**"
       - "scripts/build_catalog.py"
+      - "scripts/catalog-maintenance.json"
+      - "scripts/catalog_maintenance.py"
+      - "scripts/example_stack_facts.py"
+      - "scripts/nemoclaw-release-contracts.json"
       - "scripts/fetch_catalog_assets.py"
       - "scripts/catalog-requirements.txt"
       - "scripts/tests/test_build_catalog.py"
+      - "scripts/tests/test_catalog_maintenance.py"
+      - "scripts/tests/test_example_stack_facts.py"
       - "scripts/tests/catalog.test.mjs"
       - "site/**"
+  schedule:
+    - cron: "17 6 * * *"
   workflow_dispatch:
 
 permissions:
@@ -75,6 +89,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:
@@ -94,7 +109,11 @@ jobs:
         run: python3 scripts/build_catalog.py --check
 
       - name: Run catalog build tests
-        run: python3 -m unittest discover -s scripts/tests -p 'test_build_catalog.py'
+        run: >-
+          python3 -m unittest
+          scripts.tests.test_build_catalog
+          scripts.tests.test_catalog_maintenance
+          scripts.tests.test_example_stack_facts
 
       - name: Run catalog interaction tests
         run: node --test scripts/tests/catalog.test.mjs
@@ -112,6 +131,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -252,7 +252,10 @@ python3 -m pip install --require-hashes -r scripts/catalog-requirements.txt
 python3 scripts/fetch_catalog_assets.py
 python3 scripts/build_catalog.py --validate-metadata
 python3 scripts/build_catalog.py --check
-python3 -m unittest discover -s scripts/tests -p 'test_build_catalog.py'
+python3 -m unittest \
+  scripts.tests.test_build_catalog \
+  scripts.tests.test_catalog_maintenance \
+  scripts.tests.test_example_stack_facts
 node --test scripts/tests/catalog.test.mjs
 ```
 
@@ -389,13 +392,15 @@ frontmatter may precede the title and is ignored by catalog generation:
 | Description | Performs a concrete job and produces an observable result. |
 | Industry | ✨ Other |
 | Requirements | Linux · Docker · required service or boundary |
+| NemoClaw | v0.0.104 |
+| Harness | OpenClaw 2026.7.1 |
+| OpenShell | 0.0.85 |
 ```
 
-Add `Upstream` after `Requirements` when the example adapts a separate public
-project, `Contributor` for a partner recipe, or `Collection` with either
-`Hackathon` or `Build-a-Claw` for a recipe accepted into that collection. Omit
-rows that do not apply. Do not add YAML frontmatter for catalog data; place all
-new catalog metadata in the Markdown table. The
+After `OpenShell`, add optional rows in this order: `Lifecycle`, `Reviewed`,
+`Upstream`, `Contributor`, and `Collection`. Omit rows that do not apply. Do
+not add YAML frontmatter for catalog data; place all new catalog metadata in
+the Markdown table. The
 [catalog architecture](docs/catalog-architecture.md) documents the complete
 generation and public query contract.
 
@@ -411,6 +416,26 @@ Follow these metadata rules:
 - `Requirements` is a short, factual summary of the main environment,
   dependency, and material operating boundary. It appears as “Requirements &
   limits” in catalog cards and detail pages and is limited to 240 characters.
+- `NemoClaw` is the exact or ranged CLI/bootstrap version that creates the
+  example's stack, or `Unpinned`, `Unknown`, or `N/A`. Use `N/A` only when the
+  example runs a prebuilt or direct harness stack without invoking NemoClaw.
+- `Harness` is `Hermes`, `OpenClaw`, `LangChain Deep Agents`, or
+  `LangChain Deep Agents Code` followed by an exact/ranged version,
+  `Unpinned`, or `Unknown`. Use `N/A` only when no harness runs as part of the
+  example. When several harnesses participate, declare the one that performs
+  the example's primary agent workload and describe the others in the body.
+- `OpenShell` is an exact/ranged version, `Unpinned`, `Unknown`, or `N/A`. Use
+  `N/A` only when no supported path uses OpenShell.
+- For multiple supported deployment paths, use an exact version only when all
+  paths use it. Use `Unpinned` when any path selects a mutable version, and
+  `Unknown` when a used component or its version cannot be established.
+- `Lifecycle` is optional and accepts exactly `Active` or `Deprecated`;
+  omitting it means `Active`. Use `Deprecated` only when the
+  example is intentionally retained for reference instead of recommended for
+  new use.
+- `Reviewed` is an optional `YYYY-MM-DD` date for a focused review of setup,
+  documented behavior, and known limitations. It is maintenance metadata, not
+  a verification result or evidence level.
 - `Upstream` is optional. Set it only when the example wraps, adapts, or extends
   a separate canonical public project, and use an absolute HTTPS URL without
   embedded credentials. Do not use it as a second source link to this example.
@@ -420,6 +445,57 @@ Follow these metadata rules:
   partner, or community provenance and canonical recipe path.
 - The directory path remains the source for artifact kind and recipe
   provenance; do not repeat either in the catalog block.
+
+Do not author the public maintenance status. It is computed from the latest
+committed change anywhere under the example or a later `Reviewed` date. This
+is a repository-activity heuristic: documentation and asset changes count just
+like runtime changes. The age bands are `Current` through day 29, `Review soon`
+through day 59, `Review due` through day 119, `Review overdue` through day 239,
+and `Deprecated` from day 240. The thresholds live in
+`scripts/catalog-maintenance.json`, and the daily
+Pages build refreshes the site. An authored `Deprecated` lifecycle applies
+immediately; an automatic status never rewrites the README. These signals
+describe repository change activity, not support, quality, or runtime health.
+
+### Runtime Stack Discovery
+
+The three README rows are the human fallback; they do not confirm what the
+implementation installs. The catalog performs a deliberately small static
+check of root `Dockerfile*` or `agents/*/Dockerfile*` files.
+
+It recognizes `NEMOCLAW_VERSION`, `NEMOCLAW_COMMIT`,
+`NEMOCLAW_INSTALL_TAG`, `NEMOCLAW_INSTALL_REF`, `NEMOCLAW_AGENT`,
+`HERMES_VERSION`, `HERMES_SEMVER`, `OPENCLAW_VERSION`,
+`DEEPAGENTS_VERSION`, `DEEP_AGENTS_VERSION`,
+`LANGCHAIN_DEEP_AGENTS_CODE_VERSION`, and `OPENSHELL_VERSION`. Put standard
+runtime values in the Dockerfile that installs the stack:
+
+```dockerfile
+ARG NEMOCLAW_VERSION=v0.0.104
+ARG NEMOCLAW_COMMIT=f389c9d872775006ae069473f58250fa8f3ad40f
+ARG NEMOCLAW_AGENT=openclaw
+ARG OPENSHELL_VERSION=0.0.85
+```
+
+Do not add a catalog-only version file. Nested or custom deployment layouts
+intentionally remain README-only until they adopt a root Dockerfile
+convention.
+
+An exact NemoClaw tag or commit listed in
+`scripts/nemoclaw-release-contracts.json` can supply its stock harness and
+OpenShell versions once the selected harness is known. An explicit harness
+pin overrides the stock harness. Any explicit value must agree with the
+README and inferred values. Contract harness values are installed CLI/package
+versions, not source-tag aliases. Add a release contract only after checking
+the exact upstream commit, harness package metadata, and OpenShell constraint.
+
+The UI reports `Confirmed` when applicable exact values agree with a standard
+contract, `Unconfirmed` when exact values exist only in the README, `Unpinned`
+for ranges or mutable installs, `Unknown` when a used component or version is
+not established, `Conflict` for disagreement, and `N/A` only when the
+component does not participate. Unsupported layouts fall back instead of
+being guessed. These labels describe version evidence, not quality or
+support. Model discovery remains out of scope.
 
 Choose one of these exact industry values, including its emoji:
 
@@ -505,14 +581,21 @@ authoring comments before submission.
 | Description | [For an intended user, explain the concrete job and observable result.] |
 | Industry | [Choose one exact emoji-and-title pair from Catalog Metadata.] |
 | Requirements | [Summarize the main environment, dependency, and material operating boundary.] |
+| NemoClaw | [Exact/ranged version, Unpinned, Unknown, or N/A.] |
+| Harness | [Harness name plus exact/ranged version, Unpinned, Unknown, or N/A.] |
+| OpenShell | [Exact/ranged version, Unpinned, Unknown, or N/A.] |
 
 <!--
-When applicable, add these rows after Requirements and in this order:
+When applicable, add these rows after OpenShell and in this order:
+`| Lifecycle | [Active or Deprecated] |` for an intentional lifecycle
+exception; `| Reviewed | YYYY-MM-DD |` after a focused maintenance review;
 `| Upstream | https://github.com/organization/project |` for a separate public
 project that this example adapts; `| Contributor | [Organization] |` for a
 partner recipe; and `| Collection | [Hackathon or Build-a-Claw] |` for an
 accepted collection recipe. Omit rows that do not apply.
 -->
+
+[Introduce the intended user, problem, and result.]
 
 ## Screenshot
 
@@ -548,7 +631,7 @@ also preserve the essential expected output as searchable text.
 
 <!--
 Use the canonical category exactly. Keep category separate from contributor
-provenance. The opening catalog block is authoritative for industry and
+provenance. The catalog block is authoritative for industry and
 collection; do not repeat those fields here. Neither changes category,
 provenance, or directory placement.
 
@@ -583,6 +666,7 @@ then link the alternatives.]
 
 **This does not verify:** [State material boundaries, skipped live systems, or
 remaining validation.]
+
 ````
 
 ### Required Authoring Rules
@@ -590,7 +674,7 @@ remaining validation.]
 - Put material credential, data-sharing, permission, cost, write, or
   destructive-action warnings before the command that triggers them.
 - Start with the exact title. Put the catalog table, including its `Description`
-  outcome, in a final `Catalog Metadata` section as documented in
+  outcome, immediately after the level-one title as documented in
   [Catalog Metadata](#catalog-metadata).
 - Use the canonical category independently from contributor or organizational
   provenance.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -376,16 +376,13 @@ generated [Markdown catalog](examples/README.md), GitHub Pages cards, filters,
 detail pages, public `catalog.json` search index, and agent-oriented
 `llms.txt`. The build discovers example directories from the canonical
 taxonomy, derives kind and provenance from the path, and reads this exact table
-from the root README. Put it in a final `Catalog Metadata` section. Existing
-tables immediately after the title remain supported. Non-catalog YAML
-frontmatter may precede the title and is ignored by catalog generation:
+from the root README. Put it immediately after the level-one title. Existing
+final `Catalog Metadata` sections remain supported as a legacy placement.
+Non-catalog YAML frontmatter may precede the title and is ignored by catalog
+generation:
 
 ```markdown
 # Recognizable Example Name
-
-[Explain the example and show how to run it.]
-
-## Catalog Metadata
 
 | Catalog field | Value |
 | --- | --- |
@@ -395,6 +392,8 @@ frontmatter may precede the title and is ignored by catalog generation:
 | NemoClaw | v0.0.104 |
 | Harness | OpenClaw 2026.7.1 |
 | OpenShell | 0.0.85 |
+
+[Explain the example and show how to run it.]
 ```
 
 After `OpenShell`, add optional rows in this order: `Lifecycle`, `Reviewed`,
@@ -451,11 +450,12 @@ committed change anywhere under the example or a later `Reviewed` date. This
 is a repository-activity heuristic: documentation and asset changes count just
 like runtime changes. The age bands are `Current` through day 29, `Review soon`
 through day 59, `Review due` through day 119, `Review overdue` through day 239,
-and `Deprecated` from day 240. The thresholds live in
+and `Review critical` from day 240. The thresholds live in
 `scripts/catalog-maintenance.json`, and the daily
 Pages build refreshes the site. An authored `Deprecated` lifecycle applies
-immediately; an automatic status never rewrites the README. These signals
-describe repository change activity, not support, quality, or runtime health.
+immediately and is the only status hidden by the default catalog view. An
+automatic status never rewrites the README. These signals describe repository
+change activity, not support, quality, or runtime health.
 
 ### Runtime Stack Discovery
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,11 @@ the age each day from the thresholds in
 | 30–59 days | `Review soon` |
 | 60–119 days | `Review due` |
 | 120–239 days | `Review overdue` |
-| 240 days or more | `Deprecated` |
+| 240 days or more | `Review critical` |
+
+Only an explicit `Lifecycle` value of `Deprecated` produces the `Deprecated`
+status. The default catalog view hides explicitly deprecated examples; age
+alone does not hide an example.
 
 See [Runtime Stack Discovery](CONTRIBUTING.md#runtime-stack-discovery) for the
 recognized variables and contributor contract. See the

--- a/README.md
+++ b/README.md
@@ -39,6 +39,55 @@ Review the example README before setup.
 Additional NemoClaw examples are available in
 [brevdev/nemoclaw-demos](https://github.com/brevdev/nemoclaw-demos).
 
+## How Catalog Status Works
+
+Each example detail page reports stack verification and maintenance status.
+These are independent evidence signals, not scores for support, quality, or
+runtime health.
+
+### Stack Verification
+
+Each example README declares its NemoClaw, harness, and OpenShell values. The
+catalog compares those declarations with recognized version variables in a
+root `Dockerfile*` or `agents/*/Dockerfile*`. A reviewed exact NemoClaw release
+and a recognized harness selection can also supply the stock harness and
+OpenShell versions through the checked-in
+[release contracts](scripts/nemoclaw-release-contracts.json). The build does
+not run the example or guess values from custom file layouts.
+
+| Status | Meaning |
+| --- | --- |
+| `Confirmed` | Exact README values agree with recognized Dockerfile evidence. |
+| `Unconfirmed` | Exact values appear only in the README. |
+| `Unpinned` | A participating version is a range or mutable value. |
+| `Unknown` | The harness or a required version cannot be determined. |
+| `Conflict` | README declarations and Dockerfile evidence disagree. |
+| `N/A` | NemoClaw, a harness, and OpenShell do not participate. |
+
+For mixed component results, the overall priority is `Conflict`, `Unknown`,
+`Unpinned`, `Unconfirmed`, then `Confirmed`.
+
+### Maintenance Status
+
+The catalog uses the later of two dates: the latest committed change anywhere
+under the example, or its optional `Reviewed` date. An explicit `Deprecated`
+lifecycle takes effect immediately. The scheduled Pages build recalculates
+the age each day from the thresholds in
+[`scripts/catalog-maintenance.json`](scripts/catalog-maintenance.json).
+
+| Age since latest activity | Status |
+| --- | --- |
+| 0–29 days | `Current` |
+| 30–59 days | `Review soon` |
+| 60–119 days | `Review due` |
+| 120–239 days | `Review overdue` |
+| 240 days or more | `Deprecated` |
+
+See [Runtime Stack Discovery](CONTRIBUTING.md#runtime-stack-discovery) for the
+recognized variables and contributor contract. See the
+[catalog architecture](docs/catalog-architecture.md#static-stack-discovery)
+for the complete generation contract.
+
 ## Getting Started
 
 Choose an example and follow its README. To run an example from this repository,

--- a/docs/catalog-architecture.md
+++ b/docs/catalog-architecture.md
@@ -28,16 +28,23 @@ site/styles.css ───────┼─> _site/styles.css
 site/catalog.mjs ──────┼─> _site/catalog.mjs
 site/diagrams.mjs ─────┼─> _site/diagrams.mjs
 Mermaid Tiny cache ────┴─> _site/assets/vendor/mermaid.tiny.js
+README stack rows plus
+standard runtime Dockerfiles ─> stack values and verification in HTML, JSON,
+                               and llms.txt
+Git history, Lifecycle,
+and Reviewed ──────────────> computed maintenance status
 ```
 
-The standardized catalog block at the top of each example's root `README.md` is
-the canonical example metadata source.
+The standardized catalog block in each example's root `README.md` is the
+canonical example metadata source.
 [`scripts/build_catalog.py`](../scripts/build_catalog.py) discovers those
 READMEs from the repository taxonomy, validates their title, required
 `Description` table row, industry emoji and title, requirements, and
 conditional fields, then derives artifact kind and recipe provenance from each
-path. An optional `Upstream` field identifies a separate canonical public
-project that the example adapts.
+path. Optional `Lifecycle` and `Reviewed` fields inform maintenance status; an
+optional `Upstream` field identifies a separate canonical public project that
+the example adapts. The required NemoClaw, harness, and OpenShell rows provide
+a readable fallback while standard runtime files provide confirmation.
 
 Each of the five canonical categories and two collection views has an index
 README. Its H1 and opening description are the authored source for the browse
@@ -88,6 +95,12 @@ The catalog keeps these concepts separate:
   and also comes from the canonical path.
 - `industry` is one required controlled emoji-and-title value on every example,
   independent of kind and provenance.
+- `lifecycle` is an optional authored value: `Active` or `Deprecated`.
+  Omission means `Active`; it never belongs in an example path.
+- `reviewed` is an optional focused maintenance-review date, not runtime
+  verification evidence.
+- `stack` merges required README declarations with a small static check of
+  standardized runtime files.
 - `collection` is an optional cross-cutting recipe discovery field.
   `Hackathon` and `Build-a-Claw` are collections; neither replaces kind,
   provenance, canonical path, or contributor attribution.
@@ -96,6 +109,41 @@ The build rejects unknown taxonomy roots, unsafe or invalid example paths,
 canonical example directories without a root README, malformed metadata
 blocks, duplicate titles, and values outside the controlled vocabulary.
 
+## Static Stack Discovery
+
+Every README declares `NemoClaw`, `Harness`, and `OpenShell`. The builder then
+looks for matching values only in root `Dockerfile*` or
+`agents/*/Dockerfile*` files. It recognizes a short list of conventional
+variables documented in `CONTRIBUTING.md`; nested and custom layouts use the
+README fallback until standardized.
+
+The checked-in `scripts/nemoclaw-release-contracts.json` maps reviewed exact
+NemoClaw tags and commits to their stock harness matrix and OpenShell version.
+The builder can infer those values once it finds an exact release and selected
+harness. Contract harness values use installed CLI/package versions. Explicit
+implementation pins take precedence and must agree with the README.
+
+The final state is `Confirmed`, `Unconfirmed`, `Unpinned`, `Unknown`,
+`Conflict`, or `N/A`. This is a version-evidence statement, not a support,
+quality, or runtime-health claim. Catalog builds never fetch release metadata,
+and model discovery is out of scope.
+
+## Computed Maintenance Status
+
+Contributors may author `Lifecycle` and a focused `Reviewed` date, but not the
+public status. The effective activity date is the latest committed change
+anywhere under the example or a later review. This is deliberately a
+repository-activity heuristic: documentation and asset changes count as well
+as runtime changes. The age-only bands are `Current` through
+day 29, `Review soon` through day 59, `Review due` through day 119, `Review
+overdue` through day 239, and `Deprecated` from day 240. An authored
+`Deprecated` lifecycle applies immediately; computed deprecation never edits
+the README. Thresholds are maintained in `scripts/catalog-maintenance.json`,
+and the scheduled Pages workflow refreshes them daily. The build requires full
+Git history; a newly added, uncommitted example temporarily uses the build date
+for local preview. Maintenance status is independent of stack verification and
+is not a support or runtime-health claim.
+
 ## Browser Search Contract
 
 Catalog state is encoded in the URL so a filtered view can be copied,
@@ -103,10 +151,11 @@ bookmarked, or created by another program:
 
 | Parameter | Values | Behavior |
 | --- | --- | --- |
-| `q` | Plain text | Case-insensitive whitespace-token AND search across title, description, requirements, category and provenance display text, industry, contributor, and collections. |
+| `q` | Plain text | Case-insensitive whitespace-token AND search across title, description, requirements, category and provenance display text, industry, lifecycle, maintenance status, stack values and verification, contributor, and collections. |
 | `view` | `category` or `industry` | Selects which discovery dimension is active. The default is `category`. |
 | `category` | `all`, `nvidia-recipes`, `partner-recipes`, `community-recipes`, `nvidia-field-demos`, `developer-tools`, `hackathon-recipes`, or `build-a-claw-recipes` | Applies in category view. The final two values select recipes carrying the matching collection. |
 | `industry` | `all` or an industry ID published in `catalog.json` | Applies in industry view. |
+| `maintenance` | `maintained`, `all`, `current`, `review-soon`, `review-due`, `review-overdue`, or `deprecated` | Applies independently of the active browse view. `maintained` includes every nondeprecated status. |
 
 Examples:
 
@@ -129,8 +178,10 @@ publishes a deterministic JSON index containing:
 - every allowed industry ID, label, emoji, and current count;
 - collection IDs, labels, descriptions, and counts;
 - each example's title, description, category, kind, recipe provenance,
-  industry, contributor when applicable, collections, requirements, optional
-  upstream project URL, source path, source guide URL, and local detail URL.
+  industry, lifecycle, optional reviewed date, NemoClaw, harness, and OpenShell
+  facts, stack verification and evidence paths, computed maintenance status,
+  contributor when applicable, collections, requirements, optional upstream
+  project URL, source path, source guide URL, and local detail URL.
 
 This is a static index rather than a server-side query API. A program can fetch
 it once and apply its own filters, or construct a browser URL using the query
@@ -141,8 +192,9 @@ contract above.
 [`https://nvidia.github.io/nemoclaw-community/llms.txt`](https://nvidia.github.io/nemoclaw-community/llms.txt)
 publishes the catalog overview, filter guidance, category and collection
 fields, and one concise record for every example. Each record includes the
-example's category, industry, requirements, detail page, source guide,
-collections, and optional upstream project.
+example's category, industry, requirements, lifecycle, NemoClaw, harness, and
+OpenShell facts, stack verification, maintenance status, detail page, source
+guide, collections, and optional upstream project.
 
 The build creates `llms.txt` directly from the same validated README data used
 for `catalog.json`; it is a second generated representation, not a metadata
@@ -151,8 +203,9 @@ should continue to use `catalog.json`.
 
 ## Update And Verify
 
-After adding or changing an example README catalog block, validate its format,
-then regenerate the committed Markdown catalog and local site:
+After changing an example README catalog block or a consumed runtime stack
+source, validate the inputs, then regenerate the committed Markdown catalog
+and local site:
 
 ```bash
 python3 scripts/build_catalog.py --validate-metadata
@@ -165,7 +218,10 @@ Run the same checks used by the Pages workflow:
 
 ```bash
 python3 scripts/build_catalog.py --check
-python3 -m unittest discover -s scripts/tests -p 'test_build_catalog.py'
+python3 -m unittest \
+  scripts.tests.test_build_catalog \
+  scripts.tests.test_catalog_maintenance \
+  scripts.tests.test_example_stack_facts
 node --test scripts/tests/catalog.test.mjs
 ```
 

--- a/docs/catalog-architecture.md
+++ b/docs/catalog-architecture.md
@@ -35,8 +35,9 @@ Git history, Lifecycle,
 and Reviewed ──────────────> computed maintenance status
 ```
 
-The standardized catalog block in each example's root `README.md` is the
-canonical example metadata source.
+The standardized catalog block immediately after the level-one title in each
+example's root `README.md` is the canonical metadata source. A final
+`Catalog Metadata` section remains supported as a legacy placement.
 [`scripts/build_catalog.py`](../scripts/build_catalog.py) discovers those
 READMEs from the repository taxonomy, validates their title, required
 `Description` table row, industry emoji and title, requirements, and
@@ -136,13 +137,14 @@ anywhere under the example or a later review. This is deliberately a
 repository-activity heuristic: documentation and asset changes count as well
 as runtime changes. The age-only bands are `Current` through
 day 29, `Review soon` through day 59, `Review due` through day 119, `Review
-overdue` through day 239, and `Deprecated` from day 240. An authored
-`Deprecated` lifecycle applies immediately; computed deprecation never edits
-the README. Thresholds are maintained in `scripts/catalog-maintenance.json`,
-and the scheduled Pages workflow refreshes them daily. The build requires full
-Git history; a newly added, uncommitted example temporarily uses the build date
-for local preview. Maintenance status is independent of stack verification and
-is not a support or runtime-health claim.
+overdue` through day 239, and `Review critical` from day 240. An authored
+`Deprecated` lifecycle applies immediately and is the only status hidden by
+the default catalog view. Computed maintenance never edits the README.
+Thresholds are maintained in `scripts/catalog-maintenance.json`, and the
+scheduled Pages workflow refreshes them daily. The build requires full Git
+history; a newly added, uncommitted example temporarily uses the build date for
+local preview. Maintenance status is independent of stack verification and is
+not a support or runtime-health claim.
 
 ## Browser Search Contract
 
@@ -155,7 +157,7 @@ bookmarked, or created by another program:
 | `view` | `category` or `industry` | Selects which discovery dimension is active. The default is `category`. |
 | `category` | `all`, `nvidia-recipes`, `partner-recipes`, `community-recipes`, `nvidia-field-demos`, `developer-tools`, `hackathon-recipes`, or `build-a-claw-recipes` | Applies in category view. The final two values select recipes carrying the matching collection. |
 | `industry` | `all` or an industry ID published in `catalog.json` | Applies in industry view. |
-| `maintenance` | `maintained`, `all`, `current`, `review-soon`, `review-due`, `review-overdue`, or `deprecated` | Applies independently of the active browse view. `maintained` includes every nondeprecated status. |
+| `maintenance` | `maintained`, `all`, `current`, `review-soon`, `review-due`, `review-overdue`, `review-critical`, or `deprecated` | Applies independently of the active browse view. `maintained` includes every status except explicit deprecation. |
 
 Examples:
 

--- a/examples/demos/field/blender-omniverse-dgx-station/README.md
+++ b/examples/demos/field/blender-omniverse-dgx-station/README.md
@@ -5,6 +5,9 @@
 | Description | Lets users direct a specialized Hermes agent on DGX Station across Blender and NVIDIA Omniverse workflows, producing scene edits, OVRTX renders, native OVPhysX simulations, and replay evidence. |
 | Industry | 🎬 Media & Entertainment |
 | Requirements | DGX Station · Ubuntu 24.04 ARM64 · GB300 + RTX GPU · Blender 5.1.x + OVRTX/OVPhysX · local vLLM with Nemotron 3 Ultra · Hugging Face read access token |
+| NemoClaw | v0.0.83 |
+| Harness | Hermes 0.18.0 |
+| OpenShell | 0.0.72 |
 
 This project creates a specialized NemoClaw Hermes agent for Blender and
 NVIDIA Omniverse workflows on DGX Station. A local Nemotron 3 Ultra model plans

--- a/examples/recipes/community/axe-a11y-browser-auditor/README.md
+++ b/examples/recipes/community/axe-a11y-browser-auditor/README.md
@@ -8,6 +8,9 @@
 | Description | Helps web teams find WCAG issues through a dedicated sandbox and host-side real Chrome, returning rule-level findings with optional screenshots, PDFs, recordings, and network traces. |
 | Industry | 🌐 Consumer Internet |
 | Requirements | Docker 24+ with Compose · linux/amd64 or Docker Desktop emulation · dedicated OpenShell/NemoClaw sandbox |
+| NemoClaw | Unpinned |
+| Harness | OpenClaw Unpinned |
+| OpenShell | Unpinned |
 
 Axe A11y Browser Auditor is a community recipe for automated web quality and WCAG accessibility compliance testing inside a NemoClaw-managed sandbox. It installs an `axe-a11y` skill into an existing OpenClaw sandbox, then routes requests to a host-side Streamable-HTTP MCP sidecar running `axe-core` and Patchright against real Google Chrome Stable.
 

--- a/examples/recipes/community/deep-research-worker/README.md
+++ b/examples/recipes/community/deep-research-worker/README.md
@@ -8,6 +8,9 @@
 | Description | Adds asynchronous research to a sandbox, so users can queue long-running jobs on a host-side worker, monitor persistent task state, and return later for text or JSON results. |
 | Industry | ✨ Other |
 | Requirements | Docker Compose · dedicated OpenShell/NemoClaw sandbox · OpenAI-compatible inference endpoint + API key · no readiness guarantee |
+| NemoClaw | Unpinned |
+| Harness | LangChain Deep Agents 0.7.5 |
+| OpenShell | Unpinned |
 
 Deep Research Worker is a community recipe for asynchronous, long-horizon
 research with a NemoClaw-managed sandbox. It installs a `deep-research` skill

--- a/examples/recipes/nvidia/agentic-ai-learning-path/README.md
+++ b/examples/recipes/nvidia/agentic-ai-learning-path/README.md
@@ -8,6 +8,9 @@
 | Description | Helps learners work through the seven-module Build an Agent workshop in JupyterLab with an AI tutor that explains concepts, offers graduated hints, and checks progress inside an OpenShell sandbox. |
 | Industry | 🎓 Academia/Education |
 | Requirements | Linux · Docker · OpenShell · inference, NVIDIA, and Tavily API keys · Slack or Outlook · CPU-first; module 4 training is read-through |
+| NemoClaw | N/A |
+| Harness | Hermes 0.20.0 |
+| OpenShell | Unpinned |
 | Upstream | https://github.com/brevdev/workshop-build-an-agent |
 
 [NVIDIA's **Build an Agent** workshop](https://github.com/brevdev/workshop-build-an-agent)

--- a/examples/recipes/nvidia/developer-community-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/developer-community-chief-of-staff/README.md
@@ -5,6 +5,9 @@
 | Description | Helps developer community leaders align priorities with demand by turning available GitHub, GitLab, forum, Slack, email, and web signals into evidence-grounded briefs, gaps, and follow-up recommendations. |
 | Industry | ✨ Other |
 | Requirements | Single Linux host · Docker · OpenShell · inference provider API key · Slack or Outlook |
+| NemoClaw | N/A |
+| Harness | Hermes 0.20.0 |
+| OpenShell | 0.0.85 |
 
 ![NVIDIA](assets/nvidia_header.png)
 

--- a/examples/recipes/nvidia/kubernetes-gpu-autoscaling/README.md
+++ b/examples/recipes/nvidia/kubernetes-gpu-autoscaling/README.md
@@ -10,6 +10,9 @@
 | Description | Helps Kubernetes operators match GPU inference capacity to demand by pairing a CPU-only OpenShell sandbox with Ollama replicas that scale on utilization or latency and return to one after load. |
 | Industry | ☁️ Cloud Services |
 | Requirements | Kubernetes 1.25+ · Helm 3 · NVIDIA GPU Operator/DCGM · Metrics Server · Docker Buildx + registry · OpenShell + Agent Sandbox CRDs pinned in versions.env · OIDC or acknowledged isolated-eval exception · experimental |
+| NemoClaw | v0.0.104 |
+| Harness | OpenClaw 2026.7.1 |
+| OpenShell | 0.0.85 |
 
 This experimental community recipe demonstrates a cost-efficient architecture that runs a single OpenClaw agent securely inside a CPU-only OpenShell sandbox while independently autoscaling the GPU-backed Ollama model for inference. Because GPU inference is the primary compute and cost bottleneck, Kubernetes HPA dynamically adjusts Ollama capacity from one to multiple replicas as demand changes—maintaining responsiveness during traffic spikes while releasing idle GPU resources when demand falls.
 

--- a/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
+++ b/examples/recipes/nvidia/memory-driven-chief-of-staff/README.md
@@ -1241,3 +1241,6 @@ license: Apache-2.0
 | Description | Builds a revisable local memory from email and Slack, then ranks obligations against the user's priorities while preserving pins and ignores without changing source systems. |
 | Industry | ✨ Other |
 | Requirements | Python 3.10+ · scheduled use: a Linux NemoHermes sandbox, Hermes 0.19+, and an inference provider API key · provider setup helpers: Linux/WSL · Slack and Microsoft Graph collectors optional |
+| NemoClaw | Unpinned |
+| Harness | Hermes >=0.19.0 |
+| OpenShell | Unpinned |

--- a/examples/recipes/nvidia/nv-tech-assistant/README.md
+++ b/examples/recipes/nvidia/nv-tech-assistant/README.md
@@ -5,6 +5,9 @@
 | Description | Helps developers choose and troubleshoot NVIDIA technologies by searching allowlisted documentation, repositories, model catalogs, and forums for current, evidence-linked answers. |
 | Industry | 🖥️ Hardware/Semiconductor |
 | Requirements | Docker · NemoClaw · NVIDIA Endpoints API key · optional Brave Search · no offline corpus |
+| NemoClaw | Unpinned |
+| Harness | OpenClaw Unpinned |
+| OpenShell | Unpinned |
 
 NV Tech Assistant is a NemoClaw community example for grounded NVIDIA
 technical research. It searches authorized NVIDIA sources, GitHub, and arXiv,

--- a/examples/recipes/nvidia/payment-ops-hermes/README.md
+++ b/examples/recipes/nvidia/payment-ops-hermes/README.md
@@ -5,6 +5,9 @@
 | Description | Helps payment operators screen synthetic outbound payments, explain holds, and prepare review packets while OpenShell keeps final release authority with a human outside the Hermes sandbox. |
 | Industry | 💳 Financial Services |
 | Requirements | Linux · Docker Compose · OpenShell 0.0.53 · OpenAI-compatible inference API key · synthetic data only |
+| NemoClaw | N/A |
+| Harness | Hermes 0.14.0 |
+| OpenShell | 0.0.53 |
 
 ![NVIDIA](assets/nvidia_header.png)
 

--- a/examples/recipes/nvidia/pr-review-advisor/README.md
+++ b/examples/recipes/nvidia/pr-review-advisor/README.md
@@ -10,6 +10,9 @@ SPDX-License-Identifier: Apache-2.0
 | Description | Helps maintainers review exact pull request heads through staged, repository-aware Hermes analysis, producing attested JSON and Markdown findings for inspection before optional publication. |
 | Industry | ✨ Other |
 | Requirements | Linux + Docker · OpenShell 0.0.85 · Node.js 22.19+ · inference provider API key or existing provider · GitHub.com self-hosted runner for the generated workflow |
+| NemoClaw | N/A |
+| Harness | Hermes 0.18.0 |
+| OpenShell | 0.0.85 |
 
 This first-party NemoClaw turns Hermes and Nemotron 3 Ultra into a reusable,
 repository-aware pull-request review advisor. Its first-party design combines

--- a/examples/recipes/nvidia/pr-test-case-assistant/README.md
+++ b/examples/recipes/nvidia/pr-test-case-assistant/README.md
@@ -10,6 +10,9 @@
 | Description | Helps quality engineers turn public GitHub pull request descriptions and bounded diffs into Slack briefs and proposed, unexecuted feature test cases with source evidence. |
 | Industry | ✨ Other |
 | Requirements | NemoClaw + Docker · Slack app with Socket Mode · Slack bot + app access tokens · inference provider API key · public GitHub only |
+| NemoClaw | Unpinned |
+| Harness | OpenClaw Unpinned |
+| OpenShell | Unpinned |
 
 This NVIDIA-authored recipe runs an OpenClaw assistant in a NemoClaw sandbox.
 People send it a Slack direct message with a public GitHub repository or pull

--- a/examples/recipes/nvidia/video-search-and-summarization/README.md
+++ b/examples/recipes/nvidia/video-search-and-summarization/README.md
@@ -10,6 +10,9 @@
 | Description | Helps video analysts and engineers deploy and operate NVIDIA VSS profiles by chat, using a sandboxed agent that runs the Compose deployment through a host-side MCP server and reports the result. |
 | Industry | ✨ Other |
 | Requirements | Linux GPU host · Docker with the NVIDIA runtime · Python 3.11+ for the notebooks · NGC API key · agent model provider · VSS repository develop branch · large container image and model pulls |
+| NemoClaw | Unpinned |
+| Harness | Unknown |
+| OpenShell | Unpinned |
 
 ## Screenshot
 

--- a/examples/recipes/partners/bluetier/x402-payment-gate/README.md
+++ b/examples/recipes/partners/bluetier/x402-payment-gate/README.md
@@ -5,6 +5,9 @@
 | Description | Demonstrates a maker-checker gate for x402 payments: a sandboxed agent submits intents, while a host-side Blackwall verdict controls mock signing and settlement before any signature exists. |
 | Industry | 💳 Financial Services |
 | Requirements | Python 3 · Docker + OpenShell for sandbox checks · Blackwall service · simulated signing/no real money |
+| NemoClaw | N/A |
+| Harness | Hermes 0.18.0 |
+| OpenShell | >=0.0.85 |
 | Contributor | BlueTier Operations |
 
 A maker/checker payment boundary for [x402](https://www.x402.org/) machine

--- a/examples/recipes/partners/hpe/retail-assistant/README.md
+++ b/examples/recipes/partners/hpe/retail-assistant/README.md
@@ -5,6 +5,9 @@
 | Description | Helps store employees check inventory and sales or request transfers and reorders through role-aware Telegram conversations scoped to their assigned store. |
 | Industry | 🛍️ Retail/Consumer Packaged Goods |
 | Requirements | Telegram bot · tool-calling OpenAI-compatible LLM · Docker Compose or Kubernetes + Helm · demo identity mapping |
+| NemoClaw | Unpinned |
+| Harness | OpenClaw Unpinned |
+| OpenShell | Unpinned |
 | Contributor | HPE |
 
 This example was built by HPE AI & Data Technical consultants: Paula Serna and Sergio Donís; and is presented as-is. See credits for contact information.

--- a/examples/recipes/partners/shrike/shrike-security/README.md
+++ b/examples/recipes/partners/shrike/shrike-security/README.md
@@ -9,6 +9,9 @@
 | Description | Adds defense-in-depth action governance through an in-sandbox hook that checks each OpenClaw tool call against server-side Shrike policy and blocks prohibited or approval-required calls. |
 | Industry | ✨ Other |
 | Requirements | NemoClaw/OpenShell · Node.js + npm · inference provider · Shrike API key · in-sandbox defense-in-depth only |
+| NemoClaw | >=v0.0.76 |
+| Harness | OpenClaw Unpinned |
+| OpenShell | Unpinned |
 | Contributor | Shrike Security, Inc. |
 
 Govern what an OpenClaw agent is allowed to **do**. This recipe installs a

--- a/examples/recipes/partners/tavily/watchtower/README.md
+++ b/examples/recipes/partners/tavily/watchtower/README.md
@@ -5,6 +5,9 @@
 | Description | Tracks what changed across chosen web topics and why it matters, producing scheduled, deduplicated Markdown digests and JSON changelogs with source citations. |
 | Industry | ✨ Other |
 | Requirements | Docker · NemoClaw · Tavily and inference provider API keys · one-time operator.admin approval |
+| NemoClaw | Unpinned |
+| Harness | OpenClaw Unpinned |
+| OpenShell | Unpinned |
 | Contributor | Tavily |
 
 Watchtower is a NemoClaw community example for unattended web monitoring. It

--- a/examples/tools/agent-memory-benchmark/README.md
+++ b/examples/tools/agent-memory-benchmark/README.md
@@ -489,3 +489,6 @@ alike, under the repository's [LICENSE](../../../LICENSE).
 | Description | Measures memory built from synthetic email and chat, asks 186 questions on one corpus and 96 on a second, and reports accuracy by question type with ingest and answer token costs. |
 | Industry | ✨ Other |
 | Requirements | Python 3.9+ · pytest and tesseract for offline checks · endpoint and adapter for live scoring |
+| NemoClaw | N/A |
+| Harness | N/A |
+| OpenShell | N/A |

--- a/examples/tools/harness-engineering-playground/README.md
+++ b/examples/tools/harness-engineering-playground/README.md
@@ -5,6 +5,9 @@
 | Description | Provides an experimental loop for tuning DeepAgents harness profiles against behavioral evaluations, keeping fixes that pass verification and rolling back rejected edits. |
 | Industry | ✨ Other |
 | Requirements | Python 3.11+ · uv · DeepAgents submodule + extra · proposer and target-model API keys · experimental/not for production |
+| NemoClaw | N/A |
+| Harness | LangChain Deep Agents 0.6.12 |
+| OpenShell | N/A |
 
 > **⚠️ Experimental.** `hep` is an early, evolving example — expect rough
 > edges and breaking changes. Today it ships one framework adapter

--- a/scripts/build_catalog.py
+++ b/scripts/build_catalog.py
@@ -1687,6 +1687,7 @@ def taxonomy_contract() -> dict[str, Any]:
             "review-soon",
             "review-due",
             "review-overdue",
+            "review-critical",
             "deprecated",
         ],
     }
@@ -2126,16 +2127,13 @@ def _display_stack_value(value: str | None, status: str) -> str:
     return '<span class="fact-unknown">Unknown</span>'
 
 
-def _fact_info(entry: CatalogEntry, suffix: str, label: str, lines: list[str]) -> str:
-    tooltip_id = f"{entry.id}-{suffix}-details"
+def _fact_info(label: str, lines: list[str]) -> str:
     content = "".join(f"<span>{html.escape(line)}</span>" for line in lines)
     return (
-        f'<span class="fact-info" tabindex="0" '
-        f'aria-label="{html.escape(label, quote=True)}" '
-        f'aria-describedby="{tooltip_id}">'
-        '<span aria-hidden="true">i</span>'
-        f'<span class="fact-popover" id="{tooltip_id}" role="tooltip">'
-        f"{content}</span></span>"
+        '<details class="fact-info">'
+        f'<summary aria-label="{html.escape(label, quote=True)}">'
+        '<span aria-hidden="true">i</span></summary>'
+        f'<div class="fact-popover">{content}</div></details>'
     )
 
 
@@ -2185,7 +2183,7 @@ def render_stack_facts(entry: CatalogEntry) -> str:
         if evidence
         else "Evidence: no standardized runtime source found."
     )
-    info = _fact_info(entry, "stack", "About stack metadata", details)
+    info = _fact_info("About stack metadata", details)
     status_value = (
         '<span class="status-label"><span class="status-dot" '
         f'aria-hidden="true"></span>{html.escape(status_label)}</span>'
@@ -2206,10 +2204,11 @@ def render_maintenance_fact(entry: CatalogEntry) -> str:
         status.summary,
         f"Last committed change: {entry.last_activity.isoformat()}.",
         f"Lifecycle: {entry.lifecycle}.",
+        "This reflects repository activity only, not support, quality, or runtime health.",
     ]
     if entry.reviewed is not None:
         details.insert(2, f"Focused review: {entry.reviewed.isoformat()}.")
-    info = _fact_info(entry, "maintenance", "About maintenance status", details)
+    info = _fact_info("About maintenance status", details)
     status_value = (
         '<span class="status-label"><span class="status-dot" '
         f'aria-hidden="true"></span>{html.escape(status.label)}</span>'

--- a/scripts/build_catalog.py
+++ b/scripts/build_catalog.py
@@ -9,18 +9,49 @@ from __future__ import annotations
 
 import argparse
 import base64
+import datetime as dt
 import hashlib
 import html
 import json
 import posixpath
 import re
 import shutil
+import subprocess
 import sys
 from dataclasses import dataclass, replace
 from html.parser import HTMLParser
 from pathlib import Path, PurePosixPath
 from typing import Any, Iterable
 from urllib.parse import quote, unquote, urlsplit, urlunsplit
+
+if __package__:
+    from .catalog_maintenance import (
+        LIFECYCLES,
+        MaintenancePolicyError,
+        MaintenanceStatus,
+        compute_status,
+        load_policy,
+    )
+    from .example_stack_facts import (
+        StackDeclaration,
+        StackFacts,
+        extract_example_stack_facts,
+        parse_stack_declaration,
+    )
+else:
+    from catalog_maintenance import (  # type: ignore[no-redef]
+        LIFECYCLES,
+        MaintenancePolicyError,
+        MaintenanceStatus,
+        compute_status,
+        load_policy,
+    )
+    from example_stack_facts import (  # type: ignore[no-redef]
+        StackDeclaration,
+        StackFacts,
+        extract_example_stack_facts,
+        parse_stack_declaration,
+    )
 
 try:
     import markdown
@@ -209,6 +240,12 @@ class CatalogEntry:
     contributor: str | None = None
     upstream_url: str | None = None
     readme_body: str = ""
+    lifecycle: str = "Active"
+    reviewed: dt.date | None = None
+    last_activity: dt.date | None = None
+    stack_declaration: StackDeclaration | None = None
+    stack: StackFacts | None = None
+    maintenance: MaintenanceStatus | None = None
 
     @property
     def readme_path(self) -> str:
@@ -261,6 +298,23 @@ class CatalogEntry:
 
     @property
     def search_text(self) -> str:
+        stack_values: tuple[str, ...] = ()
+        if self.stack is not None:
+            stack_values = tuple(
+                value
+                for component in (
+                    self.stack.nemoclaw,
+                    self.stack.harness,
+                    self.stack.openshell,
+                )
+                if component.status != "not-applicable"
+                for value in (
+                    component.name,
+                    component.version,
+                    component.status,
+                )
+                if value
+            ) + (self.stack.status,)
         values = (
             self.title,
             self.description,
@@ -270,6 +324,9 @@ class CatalogEntry:
             self.display_label,
             self.contributor or "",
             " ".join(collection.title for collection in self.collections),
+            self.lifecycle,
+            self.maintenance.label if self.maintenance else "",
+            *stack_values,
         )
         return " ".join(value for value in values if value)
 
@@ -457,6 +514,11 @@ CATALOG_FIELD_ORDER = (
     "Description",
     "Industry",
     "Requirements",
+    "NemoClaw",
+    "Harness",
+    "OpenShell",
+    "Lifecycle",
+    "Reviewed",
     "Upstream",
     "Contributor",
     "Collection",
@@ -595,8 +657,13 @@ def _parse_catalog_row(line: str, readme_path: str) -> tuple[str, str]:
             f"Catalog metadata field {field!r} must have a trimmed value in "
             f"{readme_path}."
         )
+    stack_field = field in {"NemoClaw", "Harness", "OpenShell"}
+    marked_up = re.search(
+        r"[`*_\[\]]" if stack_field else r"[`*_~\[\]<>]",
+        value,
+    )
     if any(ord(character) < 32 for character in value) or (
-        field != "Upstream" and re.search(r"[`*_~\[\]<>]", value)
+        field != "Upstream" and marked_up
     ):
         raise CatalogError(
             f"Catalog metadata field {field!r} must be plain text in {readme_path}."
@@ -724,7 +791,14 @@ def parse_readme_metadata(
             + ", ".join(CATALOG_FIELD_ORDER)
             + "."
         )
-    missing_fields = {"Description", "Industry", "Requirements"} - set(fields)
+    missing_fields = {
+        "Description",
+        "Industry",
+        "Requirements",
+        "NemoClaw",
+        "Harness",
+        "OpenShell",
+    } - set(fields)
     if missing_fields:
         raise CatalogError(
             f"Missing catalog metadata fields in {readme_path}: "
@@ -775,6 +849,31 @@ def parse_readme_metadata(
             f"Requirements must be at most 240 characters in {readme_path}."
         )
 
+    try:
+        stack_declaration = parse_stack_declaration(
+            fields["NemoClaw"],
+            fields["Harness"],
+            fields["OpenShell"],
+        )
+    except ValueError as error:
+        raise CatalogError(f"Invalid runtime stack metadata in {readme_path}: {error}.") from error
+
+    lifecycle = fields.get("Lifecycle", "Active")
+    if lifecycle not in LIFECYCLES:
+        raise CatalogError(
+            f"Lifecycle must be Active or Deprecated in {readme_path}."
+        )
+    reviewed: dt.date | None = None
+    if reviewed_value := fields.get("Reviewed"):
+        if re.fullmatch(r"\d{4}-\d{2}-\d{2}", reviewed_value) is None:
+            raise CatalogError(f"Reviewed must use YYYY-MM-DD in {readme_path}.")
+        try:
+            reviewed = dt.date.fromisoformat(reviewed_value)
+        except ValueError as error:
+            raise CatalogError(
+                f"Reviewed must be a valid calendar date in {readme_path}."
+            ) from error
+
     upstream_url = fields.get("Upstream")
     if upstream_url is not None:
         upstream_url = _validate_upstream_url(upstream_url, readme_path)
@@ -815,6 +914,9 @@ def parse_readme_metadata(
         contributor=contributor,
         upstream_url=upstream_url,
         readme_body=readme_body,
+        lifecycle=lifecycle,
+        reviewed=reviewed,
+        stack_declaration=stack_declaration,
     )
 
 
@@ -871,6 +973,118 @@ def load_catalog(
         seen_titles.add(entry.title.casefold())
         seen_ids.add(entry.id)
     return entries
+
+
+def latest_committed_activity(root: Path, entry: CatalogEntry) -> dt.date | None:
+    """Return the last committed change date for one example."""
+
+    if not (root / ".git").exists():
+        raise CatalogError(
+            "Catalog maintenance status requires Git history; build from a "
+            "full Git checkout."
+        )
+
+    def run_git(arguments: list[str], operation: str) -> str:
+        try:
+            result = subprocess.run(
+                ["git", *arguments],
+                cwd=root,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+        except (OSError, subprocess.TimeoutExpired) as error:
+            raise CatalogError(
+                f"Unable to {operation} for {entry.path}: {error}"
+            ) from error
+        if result.returncode != 0:
+            detail = result.stderr.strip() or f"git exited {result.returncode}"
+            raise CatalogError(
+                f"Unable to {operation} for {entry.path}: {detail}"
+            )
+        return result.stdout.strip()
+
+    relative_path = f"examples/{entry.path}"
+    value = run_git(
+        ["log", "-1", "--format=%ct", "--", relative_path],
+        "read committed activity",
+    )
+    if not value:
+        status = run_git(
+            [
+                "status",
+                "--porcelain",
+                "--untracked-files=all",
+                "--",
+                relative_path,
+            ],
+            "inspect uncommitted activity",
+        )
+        if status:
+            return None
+        raise CatalogError(
+            f"No Git history found for {entry.path}; use a full-history checkout."
+        )
+    try:
+        return dt.datetime.fromtimestamp(
+            int(value), tz=dt.timezone.utc
+        ).date()
+    except (OSError, OverflowError, ValueError) as error:
+        raise CatalogError(
+            f"Git returned an invalid activity timestamp for {entry.path}: {value!r}."
+        ) from error
+
+
+def enrich_catalog(
+    root: Path,
+    entries: list[CatalogEntry],
+    *,
+    today: dt.date | None = None,
+    activity_dates: dict[str, dt.date] | None = None,
+) -> list[CatalogEntry]:
+    """Add read-only runtime stack facts and computed maintenance status."""
+
+    current_day = today or dt.datetime.now(dt.timezone.utc).date()
+    policy_path = root / "scripts" / "catalog-maintenance.json"
+    try:
+        policy = load_policy(policy_path) if policy_path.is_file() else load_policy()
+        enriched: list[CatalogEntry] = []
+        for entry in entries:
+            committed_on = (
+                activity_dates.get(entry.path)
+                if activity_dates is not None and entry.path in activity_dates
+                else latest_committed_activity(root, entry)
+            )
+            # A newly added, uncommitted example uses the build date for preview.
+            committed_on = committed_on or current_day
+            if entry.stack_declaration is None:
+                raise CatalogError(f"Missing runtime stack declaration for {entry.path}.")
+            try:
+                stack = extract_example_stack_facts(
+                    root / "examples" / entry.path,
+                    entry.stack_declaration,
+                )
+            except (OSError, ValueError) as error:
+                raise CatalogError(f"Invalid runtime stack contract: {error}") from error
+            maintenance = compute_status(
+                policy,
+                committed_on=committed_on,
+                reviewed_on=entry.reviewed,
+                today=current_day,
+                lifecycle=entry.lifecycle,
+            )
+            enriched.append(
+                replace(
+                    entry,
+                    last_activity=committed_on,
+                    stack=stack,
+                    maintenance=maintenance,
+                )
+            )
+        return enriched
+    except MaintenancePolicyError as error:
+        raise CatalogError(f"Invalid catalog maintenance policy: {error}") from error
 
 
 def _markdown_cell(value: str) -> str:
@@ -1184,6 +1398,7 @@ def industry_filter_options(entries: list[CatalogEntry]) -> str:
 
 def render_card(entry: CatalogEntry) -> str:
     collections = " ".join(entry.collection_ids)
+    maintenance_id = entry.maintenance.id if entry.maintenance else "current"
     collection_tags = "".join(
         f'<li class="tag tag-collection">{html.escape(collection.metadata_value)}</li>'
         for collection in entry.collections
@@ -1198,6 +1413,7 @@ def render_card(entry: CatalogEntry) -> str:
   data-category="{entry.category.id}"
   data-industry="{entry.industry_id}"
   data-collections="{html.escape(collections, quote=True)}"
+  data-maintenance="{maintenance_id}"
   data-search="{html.escape(entry.search_text, quote=True)}"
   tabindex="-1"
 >
@@ -1301,7 +1517,7 @@ def public_catalog(
     for entry in entries:
         industry_counts[entry.industry] += 1
     return {
-        "schema_version": 3,
+        "schema_version": 4,
         "source": "https://github.com/NVIDIA/nemoclaw-community/tree/main/examples",
         "categories": [
             {
@@ -1354,6 +1570,15 @@ def public_catalog(
                 "contributor": entry.contributor,
                 "collections": list(entry.collection_ids),
                 "requirements": entry.requirements,
+                "lifecycle": entry.lifecycle,
+                "reviewed": entry.reviewed.isoformat() if entry.reviewed else None,
+                "last_activity": (
+                    entry.last_activity.isoformat() if entry.last_activity else None
+                ),
+                "stack": entry.stack.as_dict() if entry.stack else None,
+                "maintenance": (
+                    entry.maintenance.to_dict() if entry.maintenance else None
+                ),
                 "upstream_url": entry.upstream_url,
                 "source_path": entry.readme_path,
                 "guide_url": entry.guide_url,
@@ -1390,9 +1615,46 @@ def render_llms(entries: list[CatalogEntry]) -> str:
                 f"  - Category: {entry.category.title}",
                 f"  - Industry: {entry.industry_label}",
                 f"  - Requirements: {entry.requirements}",
+                f"  - Lifecycle: {entry.lifecycle}",
                 f"  - Source: [README]({entry.guide_url})",
             )
         )
+        if entry.stack:
+            nemoclaw_version = (
+                entry.stack.nemoclaw.version
+                or (
+                    "N/A"
+                    if entry.stack.nemoclaw.status == "not-applicable"
+                    else "Unknown"
+                )
+            )
+            harness_na = entry.stack.harness.status == "not-applicable"
+            harness_name = entry.stack.harness.name or (
+                "N/A" if harness_na else "Unknown"
+            )
+            harness_version = (
+                entry.stack.harness.version
+                or ("N/A" if harness_na else "Unknown")
+            )
+            openshell_version = (
+                entry.stack.openshell.version
+                or (
+                    "N/A"
+                    if entry.stack.openshell.status == "not-applicable"
+                    else "Unknown"
+                )
+            )
+            lines.extend(
+                (
+                    f"  - NemoClaw version: {nemoclaw_version}",
+                    f"  - Harness: {harness_name}",
+                    f"  - Harness version: {harness_version}",
+                    f"  - OpenShell version: {openshell_version}",
+                    f"  - Stack verification: {entry.stack.status}",
+                )
+            )
+        if entry.maintenance:
+            lines.append(f"  - Maintenance: {entry.maintenance.label}")
         if entry.collections:
             lines.append(
                 "  - Collections: "
@@ -1418,6 +1680,15 @@ def taxonomy_contract() -> dict[str, Any]:
             for collection in COLLECTION_DEFINITIONS
         },
         "industries": ["all", *(slugify(industry) for industry in INDUSTRIES)],
+        "maintenance": [
+            "maintained",
+            "all",
+            "current",
+            "review-soon",
+            "review-due",
+            "review-overdue",
+            "deprecated",
+        ],
     }
 
 
@@ -1847,6 +2118,108 @@ def _detail_relative(entry: CatalogEntry, target: str) -> str:
     return posixpath.relpath(target, detail_dir)
 
 
+def _display_stack_value(value: str | None, status: str) -> str:
+    if status == "not-applicable":
+        return "N/A"
+    if value:
+        return html.escape(value)
+    return '<span class="fact-unknown">Unknown</span>'
+
+
+def _fact_info(entry: CatalogEntry, suffix: str, label: str, lines: list[str]) -> str:
+    tooltip_id = f"{entry.id}-{suffix}-details"
+    content = "".join(f"<span>{html.escape(line)}</span>" for line in lines)
+    return (
+        f'<span class="fact-info" tabindex="0" '
+        f'aria-label="{html.escape(label, quote=True)}" '
+        f'aria-describedby="{tooltip_id}">'
+        '<span aria-hidden="true">i</span>'
+        f'<span class="fact-popover" id="{tooltip_id}" role="tooltip">'
+        f"{content}</span></span>"
+    )
+
+
+def render_stack_facts(entry: CatalogEntry) -> str:
+    stack = entry.stack
+    if stack is None:
+        return ""
+    if stack.harness.status == "not-applicable":
+        harness = "N/A"
+    elif stack.harness.name:
+        harness = " ".join(
+            (
+                html.escape(stack.harness.name),
+                _display_stack_value(stack.harness.version, stack.harness.status),
+            )
+        )
+    else:
+        harness = _display_stack_value(stack.harness.version, stack.harness.status)
+    openshell_version = _display_stack_value(
+        stack.openshell.version,
+        stack.openshell.status,
+    )
+    status_label = {
+        "confirmed": "Confirmed",
+        "unconfirmed": "Unconfirmed",
+        "unpinned": "Unpinned",
+        "unknown": "Unknown",
+        "conflict": "Conflict",
+        "not-applicable": "Not applicable",
+    }[stack.status]
+    details = [
+        re.sub(
+            r" from NemoClaw v?\d+(?:\.\d+){2,3}",
+            " from background release metadata",
+            reason,
+        )
+        for reason in stack.reasons
+        if not reason.startswith("NemoClaw")
+    ] or ["All displayed runtime stack facts were confirmed."]
+    if len(stack.evidence_paths) > 3:
+        evidence = ", ".join(stack.evidence_paths[:2])
+        evidence += f", and {len(stack.evidence_paths) - 2} more standardized files"
+    else:
+        evidence = ", ".join(stack.evidence_paths)
+    details.append(
+        f"Evidence: {evidence}."
+        if evidence
+        else "Evidence: no standardized runtime source found."
+    )
+    info = _fact_info(entry, "stack", "About stack metadata", details)
+    status_value = (
+        '<span class="status-label"><span class="status-dot" '
+        f'aria-hidden="true"></span>{html.escape(status_label)}</span>'
+    )
+    return (
+        f"<div><dt>Harness</dt><dd>{harness}</dd></div>"
+        f"<div><dt>OpenShell</dt><dd>{openshell_version}</dd></div>"
+        f'<div class="stack-status-fact stack-status-{stack.status}">'
+        f"<dt>Stack verification</dt><dd>{status_value}{info}</dd></div>"
+    )
+
+
+def render_maintenance_fact(entry: CatalogEntry) -> str:
+    status = entry.maintenance
+    if status is None or entry.last_activity is None:
+        return ""
+    details = [
+        status.summary,
+        f"Last committed change: {entry.last_activity.isoformat()}.",
+        f"Lifecycle: {entry.lifecycle}.",
+    ]
+    if entry.reviewed is not None:
+        details.insert(2, f"Focused review: {entry.reviewed.isoformat()}.")
+    info = _fact_info(entry, "maintenance", "About maintenance status", details)
+    status_value = (
+        '<span class="status-label"><span class="status-dot" '
+        f'aria-hidden="true"></span>{html.escape(status.label)}</span>'
+    )
+    return (
+        f'<div class="maintenance-fact maintenance-tone-{status.tone}">'
+        f"<dt>Maintenance</dt><dd>{status_value}{info}</dd></div>"
+    )
+
+
 def render_detail_pages(
     root: Path,
     entries: list[CatalogEntry],
@@ -1907,7 +2280,9 @@ def render_detail_pages(
             "{{CATEGORY}}": html.escape(entry.category.singular),
             "{{ATTRIBUTION_FACT}}": attribution_fact,
             "{{UPSTREAM_FACT}}": upstream_fact,
+            "{{STACK_FACTS}}": render_stack_facts(entry),
             "{{REQUIREMENTS}}": html.escape(entry.requirements),
+            "{{MAINTENANCE_FACT}}": render_maintenance_fact(entry),
             "{{TABLE_OF_CONTENTS}}": toc_html,
             "{{README_HTML}}": indent(readme_html, 12),
             "{{DIAGRAM_SCRIPTS}}": diagram_scripts,
@@ -2049,6 +2424,7 @@ def validate_generated_site(
         "catalog-view-industry",
         "catalog-category",
         "catalog-industry",
+        "catalog-maintenance",
         "catalog-reset",
         "catalog-status",
         "catalog-empty",
@@ -2079,6 +2455,7 @@ def validate_generated_site(
         "catalog-view-industry",
         "catalog-category",
         "catalog-industry",
+        "catalog-maintenance",
     }
     missing_labels = required_labels - parser.labels_for
     if missing_labels:
@@ -2105,6 +2482,9 @@ def validate_generated_site(
             "data-category": entry.category.id,
             "data-industry": entry.industry_id,
             "data-collections": " ".join(entry.collection_ids),
+            "data-maintenance": (
+                entry.maintenance.id if entry.maintenance else "current"
+            ),
         }
         for entry in entries
     ]
@@ -2391,9 +2771,20 @@ class CatalogOutputs:
     copied_assets: set[str]
 
 
-def expected_outputs(root: Path) -> CatalogOutputs:
+def expected_outputs(
+    root: Path,
+    *,
+    today: dt.date | None = None,
+    activity_dates: dict[str, dt.date] | None = None,
+) -> CatalogOutputs:
     categories, collections = load_discovery_groups(root)
     entries = load_catalog(root, categories, collections)
+    entries = enrich_catalog(
+        root,
+        entries,
+        today=today,
+        activity_dates=activity_dates,
+    )
     template_path = root / "site" / "index.template.html"
     detail_template_path = root / "site" / "detail.template.html"
     try:

--- a/scripts/catalog-maintenance.json
+++ b/scripts/catalog-maintenance.json
@@ -3,5 +3,5 @@
   "review-soon": 30,
   "review-due": 60,
   "review-overdue": 120,
-  "deprecated": 240
+  "review-critical": 240
 }

--- a/scripts/catalog-maintenance.json
+++ b/scripts/catalog-maintenance.json
@@ -1,0 +1,7 @@
+{
+  "current": 0,
+  "review-soon": 30,
+  "review-due": 60,
+  "review-overdue": 120,
+  "deprecated": 240
+}

--- a/scripts/catalog_maintenance.py
+++ b/scripts/catalog_maintenance.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Load catalog maintenance policy and compute deterministic age status."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+DEFAULT_POLICY_PATH = Path(__file__).with_name("catalog-maintenance.json")
+STATUS_DETAILS = (
+    ("current", "Current", "green"),
+    ("review-soon", "Review soon", "light-orange"),
+    ("review-due", "Review due", "orange"),
+    ("review-overdue", "Review overdue", "dark-orange"),
+    ("deprecated", "Deprecated", "red"),
+)
+STATUS_IDS = tuple(status_id for status_id, _label, _tone in STATUS_DETAILS)
+LIFECYCLES = {"Active", "Deprecated"}
+ISO_DATE = re.compile(r"\d{4}-\d{2}-\d{2}\Z")
+
+
+class MaintenancePolicyError(ValueError):
+    """Raised when policy or status inputs are invalid."""
+
+
+@dataclass(frozen=True)
+class MaintenanceBand:
+    id: str
+    minimum_days: int
+    label: str
+    tone: str
+
+
+@dataclass(frozen=True)
+class MaintenancePolicy:
+    bands: tuple[MaintenanceBand, ...]
+
+
+@dataclass(frozen=True)
+class MaintenanceStatus:
+    id: str
+    label: str
+    summary: str
+    tone: str
+
+    def to_dict(self) -> dict[str, str]:
+        """Return a JSON-serializable representation."""
+
+        return asdict(self)
+
+
+def load_policy(path: str | Path = DEFAULT_POLICY_PATH) -> MaintenancePolicy:
+    """Load and strictly validate the five ordered maintenance age bands."""
+
+    policy_path = Path(path)
+    try:
+        thresholds = json.loads(policy_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise MaintenancePolicyError(
+            f"Unable to load {policy_path}: {error}"
+        ) from error
+    if not isinstance(thresholds, dict) or set(thresholds) != set(STATUS_IDS):
+        raise MaintenancePolicyError(
+            "Policy must contain exactly the canonical maintenance status IDs."
+        )
+
+    bands: list[MaintenanceBand] = []
+    for status_id, label, tone in STATUS_DETAILS:
+        days = thresholds[status_id]
+        if isinstance(days, bool) or not isinstance(days, int) or days < 0:
+            raise MaintenancePolicyError(
+                "Policy thresholds must be nonnegative integers."
+            )
+        bands.append(MaintenanceBand(status_id, days, label, tone))
+    minimums = [band.minimum_days for band in bands]
+    if minimums[0] != 0 or any(a >= b for a, b in zip(minimums, minimums[1:])):
+        raise MaintenancePolicyError("Band thresholds must start at zero and increase.")
+    return MaintenancePolicy(tuple(bands))
+
+
+def _date(value: dt.date | str, field: str) -> dt.date:
+    if type(value) is dt.date:
+        return value
+    if not isinstance(value, str) or ISO_DATE.fullmatch(value) is None:
+        raise MaintenancePolicyError(f"{field} must use YYYY-MM-DD.")
+    try:
+        return dt.date.fromisoformat(value)
+    except ValueError as error:
+        raise MaintenancePolicyError(f"{field} is not a valid date.") from error
+
+
+def compute_status(
+    policy: MaintenancePolicy,
+    *,
+    committed_on: dt.date | str,
+    today: dt.date | str,
+    reviewed_on: dt.date | str | None = None,
+    lifecycle: str = "Active",
+) -> MaintenanceStatus:
+    """Compute status from the latest activity date using an injected today."""
+
+    if lifecycle not in LIFECYCLES:
+        raise MaintenancePolicyError(f"Unsupported lifecycle: {lifecycle!r}.")
+    current_day = _date(today, "today")
+    committed = _date(committed_on, "committed_on")
+    reviewed = _date(reviewed_on, "reviewed_on") if reviewed_on is not None else None
+    if committed > current_day or (reviewed is not None and reviewed > current_day):
+        raise MaintenancePolicyError("Maintenance dates cannot be after today.")
+
+    if lifecycle == "Deprecated":
+        band = policy.bands[-1]
+        summary = "Explicitly deprecated by lifecycle metadata."
+    else:
+        activity = max(committed, reviewed) if reviewed is not None else committed
+        age = (current_day - activity).days
+        band = next(
+            candidate
+            for candidate in reversed(policy.bands)
+            if age >= candidate.minimum_days
+        )
+        summary = (
+            "Latest committed change or focused review was "
+            f"{age} day{'s' if age != 1 else ''} ago."
+        )
+    return MaintenanceStatus(band.id, band.label, summary, band.tone)

--- a/scripts/catalog_maintenance.py
+++ b/scripts/catalog_maintenance.py
@@ -20,8 +20,9 @@ STATUS_DETAILS = (
     ("review-soon", "Review soon", "light-orange"),
     ("review-due", "Review due", "orange"),
     ("review-overdue", "Review overdue", "dark-orange"),
-    ("deprecated", "Deprecated", "red"),
+    ("review-critical", "Review critical", "red"),
 )
+DEPRECATED_STATUS = ("deprecated", "Deprecated", "red")
 STATUS_IDS = tuple(status_id for status_id, _label, _tone in STATUS_DETAILS)
 LIFECYCLES = {"Active", "Deprecated"}
 ISO_DATE = re.compile(r"\d{4}-\d{2}-\d{2}\Z")
@@ -116,18 +117,23 @@ def compute_status(
         raise MaintenancePolicyError("Maintenance dates cannot be after today.")
 
     if lifecycle == "Deprecated":
-        band = policy.bands[-1]
-        summary = "Explicitly deprecated by lifecycle metadata."
-    else:
-        activity = max(committed, reviewed) if reviewed is not None else committed
-        age = (current_day - activity).days
-        band = next(
-            candidate
-            for candidate in reversed(policy.bands)
-            if age >= candidate.minimum_days
+        status_id, label, tone = DEPRECATED_STATUS
+        return MaintenanceStatus(
+            status_id,
+            label,
+            "Explicitly deprecated by lifecycle metadata.",
+            tone,
         )
-        summary = (
-            "Latest committed change or focused review was "
-            f"{age} day{'s' if age != 1 else ''} ago."
-        )
+
+    activity = max(committed, reviewed) if reviewed is not None else committed
+    age = (current_day - activity).days
+    band = next(
+        candidate
+        for candidate in reversed(policy.bands)
+        if age >= candidate.minimum_days
+    )
+    summary = (
+        "Latest committed change or focused review was "
+        f"{age} day{'s' if age != 1 else ''} ago."
+    )
     return MaintenanceStatus(band.id, band.label, summary, band.tone)

--- a/scripts/example_stack_facts.py
+++ b/scripts/example_stack_facts.py
@@ -112,6 +112,12 @@ def _version_kind(value: str) -> str:
     return "invalid"
 
 
+def _normalized_exact(value: str) -> str:
+    """Return one comparison form for exact versions with an optional v prefix."""
+
+    return value[1:] if value.startswith("v") else value
+
+
 def parse_stack_declaration(
     nemoclaw: str,
     harness: str,
@@ -226,6 +232,7 @@ def _release_contracts() -> tuple[dict[str, dict[str, object]], dict[str, str]]:
         ):
             raise ValueError(f"invalid harness version in release contract for {tag}")
         aliases[tag] = tag
+        aliases[tag.removeprefix("v")] = tag
         aliases[str(record["commit"])] = tag
     return document, aliases
 
@@ -289,6 +296,8 @@ def _merge_version(
 ) -> tuple[str | None, str]:
     declaration_kind = _version_kind(declared)
     exact_detected = {value for value in detected if _version_kind(value) == "exact"}
+    normalized_detected = {_normalized_exact(value) for value in exact_detected}
+    normalized_declared = _normalized_exact(declared)
     mutable_detected = detected - exact_detected
     if declaration_kind == "n-a":
         if detected:
@@ -307,8 +316,8 @@ def _merge_version(
             return declared, "conflict"
         reasons.append(f"{label} is not pinned to one exact version.")
         return declared, "unpinned"
-    if mutable_detected or len(exact_detected) > 1 or (
-        exact_detected and declared not in exact_detected
+    if mutable_detected or len(normalized_detected) > 1 or (
+        normalized_detected and normalized_declared not in normalized_detected
     ):
         reasons.append(
             f"{label} {declared} in the README conflicts with implementation evidence: "
@@ -316,7 +325,7 @@ def _merge_version(
             + "."
         )
         return declared, "conflict"
-    if declared in exact_detected:
+    if normalized_declared in normalized_detected:
         reasons.append(f"{label} {declared} is confirmed by implementation evidence.")
         return declared, "confirmed"
     reasons.append(f"{label} {declared} is declared in the README but not statically confirmed.")

--- a/scripts/example_stack_facts.py
+++ b/scripts/example_stack_facts.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Confirm README runtime-stack declarations from a few standard code shapes."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass
+from functools import cache
+from pathlib import Path
+
+
+_SPECIAL_VALUES = {"N/A", "Unknown", "Unpinned"}
+_HARNESS_NAMES = (
+    "LangChain Deep Agents Code",
+    "LangChain Deep Agents",
+    "OpenClaw",
+    "Hermes",
+)
+_HARNESS_COMPONENTS = {
+    "Hermes": "hermes",
+    "OpenClaw": "openclaw",
+    "LangChain Deep Agents": "deepagents",
+    "LangChain Deep Agents Code": "langchain-code",
+}
+_COMPONENT_HARNESSES = {component: name for name, component in _HARNESS_COMPONENTS.items()}
+_AGENT_HARNESSES = {
+    "hermes": "Hermes",
+    "hermes-agent": "Hermes",
+    "openclaw": "OpenClaw",
+    "langchain-deepagents-code": "LangChain Deep Agents Code",
+}
+_EXACT_VERSION = re.compile(r"v?\d+(?:\.\d+){1,3}(?:[-+][0-9A-Za-z.-]+)?\Z")
+_VERSION_RANGE = re.compile(
+    r"(?:==|!=|<=|>=|~=|<|>|\^|~)\s*v?\d+(?:\.\d+){1,3}"
+    r"(?:\s*,\s*(?:==|!=|<=|>=|~=|<|>|\^|~)\s*v?\d+(?:\.\d+){1,3})*\Z"
+)
+_COMMIT = re.compile(r"[0-9a-f]{40}\Z")
+_DYNAMIC = re.compile(r"\$|`|\b(?:HEAD|develop|latest|main|master|nightly)\b", re.I)
+_ASSIGNMENT_KEYS = {
+    "nemoclaw": (
+        "NEMOCLAW_VERSION",
+        "NEMOCLAW_COMMIT",
+        "NEMOCLAW_INSTALL_TAG",
+        "NEMOCLAW_INSTALL_REF",
+    ),
+    "hermes": ("HERMES_VERSION", "HERMES_SEMVER"),
+    "openclaw": ("OPENCLAW_VERSION",),
+    "deepagents": ("DEEPAGENTS_VERSION", "DEEP_AGENTS_VERSION"),
+    "langchain-code": ("LANGCHAIN_DEEP_AGENTS_CODE_VERSION",),
+    "openshell": ("OPENSHELL_VERSION",),
+}
+_RELEASE_CONTRACT_PATH = Path(__file__).with_name("nemoclaw-release-contracts.json")
+
+
+@dataclass(frozen=True, slots=True)
+class StackDeclaration:
+    """The three human-readable stack rows from an example README."""
+
+    nemoclaw: str
+    harness_name: str | None
+    harness_version: str | None
+    harness_value: str
+    openshell: str
+
+
+@dataclass(frozen=True, slots=True)
+class ComponentFact:
+    """One displayed component after static evidence and README data are merged."""
+
+    name: str | None
+    version: str | None
+    status: str
+
+
+@dataclass(frozen=True, slots=True)
+class StackFacts:
+    """Serializable stack facts and their overall verification state."""
+
+    nemoclaw: ComponentFact
+    harness: ComponentFact
+    openshell: ComponentFact
+    status: str
+    evidence_paths: tuple[str, ...]
+    reasons: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, object]:
+        """Return JSON-compatible primitives."""
+
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class _Detected:
+    values: dict[str, set[str]]
+    paths: dict[str, set[str]]
+    harness_names: set[str]
+    notes: list[str]
+
+
+def _version_kind(value: str) -> str:
+    if value in _SPECIAL_VALUES:
+        return value.casefold().replace("/", "-")
+    if _EXACT_VERSION.fullmatch(value):
+        return "exact"
+    if _VERSION_RANGE.fullmatch(value):
+        return "range"
+    return "invalid"
+
+
+def parse_stack_declaration(
+    nemoclaw: str,
+    harness: str,
+    openshell: str,
+) -> StackDeclaration:
+    """Parse the deliberately small README stack grammar."""
+
+    if _version_kind(nemoclaw) == "invalid":
+        raise ValueError("NemoClaw must be an exact/ranged version, Unpinned, Unknown, or N/A")
+    if _version_kind(openshell) == "invalid":
+        raise ValueError("OpenShell must be an exact/ranged version, Unpinned, Unknown, or N/A")
+    if harness in _SPECIAL_VALUES:
+        harness_name = None
+        harness_version = None
+    else:
+        harness_name = next(
+            (name for name in _HARNESS_NAMES if harness.startswith(name + " ")),
+            None,
+        )
+        if harness_name is None:
+            raise ValueError(
+                "Harness must name Hermes, OpenClaw, LangChain Deep Agents, "
+                "or LangChain Deep Agents Code"
+            )
+        harness_version = harness.removeprefix(harness_name + " ")
+        if _version_kind(harness_version) == "invalid" or harness_version == "N/A":
+            raise ValueError(
+                "Harness must pair its name with an exact/ranged version, Unpinned, or Unknown"
+            )
+    return StackDeclaration(
+        nemoclaw,
+        harness_name,
+        harness_version,
+        harness,
+        openshell,
+    )
+
+
+def _runtime_files(root: Path) -> list[Path]:
+    """Return supported Dockerfiles; custom layouts fall back to README data."""
+
+    candidates = list(root.glob("Dockerfile*"))
+    candidates.extend(root.glob("agents/*/Dockerfile*"))
+    files: list[Path] = []
+    for path in sorted(set(candidates)):
+        try:
+            relative = path.relative_to(root)
+        except ValueError:
+            continue
+        prefixes = (
+            root.joinpath(*relative.parts[:index])
+            for index in range(1, len(relative.parts) + 1)
+        )
+        if (
+            path.is_file()
+            and path.stat().st_size <= 1_000_000
+            and not any(candidate.is_symlink() for candidate in prefixes)
+        ):
+            files.append(path)
+    return files
+
+
+def _active_text(path: Path) -> str:
+    """Remove full-line comments without interpreting a scripting language."""
+
+    return "\n".join(
+        line
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if not line.lstrip().startswith("#")
+    )
+
+
+def _assignment_values(text: str, keys: tuple[str, ...]) -> set[str]:
+    key_pattern = "|".join(re.escape(key) for key in keys)
+    pattern = re.compile(
+        rf"\b(?:{key_pattern})\s*(?:=|:)\s*[\"']?(?P<value>[^\s\"';,]+)",
+    )
+    values: set[str] = set()
+    for match in pattern.finditer(text):
+        value = match.group("value").rstrip("}])")
+        if _EXACT_VERSION.fullmatch(value) or _VERSION_RANGE.fullmatch(value) or _COMMIT.fullmatch(value):
+            values.add(value)
+        elif _DYNAMIC.search(value):
+            values.add("Unpinned")
+    return values
+
+
+@cache
+def _release_contracts() -> tuple[dict[str, dict[str, object]], dict[str, str]]:
+    document = json.loads(_RELEASE_CONTRACT_PATH.read_text(encoding="utf-8"))
+    if not isinstance(document, dict):
+        raise ValueError("NemoClaw release contracts must be an object")
+    aliases: dict[str, str] = {}
+    for tag, record in document.items():
+        if (
+            not isinstance(tag, str)
+            or not re.fullmatch(r"v\d+(?:\.\d+){2}", tag)
+            or not isinstance(record, dict)
+        ):
+            raise ValueError(f"invalid NemoClaw release contract: {tag!r}")
+        expected = {"commit", "openshell", "harnesses"}
+        if set(record) != expected or not _COMMIT.fullmatch(str(record["commit"])):
+            raise ValueError(f"invalid NemoClaw release contract for {tag}")
+        if _version_kind(str(record["openshell"])) != "exact":
+            raise ValueError(f"invalid OpenShell release contract for {tag}")
+        harnesses = record["harnesses"]
+        if not isinstance(harnesses, dict) or not harnesses:
+            raise ValueError(f"invalid harness release contract for {tag}")
+        if any(
+            name not in _HARNESS_NAMES or _version_kind(str(version)) != "exact"
+            for name, version in harnesses.items()
+        ):
+            raise ValueError(f"invalid harness version in release contract for {tag}")
+        aliases[tag] = tag
+        aliases[str(record["commit"])] = tag
+    return document, aliases
+
+
+def _scan(root: Path) -> _Detected:
+    values = {key: set() for key in _ASSIGNMENT_KEYS}
+    paths = {key: set() for key in values}
+    harness_names: set[str] = set()
+    notes: list[str] = []
+    for path in _runtime_files(root):
+        relative = path.relative_to(root).as_posix()
+        text = _active_text(path)
+        for component, keys in _ASSIGNMENT_KEYS.items():
+            found = _assignment_values(text, keys)
+            if found:
+                values[component].update(found)
+                paths[component].add(relative)
+                harness_name = _COMPONENT_HARNESSES.get(component)
+                if harness_name:
+                    harness_names.add(harness_name)
+        for agent in re.findall(r"\bNEMOCLAW_AGENT\s*=\s*[\"']?([A-Za-z-]+)", text):
+            harness = _AGENT_HARNESSES.get(agent.casefold())
+            if harness:
+                harness_names.add(harness)
+            else:
+                notes.append(f"NemoClaw agent selection {agent!r} is not recognized.")
+
+    contracts, aliases = _release_contracts()
+    identities = values["nemoclaw"] - {"Unpinned"}
+    releases = {aliases[value] for value in identities if value in aliases}
+    unknown_identities = identities - set(aliases)
+    if unknown_identities or len(releases) > 1 or (releases and "Unpinned" in values["nemoclaw"]):
+        notes.append("NemoClaw evidence is unknown, mutable, or conflicting.")
+    elif len(releases) == 1:
+        tag = next(iter(releases))
+        values["nemoclaw"] = {tag}
+        contract = contracts[tag]
+        if len(harness_names) == 1:
+            harness_name = next(iter(harness_names))
+            stock_version = contract["harnesses"].get(harness_name)  # type: ignore[union-attr]
+            key = _HARNESS_COMPONENTS[harness_name]
+            if stock_version and not values.get(key):
+                values[key].add(str(stock_version))
+                paths[key].update(paths["nemoclaw"])
+                notes.append(f"{harness_name} {stock_version} is inferred from NemoClaw {tag}.")
+        elif not harness_names:
+            notes.append(
+                f"NemoClaw {tag} is pinned, but no standard harness selection was found."
+            )
+        values["openshell"].add(str(contract["openshell"]))
+        paths["openshell"].update(paths["nemoclaw"])
+        notes.append(f"OpenShell {contract['openshell']} is inferred from NemoClaw {tag}.")
+    return _Detected(values, paths, harness_names, notes)
+
+
+def _merge_version(
+    label: str,
+    declared: str,
+    detected: set[str],
+    reasons: list[str],
+) -> tuple[str | None, str]:
+    declaration_kind = _version_kind(declared)
+    exact_detected = {value for value in detected if _version_kind(value) == "exact"}
+    mutable_detected = detected - exact_detected
+    if declaration_kind == "n-a":
+        if detected:
+            reasons.append(f"{label} is declared N/A but implementation evidence was found.")
+            return None, "conflict"
+        return None, "not-applicable"
+    if declaration_kind == "unknown":
+        if detected:
+            reasons.append(f"{label} is Unknown in the README but implementation evidence was found.")
+            return None, "conflict"
+        reasons.append(f"{label} is not declared or detected.")
+        return None, "unknown"
+    if declaration_kind in {"unpinned", "range"}:
+        if exact_detected and not mutable_detected:
+            reasons.append(f"{label} is {declared} in the README but code contains an exact value.")
+            return declared, "conflict"
+        reasons.append(f"{label} is not pinned to one exact version.")
+        return declared, "unpinned"
+    if mutable_detected or len(exact_detected) > 1 or (
+        exact_detected and declared not in exact_detected
+    ):
+        reasons.append(
+            f"{label} {declared} in the README conflicts with implementation evidence: "
+            + ", ".join(sorted(detected))
+            + "."
+        )
+        return declared, "conflict"
+    if declared in exact_detected:
+        reasons.append(f"{label} {declared} is confirmed by implementation evidence.")
+        return declared, "confirmed"
+    reasons.append(f"{label} {declared} is declared in the README but not statically confirmed.")
+    return declared, "unconfirmed"
+
+
+def extract_example_stack_facts(
+    example_root: str | Path,
+    declaration: StackDeclaration,
+) -> StackFacts:
+    """Merge a README declaration with conservative, fixed-shape static evidence."""
+
+    root = Path(example_root)
+    detected = _scan(root)
+    reasons = list(detected.notes)
+
+    nemoclaw_version, nemoclaw_status = _merge_version(
+        "NemoClaw", declaration.nemoclaw, detected.values["nemoclaw"], reasons
+    )
+
+    detected_harness_name = (
+        next(iter(detected.harness_names)) if len(detected.harness_names) == 1 else None
+    )
+    harness_detected = detected.values.get(
+        _HARNESS_COMPONENTS.get(declaration.harness_name or "", ""),
+        set(),
+    )
+    if len(detected.harness_names) > 1 or (
+        declaration.harness_name
+        and detected_harness_name
+        and declaration.harness_name != detected_harness_name
+    ):
+        harness_name = declaration.harness_name
+        harness_version = declaration.harness_version
+        harness_status = "conflict"
+        reasons.append(
+            "Harness declaration conflicts with detected harnesses: "
+            + ", ".join(sorted(detected.harness_names))
+            + "."
+        )
+    elif declaration.harness_value == "N/A":
+        harness_name = None
+        harness_version = None
+        harness_status = "not-applicable" if not detected.harness_names else "conflict"
+        if harness_status == "conflict":
+            reasons.append("Harness is declared N/A but a harness was detected.")
+    elif declaration.harness_value == "Unknown":
+        harness_name = None
+        harness_version = None
+        harness_status = "unknown" if not detected.harness_names else "conflict"
+        reasons.append("Harness name and version are not established.")
+    elif declaration.harness_value == "Unpinned":
+        harness_name = detected_harness_name
+        harness_version = "Unpinned"
+        harness_status = "unpinned"
+        reasons.append("Harness is not pinned to one exact version.")
+    else:
+        harness_name = declaration.harness_name
+        harness_version, harness_status = _merge_version(
+            f"{harness_name} harness",
+            declaration.harness_version or "Unknown",
+            harness_detected,
+            reasons,
+        )
+        if harness_status == "confirmed" and not detected_harness_name:
+            harness_status = "unconfirmed"
+        if harness_status == "unconfirmed" and detected_harness_name == harness_name:
+            reasons.append(f"The {harness_name} name is detected, but its version is README-only.")
+
+    openshell_version, openshell_status = _merge_version(
+        "OpenShell", declaration.openshell, detected.values["openshell"], reasons
+    )
+    statuses = {nemoclaw_status, harness_status, openshell_status}
+    if statuses == {"not-applicable"}:
+        status = "not-applicable"
+    elif "conflict" in statuses:
+        status = "conflict"
+    elif "unknown" in statuses:
+        status = "unknown"
+    elif "unpinned" in statuses:
+        status = "unpinned"
+    elif "unconfirmed" in statuses:
+        status = "unconfirmed"
+    else:
+        status = "confirmed"
+
+    evidence_paths = set().union(*detected.paths.values())
+    if status == "not-applicable":
+        reasons.append("This example declares no NemoClaw, harness, or OpenShell runtime.")
+    elif not evidence_paths:
+        reasons.append("No standardized runtime source was found; displayed values come from the README.")
+    return StackFacts(
+        ComponentFact("NemoClaw", nemoclaw_version, nemoclaw_status),
+        ComponentFact(harness_name, harness_version, harness_status),
+        ComponentFact("OpenShell", openshell_version, openshell_status),
+        status,
+        tuple(sorted(evidence_paths)),
+        tuple(dict.fromkeys(reasons)),
+    )

--- a/scripts/nemoclaw-release-contracts.json
+++ b/scripts/nemoclaw-release-contracts.json
@@ -1,0 +1,11 @@
+{
+  "v0.0.104": {
+    "commit": "f389c9d872775006ae069473f58250fa8f3ad40f",
+    "openshell": "0.0.85",
+    "harnesses": {
+      "OpenClaw": "2026.7.1",
+      "Hermes": "0.19.0",
+      "LangChain Deep Agents Code": "0.1.34"
+    }
+  }
+}

--- a/scripts/tests/catalog.test.mjs
+++ b/scripts/tests/catalog.test.mjs
@@ -132,11 +132,17 @@ test("industry view matches an exact industry slug", () => {
 
 test("maintenance defaults to nondeprecated examples and supports exact states", () => {
   const current = { maintenance: "current" };
+  const reviewCritical = { maintenance: "review-critical" };
   const deprecated = { maintenance: "deprecated" };
 
   assert.equal(matchesCatalogRecord(current), true);
+  assert.equal(matchesCatalogRecord(reviewCritical), true);
   assert.equal(matchesCatalogRecord(deprecated), false);
   assert.equal(matchesCatalogRecord(deprecated, { maintenance: "all" }), true);
+  assert.equal(
+    matchesCatalogRecord(reviewCritical, { maintenance: "review-critical" }),
+    true,
+  );
   assert.equal(
     matchesCatalogRecord(current, { maintenance: "review-due" }),
     false,

--- a/scripts/tests/catalog.test.mjs
+++ b/scripts/tests/catalog.test.mjs
@@ -10,6 +10,7 @@ import {
   CATALOG_CATEGORIES,
   CATALOG_COLLECTION_CATEGORIES,
   CATALOG_INDUSTRIES,
+  CATALOG_MAINTENANCE,
   DEFAULT_CATALOG_STATE,
   canonicalizeCatalogState,
   initCatalog,
@@ -129,6 +130,19 @@ test("industry view matches an exact industry slug", () => {
   );
 });
 
+test("maintenance defaults to nondeprecated examples and supports exact states", () => {
+  const current = { maintenance: "current" };
+  const deprecated = { maintenance: "deprecated" };
+
+  assert.equal(matchesCatalogRecord(current), true);
+  assert.equal(matchesCatalogRecord(deprecated), false);
+  assert.equal(matchesCatalogRecord(deprecated, { maintenance: "all" }), true);
+  assert.equal(
+    matchesCatalogRecord(current, { maintenance: "review-due" }),
+    false,
+  );
+});
+
 test("invalid URL values canonicalize to defaults", () => {
   assert.deepEqual(
     parseCatalogURLState("?q=%20GPU%20%20cloud%20&view=map&category=unknown&industry=finance"),
@@ -183,6 +197,7 @@ test("client facet identifiers match the README catalog builder", () => {
     taxonomy.collection_categories,
   );
   assert.deepEqual(CATALOG_INDUSTRIES, taxonomy.industries);
+  assert.deepEqual(CATALOG_MAINTENANCE, taxonomy.maintenance);
 });
 
 test("category information buttons toggle one description at a time", () => {
@@ -265,6 +280,7 @@ function fakeCatalogDOM() {
       category: "nvidia-recipes",
       industry: "financial-services",
       collections: "",
+      maintenance: "current",
       search: "payment operations",
     },
   });
@@ -273,6 +289,7 @@ function fakeCatalogDOM() {
       category: "partner-recipes",
       industry: "financial-services",
       collections: "",
+      maintenance: "current",
       search: "x402 payment",
     },
   });
@@ -293,6 +310,7 @@ function fakeCatalogDOM() {
   const partnerGroup = group("partner-recipes", [partnerCard]);
   const category = fakeControl({ value: "all" });
   const industry = fakeControl({ value: "all" });
+  const maintenance = fakeControl({ value: "maintained" });
   const categoryWrapper = fakeControl({
     dataset: { filterFor: "category" },
     querySelectorAll: () => [category],
@@ -315,6 +333,7 @@ function fakeCatalogDOM() {
     "catalog-view-industry": fakeControl(),
     "catalog-category": category,
     "catalog-industry": industry,
+    "catalog-maintenance": maintenance,
     "catalog-reset": fakeControl(),
     "catalog-status": fakeControl({ textContent: "" }),
     "catalog-empty": fakeControl({ hidden: true }),

--- a/scripts/tests/test_build_catalog.py
+++ b/scripts/tests/test_build_catalog.py
@@ -544,6 +544,20 @@ class CatalogBuildTests(unittest.TestCase):
                 facts_panel.count('class="status-dot" aria-hidden="true"'),
                 2,
             )
+            self.assertEqual(facts_panel.count('<details class="fact-info">'), 2)
+            self.assertIn(
+                '<summary aria-label="About stack metadata">', facts_panel
+            )
+            self.assertIn(
+                '<summary aria-label="About maintenance status">', facts_panel
+            )
+            self.assertNotIn('role="tooltip"', facts_panel)
+            self.assertNotIn('tabindex="0"', facts_panel)
+            self.assertIn(
+                "This reflects repository activity only, not support, quality, "
+                "or runtime health.",
+                facts_panel,
+            )
             self.assertIn("Maintenance", page)
             self.assertIn(f"stack-status-{entry.stack.status}", page)
             self.assertIn(f"maintenance-tone-{entry.maintenance.tone}", page)

--- a/scripts/tests/test_build_catalog.py
+++ b/scripts/tests/test_build_catalog.py
@@ -5,10 +5,13 @@
 
 from __future__ import annotations
 
+import datetime as dt
 import html
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 
 from scripts.build_catalog import (
     CATEGORY_DEFINITIONS,
@@ -23,6 +26,7 @@ from scripts.build_catalog import (
     check_catalog,
     expected_outputs,
     extract_mermaid_sources,
+    latest_committed_activity,
     load_catalog,
     load_discovery_groups,
     public_catalog,
@@ -79,6 +83,9 @@ class CatalogBuildTests(unittest.TestCase):
             "description": "Produces a small observable fixture result.",
             "industry": "Other",
             "requirements": "Python 3 · local/static",
+            "nemoclaw": "N/A",
+            "harness": "N/A",
+            "openshell": "N/A",
         }
         if record:
             values.update(record)
@@ -91,8 +98,17 @@ class CatalogBuildTests(unittest.TestCase):
             f"| Description | {values['description']} |",
             f"| Industry | {industry_cell} |",
             f"| Requirements | {values['requirements']} |",
+            f"| NemoClaw | {values['nemoclaw']} |",
+            f"| Harness | {values['harness']} |",
+            f"| OpenShell | {values['openshell']} |",
         ]
-        for field in ("Upstream", "Contributor", "Collection"):
+        for field in (
+            "Lifecycle",
+            "Reviewed",
+            "Upstream",
+            "Contributor",
+            "Collection",
+        ):
             value = values.get(field.casefold())
             if value:
                 rows.append(f"| {field} | {value} |")
@@ -244,6 +260,62 @@ class CatalogBuildTests(unittest.TestCase):
         with self.assertRaisesRegex(CatalogError, "Example README is empty"):
             load_catalog(root)
 
+    def test_committed_activity_requires_a_git_checkout(self) -> None:
+        root = self._fixture_root()
+        entry = load_catalog(root)[0]
+
+        with self.assertRaisesRegex(CatalogError, "requires Git history"):
+            latest_committed_activity(root, entry)
+
+    def test_committed_activity_uses_a_utc_epoch(self) -> None:
+        root = self._fixture_root()
+        (root / ".git").mkdir()
+        entry = load_catalog(root)[0]
+
+        with patch("scripts.build_catalog.subprocess.run") as run:
+            run.return_value = SimpleNamespace(
+                returncode=0,
+                stdout="1788136200\n",
+                stderr="",
+            )
+            activity = latest_committed_activity(root, entry)
+
+        self.assertEqual(activity, dt.date(2026, 8, 31))
+        self.assertIn("--format=%ct", run.call_args.args[0])
+
+    def test_uncommitted_new_example_uses_the_build_date(self) -> None:
+        root = self._fixture_root()
+        (root / ".git").mkdir()
+        entry = load_catalog(root)[0]
+
+        with patch("scripts.build_catalog.subprocess.run") as run:
+            run.side_effect = (
+                SimpleNamespace(returncode=0, stdout="", stderr=""),
+                SimpleNamespace(
+                    returncode=0,
+                    stdout=f"?? examples/{entry.path}/README.md\n",
+                    stderr="",
+                ),
+            )
+            activity = latest_committed_activity(root, entry)
+
+        self.assertIsNone(activity)
+        self.assertEqual(run.call_count, 2)
+        self.assertIn("status", run.call_args.args[0])
+
+    def test_clean_example_without_history_requires_a_full_checkout(self) -> None:
+        root = self._fixture_root()
+        (root / ".git").mkdir()
+        entry = load_catalog(root)[0]
+
+        with patch("scripts.build_catalog.subprocess.run") as run:
+            run.side_effect = (
+                SimpleNamespace(returncode=0, stdout="", stderr=""),
+                SimpleNamespace(returncode=0, stdout="", stderr=""),
+            )
+            with self.assertRaisesRegex(CatalogError, "full-history checkout"):
+                latest_committed_activity(root, entry)
+
     def test_path_derives_kind_and_recipe_provenance(self) -> None:
         entry = load_catalog(self._fixture_root())[0]
 
@@ -274,6 +346,17 @@ class CatalogBuildTests(unittest.TestCase):
 
         with self.assertRaisesRegex(CatalogError, "Missing.*Description"):
             load_catalog(root)
+
+    def test_runtime_stack_rows_are_required_and_strict(self) -> None:
+        for field, value in (
+            ("NemoClaw", "latest"),
+            ("Harness", "AnyAgent 1.0.0"),
+            ("OpenShell", "current"),
+        ):
+            with self.subTest(field=field):
+                root = self._fixture_root({field.casefold(): value})
+                with self.assertRaisesRegex(CatalogError, "runtime stack metadata"):
+                    load_catalog(root)
 
     def test_catalog_table_requires_a_supported_position(self) -> None:
         root = self._fixture_root()
@@ -315,6 +398,25 @@ class CatalogBuildTests(unittest.TestCase):
 
                 with self.assertRaisesRegex(CatalogError, message):
                     load_catalog(root)
+
+    def test_optional_lifecycle_and_review_date_are_strict(self) -> None:
+        entry = load_catalog(
+            self._fixture_root(
+                {"lifecycle": "Active", "reviewed": "2026-08-01"}
+            )
+        )[0]
+        self.assertEqual(entry.lifecycle, "Active")
+        self.assertEqual(entry.reviewed.isoformat(), "2026-08-01")
+
+        for record in (
+            {"lifecycle": "Stable"},
+            {"lifecycle": "Archived"},
+            {"reviewed": "2026-02-30"},
+            {"reviewed": "August 1, 2026"},
+        ):
+            with self.subTest(record=record):
+                with self.assertRaises(CatalogError):
+                    load_catalog(self._fixture_root(record))
 
     def test_industry_navigation_wraps_slash_labels_at_word_boundaries(self) -> None:
         entries = load_catalog(
@@ -399,6 +501,9 @@ class CatalogBuildTests(unittest.TestCase):
             "Produces a small observable fixture result.",
         )
         self.assertEqual(example["requirements"], "Python 3 · local/static")
+        self.assertEqual(example["lifecycle"], "Active")
+        self.assertIsNone(example["stack"])
+        self.assertIsNone(example["maintenance"])
         self.assertEqual(
             example["detail_url"], "examples/recipes/community/sample/"
         )
@@ -427,6 +532,21 @@ class CatalogBuildTests(unittest.TestCase):
                 page,
             )
             self.assertIn("Requirements &amp; limits", page)
+            facts_panel = page.split('<aside class="detail-facts"', 1)[1].split(
+                "</aside>", 1
+            )[0]
+            self.assertIn("<dt>Harness</dt>", facts_panel)
+            self.assertIn("<dt>OpenShell</dt>", facts_panel)
+            self.assertNotIn("<dt>NemoClaw</dt>", facts_panel)
+            self.assertNotIn("<dt>Harness version</dt>", facts_panel)
+            self.assertNotRegex(facts_panel, r"NemoClaw v?\d")
+            self.assertEqual(
+                facts_panel.count('class="status-dot" aria-hidden="true"'),
+                2,
+            )
+            self.assertIn("Maintenance", page)
+            self.assertIn(f"stack-status-{entry.stack.status}", page)
+            self.assertIn(f"maintenance-tone-{entry.maintenance.tone}", page)
             self.assertNotIn("Catalog field", page)
             self.assertIn('id="readme" tabindex="-1"', page)
             self.assertNotRegex(page, r'<(?:iframe|object|embed)\b')
@@ -450,6 +570,18 @@ class CatalogBuildTests(unittest.TestCase):
                 self.assertIn("diagrams.mjs", page)
             else:
                 self.assertNotIn("<script", page)
+        generated_index = public_catalog(
+            entries,
+            outputs.categories,
+            outputs.collections,
+        )
+        self.assertEqual(generated_index["schema_version"], 4)
+        self.assertTrue(
+            all(example["stack"] for example in generated_index["examples"])
+        )
+        self.assertTrue(
+            all(example["maintenance"] for example in generated_index["examples"])
+        )
         self.assertGreater(mermaid_pages, 0)
         self.assertGreater(mermaid_diagrams, 0)
 
@@ -623,7 +755,6 @@ class CatalogBuildTests(unittest.TestCase):
 
     def test_readme_compiler_rejects_missing_fragments(self) -> None:
         root = self._fixture_root(body="[Missing](README.md#not-present)\n")
-        example = root / "examples" / "recipes" / "community" / "sample"
         entry = load_catalog(root)[0]
         with self.assertRaisesRegex(CatalogError, "unresolved local fragments"):
             render_readme_html(root, entry, {entry.readme_path: entry}, set())

--- a/scripts/tests/test_catalog_maintenance.py
+++ b/scripts/tests/test_catalog_maintenance.py
@@ -36,7 +36,13 @@ class CatalogMaintenanceTests(unittest.TestCase):
     def test_default_policy_has_five_monotonic_bands(self) -> None:
         self.assertEqual(
             [band.id for band in self.policy.bands],
-            ["current", "review-soon", "review-due", "review-overdue", "deprecated"],
+            [
+                "current",
+                "review-soon",
+                "review-due",
+                "review-overdue",
+                "review-critical",
+            ],
         )
         self.assertEqual(
             [band.minimum_days for band in self.policy.bands], [0, 30, 60, 120, 240]
@@ -57,8 +63,8 @@ class CatalogMaintenanceTests(unittest.TestCase):
             119: "review-due",
             120: "review-overdue",
             239: "review-overdue",
-            240: "deprecated",
-            900: "deprecated",
+            240: "review-critical",
+            900: "review-critical",
         }
         for age, expected in cases.items():
             with self.subTest(age=age):

--- a/scripts/tests/test_catalog_maintenance.py
+++ b/scripts/tests/test_catalog_maintenance.py
@@ -1,0 +1,175 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused tests for catalog maintenance age policy."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.catalog_maintenance import (
+    DEFAULT_POLICY_PATH,
+    MaintenancePolicyError,
+    compute_status,
+    load_policy,
+)
+
+
+class CatalogMaintenanceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.policy = load_policy()
+
+    def _policy_file(self, value: object) -> Path:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        path = Path(temporary.name) / "policy.json"
+        path.write_text(json.dumps(value), encoding="utf-8")
+        return path
+
+    def _policy_value(self) -> dict[str, int]:
+        return json.loads(DEFAULT_POLICY_PATH.read_text(encoding="utf-8"))
+
+    def test_default_policy_has_five_monotonic_bands(self) -> None:
+        self.assertEqual(
+            [band.id for band in self.policy.bands],
+            ["current", "review-soon", "review-due", "review-overdue", "deprecated"],
+        )
+        self.assertEqual(
+            [band.minimum_days for band in self.policy.bands], [0, 30, 60, 120, 240]
+        )
+        styles = (Path(__file__).parents[2] / "site/styles.css").read_text(
+            encoding="utf-8"
+        )
+        for band in self.policy.bands:
+            self.assertIn(f".maintenance-tone-{band.tone}", styles)
+
+    def test_every_age_boundary(self) -> None:
+        cases = {
+            0: "current",
+            29: "current",
+            30: "review-soon",
+            59: "review-soon",
+            60: "review-due",
+            119: "review-due",
+            120: "review-overdue",
+            239: "review-overdue",
+            240: "deprecated",
+            900: "deprecated",
+        }
+        for age, expected in cases.items():
+            with self.subTest(age=age):
+                # Use date arithmetic so leap years cannot distort the boundary.
+                today = dt.date(2026, 8, 31)
+                committed = today - dt.timedelta(days=age)
+                self.assertEqual(
+                    compute_status(self.policy, committed_on=committed, today=today).id,
+                    expected,
+                )
+
+    def test_latest_review_or_commit_controls_age(self) -> None:
+        reviewed = compute_status(
+            self.policy,
+            committed_on="2025-01-01",
+            reviewed_on="2026-08-15",
+            today="2026-08-31",
+        )
+        committed = compute_status(
+            self.policy,
+            committed_on="2026-08-20",
+            reviewed_on="2025-01-01",
+            today="2026-08-31",
+        )
+        self.assertEqual(reviewed.id, "current")
+        self.assertEqual(committed.id, "current")
+        self.assertEqual(
+            reviewed.summary,
+            "Latest committed change or focused review was 16 days ago.",
+        )
+        self.assertEqual(
+            committed.summary,
+            "Latest committed change or focused review was 11 days ago.",
+        )
+
+    def test_explicit_deprecation_is_immediate_and_serializable(self) -> None:
+        status = compute_status(
+            self.policy,
+            committed_on="2026-08-31",
+            today="2026-08-31",
+            lifecycle="Deprecated",
+        )
+        self.assertEqual(
+            status.to_dict(),
+            {
+                "id": "deprecated",
+                "label": "Deprecated",
+                "summary": "Explicitly deprecated by lifecycle metadata.",
+                "tone": "red",
+            },
+        )
+        json.dumps(status.to_dict())
+
+    def test_dates_are_strict_valid_and_not_future(self) -> None:
+        for value in ("2026-8-01", "20260801", "2026-02-30", "", 20260801):
+            with self.subTest(value=value):
+                with self.assertRaises(MaintenancePolicyError):
+                    compute_status(
+                        self.policy,
+                        committed_on=value,  # type: ignore[arg-type]
+                        today="2026-08-31",
+                    )
+        with self.assertRaisesRegex(MaintenancePolicyError, "after today"):
+            compute_status(self.policy, committed_on="2026-09-01", today="2026-08-31")
+        with self.assertRaisesRegex(MaintenancePolicyError, "after today"):
+            compute_status(
+                self.policy,
+                committed_on="2026-08-01",
+                reviewed_on="2026-09-01",
+                today="2026-08-31",
+            )
+
+    def test_policy_rejects_shape_and_threshold_errors(self) -> None:
+        invalid: list[object] = [[]]
+        missing_status = self._policy_value()
+        del missing_status["review-soon"]
+        invalid.append(missing_status)
+        unknown_status = self._policy_value()
+        unknown_status["unknown"] = 10
+        invalid.append(unknown_status)
+        non_monotonic = self._policy_value()
+        non_monotonic["review-due"] = 30
+        invalid.append(non_monotonic)
+        boolean_days = self._policy_value()
+        boolean_days["review-soon"] = True  # type: ignore[assignment]
+        invalid.append(boolean_days)
+
+        for index, value in enumerate(invalid):
+            with self.subTest(index=index):
+                with self.assertRaises(MaintenancePolicyError):
+                    load_policy(self._policy_file(value))
+
+    def test_policy_rejects_bad_json_and_unknown_lifecycle(self) -> None:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        path = Path(temporary.name) / "bad.json"
+        path.write_text("{", encoding="utf-8")
+        with self.assertRaises(MaintenancePolicyError):
+            load_policy(path)
+        for lifecycle in ("Stable", "Unknown"):
+            with self.subTest(lifecycle=lifecycle):
+                with self.assertRaisesRegex(
+                    MaintenancePolicyError, "Unsupported lifecycle"
+                ):
+                    compute_status(
+                        self.policy,
+                        committed_on="2026-08-01",
+                        today="2026-08-31",
+                        lifecycle=lifecycle,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_example_stack_facts.py
+++ b/scripts/tests/test_example_stack_facts.py
@@ -1,0 +1,204 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused tests for README stack declarations and fixed-shape confirmation."""
+
+from __future__ import annotations
+
+import re
+import sys
+import tempfile
+import unittest
+from collections import Counter
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from example_stack_facts import (  # noqa: E402
+    extract_example_stack_facts,
+    parse_stack_declaration,
+)
+
+
+class ExampleStackFactsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name) / "sample"
+        self.root.mkdir()
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def write(self, relative: str, content: str) -> None:
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+    def facts(
+        self,
+        nemoclaw: str,
+        harness: str,
+        openshell: str,
+    ):
+        declaration = parse_stack_declaration(nemoclaw, harness, openshell)
+        return extract_example_stack_facts(self.root, declaration)
+
+    def test_readme_stack_grammar_is_small_and_strict(self) -> None:
+        valid = (
+            ("v0.0.104", "OpenClaw 2026.7.1", "0.0.85"),
+            ("N/A", "Hermes >=0.19.0", "Unknown"),
+            ("Unpinned", "OpenClaw Unpinned", "Unpinned"),
+            ("N/A", "N/A", "N/A"),
+        )
+        for values in valid:
+            with self.subTest(values=values):
+                parse_stack_declaration(*values)
+
+        invalid = (
+            ("latest", "OpenClaw 2026.7.1", "0.0.85"),
+            ("v0.0.104", "Any agent", "0.0.85"),
+            ("v0.0.104", "Hermes", "0.0.85"),
+            ("v0.0.104", "Hermes 0.19.0", "current"),
+        )
+        for values in invalid:
+            with self.subTest(values=values), self.assertRaises(ValueError):
+                parse_stack_declaration(*values)
+
+    def test_exact_nemoclaw_release_confirms_stock_stack(self) -> None:
+        self.write(
+            "Dockerfile",
+            "ARG NEMOCLAW_VERSION=v0.0.104\n"
+            "ARG NEMOCLAW_COMMIT=f389c9d872775006ae069473f58250fa8f3ad40f\n"
+            "ARG NEMOCLAW_AGENT=openclaw\n"
+            "ARG OPENSHELL_VERSION=0.0.85\n",
+        )
+
+        facts = self.facts("v0.0.104", "OpenClaw 2026.7.1", "0.0.85")
+
+        self.assertEqual(facts.status, "confirmed")
+        self.assertEqual(facts.nemoclaw.version, "v0.0.104")
+        self.assertEqual(facts.harness.version, "2026.7.1")
+        self.assertEqual(facts.openshell.version, "0.0.85")
+        self.assertIn("inferred from NemoClaw", " ".join(facts.reasons))
+
+    def test_nemoclaw_langchain_selector_uses_the_release_contract(self) -> None:
+        self.write(
+            "Dockerfile",
+            "ARG NEMOCLAW_VERSION=v0.0.104\n"
+            "ARG NEMOCLAW_AGENT=langchain-deepagents-code\n",
+        )
+
+        facts = self.facts(
+            "v0.0.104", "LangChain Deep Agents Code 0.1.34", "0.0.85"
+        )
+
+        self.assertEqual(facts.status, "confirmed")
+        self.assertEqual(facts.harness.name, "LangChain Deep Agents Code")
+
+    def test_direct_harness_can_mix_confirmed_and_readme_only_values(self) -> None:
+        self.write(
+            "agents/hermes/Dockerfile",
+            "ARG HERMES_SEMVER=0.20.0\nFROM example/hermes:${HERMES_SEMVER}\n",
+        )
+
+        facts = self.facts("N/A", "Hermes 0.20.0", "0.0.85")
+
+        self.assertEqual(facts.status, "unconfirmed")
+        self.assertEqual(facts.harness.status, "confirmed")
+        self.assertEqual(facts.openshell.status, "unconfirmed")
+
+    def test_readme_only_exact_values_are_unconfirmed(self) -> None:
+        facts = self.facts("v0.0.83", "Hermes 0.18.0", "0.0.72")
+
+        self.assertEqual(facts.status, "unconfirmed")
+        self.assertTrue(all(component.status == "unconfirmed" for component in (
+            facts.nemoclaw,
+            facts.harness,
+            facts.openshell,
+        )))
+
+    def test_mutable_or_ranged_declarations_are_unpinned(self) -> None:
+        facts = self.facts("Unpinned", "OpenClaw Unpinned", "Unpinned")
+
+        self.assertEqual(facts.status, "unpinned")
+        self.assertEqual(facts.nemoclaw.status, "unpinned")
+
+    def test_unknown_declaration_remains_visible(self) -> None:
+        facts = self.facts("Unpinned", "Unknown", "Unpinned")
+
+        self.assertEqual(facts.status, "unknown")
+        self.assertIsNone(facts.harness.name)
+        self.assertIn("not established", " ".join(facts.reasons))
+
+    def test_readme_and_code_disagreement_is_a_conflict(self) -> None:
+        self.write("Dockerfile", "ARG OPENSHELL_VERSION=0.0.84\n")
+
+        facts = self.facts("N/A", "N/A", "0.0.85")
+
+        self.assertEqual(facts.status, "conflict")
+        self.assertEqual(facts.openshell.status, "conflict")
+        self.assertIn("conflicts", " ".join(facts.reasons))
+
+    def test_nested_custom_layout_uses_readme_fallback(self) -> None:
+        self.write(
+            "helm/templates/startup-configmap.yaml",
+            "NEMOCLAW_INSTALL_REF=v0.0.50\nOPENSHELL_VERSION=0.0.44\n",
+        )
+
+        facts = self.facts("v0.0.50", "OpenClaw 2026.5.18", "0.0.44")
+
+        self.assertEqual(facts.status, "unconfirmed")
+        self.assertEqual(facts.evidence_paths, ())
+
+    def test_all_na_is_not_applicable(self) -> None:
+        facts = self.facts("N/A", "N/A", "N/A")
+
+        self.assertEqual(facts.status, "not-applicable")
+        self.assertEqual(facts.harness.status, "not-applicable")
+
+    def test_current_catalog_has_each_expected_verification_state(self) -> None:
+        examples = ROOT / "examples"
+        patterns = (
+            "recipes/nvidia/*",
+            "recipes/community/*",
+            "recipes/partners/*/*",
+            "demos/field/*",
+            "tools/*",
+        )
+        roots = sorted(
+            path
+            for pattern in patterns
+            for path in examples.glob(pattern)
+            if path.is_dir() and (path / "README.md").is_file()
+        )
+        states: Counter[str] = Counter()
+        for root in roots:
+            rows = dict(
+                re.findall(
+                    r"^\| ([A-Za-z]+) \| ([^|]+) \|$",
+                    (root / "README.md").read_text(encoding="utf-8"),
+                    re.MULTILINE,
+                )
+            )
+            declaration = parse_stack_declaration(
+                rows["NemoClaw"], rows["Harness"], rows["OpenShell"]
+            )
+            states[extract_example_stack_facts(root, declaration).status] += 1
+
+        self.assertEqual(
+            states,
+            Counter(
+                {
+                    "unconfirmed": 6,
+                    "unpinned": 10,
+                    "unknown": 1,
+                    "not-applicable": 1,
+                }
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_example_stack_facts.py
+++ b/scripts/tests/test_example_stack_facts.py
@@ -97,6 +97,27 @@ class ExampleStackFactsTests(unittest.TestCase):
         self.assertEqual(facts.status, "confirmed")
         self.assertEqual(facts.harness.name, "LangChain Deep Agents Code")
 
+    def test_nemoclaw_release_allows_mixed_v_prefixes(self) -> None:
+        self.write(
+            "Dockerfile",
+            "ARG NEMOCLAW_VERSION=0.0.104\n"
+            "ARG NEMOCLAW_AGENT=openclaw\n",
+        )
+
+        facts = self.facts("v0.0.104", "OpenClaw 2026.7.1", "v0.0.85")
+
+        self.assertEqual(facts.status, "confirmed")
+        self.assertEqual(facts.nemoclaw.status, "confirmed")
+        self.assertEqual(facts.openshell.status, "confirmed")
+
+    def test_direct_component_allows_mixed_v_prefixes(self) -> None:
+        self.write("Dockerfile", "ARG OPENSHELL_VERSION=v0.0.85\n")
+
+        facts = self.facts("N/A", "N/A", "0.0.85")
+
+        self.assertEqual(facts.status, "confirmed")
+        self.assertEqual(facts.openshell.status, "confirmed")
+
     def test_direct_harness_can_mix_confirmed_and_readme_only_values(self) -> None:
         self.write(
             "agents/hermes/Dockerfile",

--- a/site/catalog.mjs
+++ b/site/catalog.mjs
@@ -59,6 +59,7 @@ export const CATALOG_MAINTENANCE = Object.freeze([
   "review-soon",
   "review-due",
   "review-overdue",
+  "review-critical",
   "deprecated",
 ]);
 

--- a/site/catalog.mjs
+++ b/site/catalog.mjs
@@ -6,6 +6,7 @@ export const DEFAULT_CATALOG_STATE = Object.freeze({
   view: "category",
   category: "all",
   industry: "all",
+  maintenance: "maintained",
 });
 
 export const CATALOG_VIEWS = Object.freeze(["category", "industry"]);
@@ -51,9 +52,20 @@ export const CATALOG_INDUSTRIES = Object.freeze([
   "other",
 ]);
 
+export const CATALOG_MAINTENANCE = Object.freeze([
+  "maintained",
+  "all",
+  "current",
+  "review-soon",
+  "review-due",
+  "review-overdue",
+  "deprecated",
+]);
+
 const viewValues = new Set(CATALOG_VIEWS);
 const categoryValues = new Set(CATALOG_CATEGORIES);
 const industryValues = new Set(CATALOG_INDUSTRIES);
+const maintenanceValues = new Set(CATALOG_MAINTENANCE);
 
 export function normalizeWhitespace(value) {
   return String(value ?? "").trim().replace(/\s+/gu, " ");
@@ -101,6 +113,11 @@ export function canonicalizeCatalogState(state = {}) {
         DEFAULT_CATALOG_STATE.industry,
       )
       : DEFAULT_CATALOG_STATE.industry,
+    maintenance: allowedOrDefault(
+      state.maintenance,
+      maintenanceValues,
+      DEFAULT_CATALOG_STATE.maintenance,
+    ),
   };
 }
 
@@ -125,6 +142,7 @@ export function parseCatalogURLState(source = "") {
     view: params.get("view") ?? DEFAULT_CATALOG_STATE.view,
     category: params.get("category") ?? DEFAULT_CATALOG_STATE.category,
     industry: params.get("industry") ?? DEFAULT_CATALOG_STATE.industry,
+    maintenance: params.get("maintenance") ?? DEFAULT_CATALOG_STATE.maintenance,
   });
 }
 
@@ -143,6 +161,9 @@ export function serializeCatalogURLState(state = {}) {
   }
   if (canonical.industry !== DEFAULT_CATALOG_STATE.industry) {
     params.set("industry", canonical.industry);
+  }
+  if (canonical.maintenance !== DEFAULT_CATALOG_STATE.maintenance) {
+    params.set("maintenance", canonical.maintenance);
   }
 
   return params.toString();
@@ -189,6 +210,15 @@ export function matchesCatalogRecord(record, state = {}) {
     canonical.view === "industry"
     && canonical.industry !== "all"
     && recordValue(record, "industry") !== canonical.industry
+  ) {
+    return false;
+  }
+
+  const maintenance = recordValue(record, "maintenance");
+  if (
+    canonical.maintenance !== "all"
+    && !(canonical.maintenance === "maintained" && maintenance !== "deprecated")
+    && maintenance !== canonical.maintenance
   ) {
     return false;
   }
@@ -287,6 +317,7 @@ export function initCatalog({
   const industryView = documentObject.getElementById("catalog-view-industry");
   const category = documentObject.getElementById("catalog-category");
   const industry = documentObject.getElementById("catalog-industry");
+  const maintenance = documentObject.getElementById("catalog-maintenance");
   const reset = documentObject.getElementById("catalog-reset");
   const status = documentObject.getElementById("catalog-status");
   const empty = documentObject.getElementById("catalog-empty");
@@ -302,6 +333,7 @@ export function initCatalog({
     || !industryView
     || !category
     || !industry
+    || !maintenance
     || !reset
     || !status
     || !empty
@@ -321,6 +353,7 @@ export function initCatalog({
     search.value = state.q;
     category.value = state.category;
     industry.value = state.industry;
+    maintenance.value = state.maintenance;
     setViewControlState(categoryView, state.view === "category");
     setViewControlState(industryView, state.view === "industry");
     categoryPanel.hidden = state.view !== "category";
@@ -379,6 +412,14 @@ export function initCatalog({
         && next.industry !== targetCard.dataset.industry
       ) {
         next.industry = "all";
+      }
+      const targetMaintenance = targetCard.dataset.maintenance;
+      if (
+        next.maintenance !== "all"
+        && !(next.maintenance === "maintained" && targetMaintenance !== "deprecated")
+        && next.maintenance !== targetMaintenance
+      ) {
+        next.maintenance = "all";
       }
     }
 
@@ -463,6 +504,10 @@ export function initCatalog({
 
   industry.addEventListener("change", () => {
     commit({ ...state, industry: industry.value }, "push");
+  });
+
+  maintenance.addEventListener("change", () => {
+    commit({ ...state, maintenance: maintenance.value }, "push");
   });
 
   reset.addEventListener("click", () => {

--- a/site/detail.template.html
+++ b/site/detail.template.html
@@ -53,7 +53,9 @@
               <div><dt>Industry</dt><dd>{{INDUSTRY}}</dd></div>
               {{ATTRIBUTION_FACT}}
               {{UPSTREAM_FACT}}
+              {{STACK_FACTS}}
               <div><dt>Requirements &amp; limits</dt><dd>{{REQUIREMENTS}}</dd></div>
+              {{MAINTENANCE_FACT}}
             </dl>
             <a class="button button-primary detail-source" href="{{SOURCE_URL}}">
               View source on GitHub <span aria-hidden="true">↗</span>

--- a/site/index.template.html
+++ b/site/index.template.html
@@ -191,6 +191,21 @@
             </div>
           </div>
 
+          <div class="filter-control">
+            <label for="catalog-maintenance">Maintenance</label>
+            <div class="select-shell">
+              <select id="catalog-maintenance">
+                <option value="maintained">Maintained examples</option>
+                <option value="all">All maintenance states</option>
+                <option value="current">Current</option>
+                <option value="review-soon">Review soon</option>
+                <option value="review-due">Review due</option>
+                <option value="review-overdue">Review overdue</option>
+                <option value="deprecated">Deprecated</option>
+              </select>
+            </div>
+          </div>
+
           <div class="control-summary">
             <p id="catalog-status" role="status" aria-live="polite">{{EXAMPLE_COUNT}} examples shown</p>
             <button class="reset-button" id="catalog-reset" type="button" disabled>Reset filters</button>

--- a/site/index.template.html
+++ b/site/index.template.html
@@ -201,6 +201,7 @@
                 <option value="review-soon">Review soon</option>
                 <option value="review-due">Review due</option>
                 <option value="review-overdue">Review overdue</option>
+                <option value="review-critical">Review critical</option>
                 <option value="deprecated">Deprecated</option>
               </select>
             </div>

--- a/site/styles.css
+++ b/site/styles.css
@@ -15,6 +15,16 @@
   --line: #353535;
   --line-strong: #656565;
   --tile-line: #4d692e;
+  --status-green: #76b900;
+  --status-green-bg: #1e310d;
+  --status-light-orange: #f2b866;
+  --status-light-orange-bg: #382a18;
+  --status-orange: #f29f3d;
+  --status-orange-bg: #3d2710;
+  --status-dark-orange: #dc7929;
+  --status-dark-orange-bg: #3a1f0e;
+  --status-red: #ee6666;
+  --status-red-bg: #3b1717;
   --shell: clamp(74rem, 90vw, 120rem);
 }
 
@@ -1029,14 +1039,14 @@ h3 {
 }
 
 .detail-facts {
-  padding: 1.25rem;
+  padding: 1.1rem;
   border: 1px solid var(--line);
   border-top: 3px solid var(--nvidia-green);
   background: var(--surface);
 }
 
 .detail-facts h2 {
-  margin-bottom: 1rem;
+  margin-bottom: 0.85rem;
   font-size: 1rem;
   font-weight: 600;
 }
@@ -1047,12 +1057,187 @@ h3 {
   margin: 0;
 }
 
-.detail-facts dl div {
+.detail-facts dl > div {
   display: grid;
   grid-template-columns: minmax(6rem, 0.7fr) minmax(0, 1.3fr);
   gap: 1rem;
-  padding-block: 0.7rem;
+  padding-block: 0.62rem;
   border-top: 1px solid var(--line);
+}
+
+.detail-facts .maintenance-fact,
+.detail-facts .stack-status-fact {
+  position: relative;
+  margin-inline: -0.65rem;
+  padding-inline: 0.65rem;
+  border-radius: 0.3rem;
+}
+
+.detail-facts .maintenance-fact dd,
+.detail-facts .stack-status-fact dd {
+  padding-right: 1.8rem;
+}
+
+.stack-status-fact dt {
+  white-space: nowrap;
+}
+
+.status-label {
+  position: relative;
+}
+
+.status-dot {
+  position: absolute;
+  top: 50%;
+  left: -0.67rem;
+  width: 0.42rem;
+  height: 0.42rem;
+  border-radius: 50%;
+  background: #969696;
+  transform: translateY(-50%);
+}
+
+.maintenance-tone-green .status-dot,
+.stack-status-confirmed .status-dot {
+  background: var(--status-green);
+}
+
+.maintenance-tone-light-orange .status-dot,
+.stack-status-unconfirmed .status-dot {
+  background: var(--status-light-orange);
+}
+
+.maintenance-tone-orange .status-dot,
+.stack-status-unknown .status-dot {
+  background: var(--status-orange);
+}
+
+.maintenance-tone-dark-orange .status-dot,
+.stack-status-unpinned .status-dot {
+  background: var(--status-dark-orange);
+}
+
+.maintenance-tone-red .status-dot,
+.stack-status-conflict .status-dot {
+  background: var(--status-red);
+}
+
+.maintenance-tone-green {
+  background: var(--status-green-bg);
+  box-shadow: inset 3px 0 var(--status-green);
+}
+
+.maintenance-tone-light-orange {
+  background: var(--status-light-orange-bg);
+  box-shadow: inset 3px 0 var(--status-light-orange);
+}
+
+.maintenance-tone-orange {
+  background: var(--status-orange-bg);
+  box-shadow: inset 3px 0 var(--status-orange);
+}
+
+.maintenance-tone-dark-orange {
+  background: var(--status-dark-orange-bg);
+  box-shadow: inset 3px 0 var(--status-dark-orange);
+}
+
+.maintenance-tone-red {
+  background: var(--status-red-bg);
+  box-shadow: inset 3px 0 var(--status-red);
+}
+
+.stack-status-unknown {
+  background: var(--status-orange-bg);
+  box-shadow: inset 3px 0 var(--status-orange);
+}
+
+.stack-status-confirmed {
+  background: var(--status-green-bg);
+  box-shadow: inset 3px 0 var(--status-green);
+}
+
+.stack-status-unconfirmed {
+  background: var(--status-light-orange-bg);
+  box-shadow: inset 3px 0 var(--status-light-orange);
+}
+
+.stack-status-unpinned {
+  background: var(--status-dark-orange-bg);
+  box-shadow: inset 3px 0 var(--status-dark-orange);
+}
+
+.stack-status-conflict {
+  background: var(--status-red-bg);
+  box-shadow: inset 3px 0 var(--status-red);
+}
+
+.fact-unknown {
+  color: #d1d1d1;
+  font-style: italic;
+}
+
+.fact-info {
+  position: absolute;
+  z-index: 3;
+  top: 0.45rem;
+  right: 0.55rem;
+  display: grid;
+  width: 1.2rem;
+  height: 1.2rem;
+  place-items: center;
+  border: 1px solid #858585;
+  border-radius: 50%;
+  color: #e5e5e5;
+  cursor: help;
+  font-size: 0.68rem;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.fact-info:focus-visible {
+  outline-width: 2px;
+  outline-offset: 2px;
+}
+
+.fact-popover {
+  position: absolute;
+  z-index: 4;
+  top: calc(100% + 0.55rem);
+  right: 0;
+  display: none;
+  width: min(20rem, calc(100vw - 3rem));
+  padding: 0.8rem;
+  border: 1px solid var(--line-strong);
+  border-radius: 0.35rem;
+  background: #101010;
+  box-shadow: 0 0.75rem 2rem rgb(0 0 0 / 35%);
+  color: var(--ink-soft);
+  font-size: 0.75rem;
+  font-weight: 400;
+  line-height: 1.45;
+  text-align: left;
+}
+
+.fact-popover > span {
+  display: block;
+}
+
+.fact-popover > span + span {
+  margin-top: 0.35rem;
+}
+
+.fact-info:hover .fact-popover,
+.fact-info:focus .fact-popover,
+.fact-info:focus-within .fact-popover {
+  display: block;
+}
+
+.fact-info:hover,
+.fact-info:focus,
+.fact-info:focus-within {
+  z-index: 5;
 }
 
 .detail-facts dt,
@@ -1460,6 +1645,7 @@ h3 {
     grid-template-columns:
       minmax(22rem, 1.8fr)
       minmax(18rem, 1fr)
+      minmax(16rem, 0.9fr)
       minmax(17rem, 0.65fr);
     align-items: end;
   }
@@ -1483,7 +1669,7 @@ h3 {
   }
 
   .detail-hero-grid {
-    grid-template-columns: minmax(0, 1fr) minmax(22rem, 26rem);
+    grid-template-columns: minmax(0, 1fr) minmax(20rem, 24rem);
   }
 }
 
@@ -1674,9 +1860,14 @@ h3 {
     flex-direction: column;
   }
 
-  .detail-facts dl div {
+  .detail-facts dl > div {
     grid-template-columns: 1fr;
     gap: 0.2rem;
+  }
+
+  .fact-popover {
+    top: auto;
+    bottom: calc(100% + 0.55rem);
   }
 }
 

--- a/site/styles.css
+++ b/site/styles.css
@@ -1182,21 +1182,36 @@ h3 {
   z-index: 3;
   top: 0.45rem;
   right: 0.55rem;
-  display: grid;
+  display: block;
   width: 1.2rem;
   height: 1.2rem;
-  place-items: center;
   border: 1px solid #858585;
   border-radius: 50%;
   color: #e5e5e5;
-  cursor: help;
   font-size: 0.68rem;
   font-style: normal;
   font-weight: 700;
   line-height: 1;
 }
 
-.fact-info:focus-visible {
+.fact-info summary {
+  display: grid;
+  width: 100%;
+  height: 100%;
+  place-items: center;
+  cursor: pointer;
+  list-style: none;
+}
+
+.fact-info summary::-webkit-details-marker {
+  display: none;
+}
+
+.fact-info summary::marker {
+  content: "";
+}
+
+.fact-info summary:focus-visible {
   outline-width: 2px;
   outline-offset: 2px;
 }
@@ -1228,15 +1243,11 @@ h3 {
   margin-top: 0.35rem;
 }
 
-.fact-info:hover .fact-popover,
-.fact-info:focus .fact-popover,
-.fact-info:focus-within .fact-popover {
+.fact-info[open] .fact-popover {
   display: block;
 }
 
-.fact-info:hover,
-.fact-info:focus,
-.fact-info:focus-within {
+.fact-info[open] {
   z-index: 5;
 }
 


### PR DESCRIPTION
## Related Issue

N/A

## Description

- Detect the harness and OpenShell versions from standardized runtime Dockerfiles, using README metadata only as an unconfirmed fallback.
- Show stack verification and maintenance status in each catalog detail page At a Glance table, including clear current, aging, deprecated, and unknown states.
- Document the contribution contract, centralize the adjustable maintenance thresholds and NemoClaw release mappings, and validate the generated metadata in CI.

## Screenshots

### Verified stack and current maintenance

<img width="589" height="610" alt="image" src="https://github.com/user-attachments/assets/7fc2875e-b635-4d76-9ee1-630b81a7ffb4" />

### Unconfirmed or unknown stack

#### Unconfirmed

<img width="624" height="579" alt="image" src="https://github.com/user-attachments/assets/c4faf503-b7d9-4113-a66f-83af12e3b753" />

#### Unpinned

<img width="592" height="554" alt="image" src="https://github.com/user-attachments/assets/616db4c2-9aba-45e6-9aae-bf7d80687378" />

## Verification

- [x] `python3 scripts/check_license_headers.py --check`
- [x] `python3 scripts/check_label_taxonomy.py --check`
- [x] `git diff --check`
- [x] `python3 scripts/build_catalog.py --validate-metadata`
- [x] `python3 scripts/build_catalog.py --check`
- [x] Focused catalog Python suite: 58 passed
- [x] Full `scripts/tests` Python discovery: 62 passed
- [x] Node tests: 13 passed

## Documentation Writer Review

- [x] Documentation writer review completed for the final changes
- Result: `docs-updated`
- Evidence or justification: `README.md`, `CONTRIBUTING.md`, `docs/catalog-architecture.md`, example README catalog metadata, and the contributor taxonomy reference were reviewed at exact head `6875e768946076f2c0083b8b83a0e3697eb0b2c2`.
- Reviewer: Apurv Kumaria
- [x] Changed user-facing text follows the [writing guide](https://github.com/NVIDIA/nemoclaw-community/blob/main/WRITING.md) and [controlled-word list](https://github.com/NVIDIA/nemoclaw-community/blob/main/.agents/skills/_shared/controlled-words.md).
- [x] A public contributor can understand the changed text without internal company context.
- [x] I reviewed any agent-generated text before submission.

## Release And Compliance

- [x] No secrets or credentials are included, including API keys, access tokens, passwords, local `.env` files, private certificates, or token caches.
- [x] No nonpublic project names, environment names, hostnames, URLs, ticket identifiers, workspace paths, logs, screenshots, or configuration values are included.
- [x] Third-party dependency changes are reflected in `THIRD-PARTY-NOTICES` — no third-party dependencies were added.
- [x] Public content uses sanitized examples and placeholders instead of private values.
- [x] I added my DCO sign-off declaration to this pull request description.

Signed-off-by: Sam Pastoriza <spastoriza@nvidia.com>
