### PR TITLE
feat(catalog): add homepage SEO metadata

### DIFF
--- a/docs/catalog-architecture.md
+++ b/docs/catalog-architecture.md
@@ -83,6 +83,19 @@ filters those cards in the browser, so the full category-organized catalog
 remains readable when JavaScript is unavailable. GitHub Pages only serves the
 generated files.
 
+## Homepage Discovery Metadata
+
+The catalog homepage publishes one title, description, keyword set, canonical
+URL, and Open Graph object from `site/templates/index.html`. The canonical URL
+is the approved GitHub Pages root in `scripts/catalog/model.py`. It must use a
+standalone `canonical` link relation so it cannot hide a stylesheet, icon,
+preload, or other browser-fetched resource from validation.
+
+The Open Graph object uses the same canonical URL and a same-origin, tracked
+PNG image with its type, dimensions, and alternative text. The generated-site
+validator requires exactly one approved canonical URL, rejects duplicate HTML
+attributes, and continues to inventory and reject remote page resources.
+
 Each card links to a static detail page. The build extracts the source-document
 title, compiles headings, tables, lists, links, code, and images, and renders
 the result inside the shared site theme. Normal detail pages without Mermaid

--- a/scripts/catalog/validation.py
+++ b/scripts/catalog/validation.py
@@ -112,7 +112,9 @@ class GeneratedHTMLValidator(HTMLParser):
                     self.errors.append(f"Root-relative URL breaks project Pages: {value}")
                 if value.startswith("#"):
                     self.fragments.add(unquote(value[1:]))
-        if tag in {"img", "link", "script"}:
+        link_relations = values.get("rel", "").casefold().split()
+        is_canonical = tag == "link" and "canonical" in link_relations
+        if tag in {"img", "link", "script"} and not is_canonical:
             resource = values.get("src") or values.get("href") or ""
             if resource:
                 self.resources.append(resource)

--- a/scripts/catalog/validation.py
+++ b/scripts/catalog/validation.py
@@ -22,7 +22,7 @@ from .markdown import (
     TUTORIAL_CONTENT_SECURITY_POLICY,
     TUTORIAL_IFRAME_PATHS,
 )
-from .model import CatalogEntry, CatalogError, Category, Collection
+from .model import PAGES_BASE_URL, CatalogEntry, CatalogError, Category, Collection
 from .sources import is_regular_repo_file
 
 
@@ -45,6 +45,7 @@ class GeneratedHTMLValidator(HTMLParser):
         self.labels_for: set[str] = set()
         self.tag_counts: dict[str, int] = {}
         self.content_security_policies: list[str] = []
+        self.canonical_urls: list[str] = []
         self.html_language = ""
         self.has_viewport = False
         self.h1_count = 0
@@ -53,6 +54,19 @@ class GeneratedHTMLValidator(HTMLParser):
     def handle_starttag(
         self, tag: str, attrs: list[tuple[str, str | None]]
     ) -> None:
+        attribute_names = [name.casefold() for name, _ in attrs]
+        duplicate_attributes = sorted(
+            {
+                name
+                for name in attribute_names
+                if attribute_names.count(name) > 1
+            }
+        )
+        if duplicate_attributes:
+            self.errors.append(
+                "Duplicate HTML attributes are not allowed: "
+                + ", ".join(duplicate_attributes)
+            )
         values = {name: value or "" for name, value in attrs}
         self.tag_counts[tag] = self.tag_counts.get(tag, 0) + 1
         if tag == "html":
@@ -113,8 +127,15 @@ class GeneratedHTMLValidator(HTMLParser):
                 if value.startswith("#"):
                     self.fragments.add(unquote(value[1:]))
         link_relations = values.get("rel", "").casefold().split()
-        is_canonical = tag == "link" and "canonical" in link_relations
-        if tag in {"img", "link", "script"} and not is_canonical:
+        has_canonical = tag == "link" and "canonical" in link_relations
+        is_canonical_metadata = has_canonical and link_relations == ["canonical"]
+        if has_canonical:
+            self.canonical_urls.append(values.get("href", ""))
+            if not is_canonical_metadata:
+                self.errors.append(
+                    "Canonical metadata must use only the canonical link relation."
+                )
+        if tag in {"img", "link", "script"} and not is_canonical_metadata:
             resource = values.get("src") or values.get("href") or ""
             if resource:
                 self.resources.append(resource)
@@ -173,6 +194,10 @@ def validate_generated_site(
         errors.append("The generated page must declare html lang=\"en\".")
     if not parser.has_viewport:
         errors.append("The generated page must include a viewport meta tag.")
+    if parser.canonical_urls != [PAGES_BASE_URL]:
+        errors.append(
+            "Expected exactly one approved catalog canonical URL: " + PAGES_BASE_URL
+        )
     if parser.tag_counts.get("header", 0) < 1:
         errors.append("The generated page must include a header landmark.")
     for landmark in ("main", "footer"):

--- a/scripts/tests/test_catalog_pipeline.py
+++ b/scripts/tests/test_catalog_pipeline.py
@@ -71,6 +71,26 @@ class CatalogPipelineTests(CatalogFixtureMixin, unittest.TestCase):
             'href="assets/nvidia-favicon.png">',
             outputs.site_html,
         )
+        seo_markup = (
+            "<title>NVIDIA NemoClaw Community Examples</title>",
+            '<link rel="canonical" href="https://nvidia.github.io/nemoclaw-community/">',
+            '<meta name="description" content="Explore NVIDIA NemoClaw community '
+            "examples, blueprints, showcases, and integrations for constrained, "
+            'inspectable AI agent workflows.">',
+            '<meta name="keywords" content="NemoClaw examples, NemoClaw community, '
+            "NemoClaw blueprints, AI agent examples, OpenShell, agent integrations, "
+            'agent workflows">',
+            '<meta property="og:site_name" content="NVIDIA Developer">',
+            '<meta property="og:type" content="website">',
+            '<meta property="og:title" content="NVIDIA NemoClaw Community Examples">',
+            '<meta property="og:description" content="Browse blueprints, showcases, '
+            'and integrations.">',
+            '<meta property="og:url" content="https://nvidia.github.io/'
+            'nemoclaw-community/">',
+        )
+        for snippet in seo_markup:
+            with self.subTest(seo_markup=snippet):
+                self.assertEqual(outputs.site_html.count(snippet), 1)
         header = outputs.site_html.split('<header class="site-header">', 1)[1].split(
             "</header>", 1
         )[0]

--- a/scripts/tests/test_catalog_pipeline.py
+++ b/scripts/tests/test_catalog_pipeline.py
@@ -22,6 +22,7 @@ from scripts.catalog.pipeline import (
     check_catalog,
     expected_outputs,
 )
+from scripts.catalog.validation import validate_generated_site
 from scripts.catalog.sources import load_discovery_groups
 from scripts.fetch_catalog_assets import (
     MERMAID_SHA256 as FETCHED_MERMAID_SHA256,
@@ -87,6 +88,12 @@ class CatalogPipelineTests(CatalogFixtureMixin, unittest.TestCase):
             'and integrations.">',
             '<meta property="og:url" content="https://nvidia.github.io/'
             'nemoclaw-community/">',
+            '<meta property="og:image" content="https://nvidia.github.io/'
+            'nemoclaw-community/assets/nvidia-logo.png">',
+            '<meta property="og:image:type" content="image/png">',
+            '<meta property="og:image:width" content="400">',
+            '<meta property="og:image:height" content="138">',
+            '<meta property="og:image:alt" content="NVIDIA logo">',
         )
         for snippet in seo_markup:
             with self.subTest(seo_markup=snippet):
@@ -195,6 +202,26 @@ class CatalogPipelineTests(CatalogFixtureMixin, unittest.TestCase):
         )
         self.assertGreater(mermaid_pages, 0)
         self.assertGreater(mermaid_diagrams, 0)
+
+    def test_duplicate_attributes_cannot_hide_a_remote_catalog_resource(self) -> None:
+        outputs = expected_outputs(ROOT)
+        compromised_site = outputs.site_html.replace(
+            '<link rel="canonical" '
+            'href="https://nvidia.github.io/nemoclaw-community/">',
+            '<link rel="stylesheet" rel="canonical" '
+            'href="https://example.com/remote.css" '
+            'href="https://nvidia.github.io/nemoclaw-community/">',
+            1,
+        )
+
+        with self.assertRaisesRegex(CatalogError, "Duplicate HTML attributes"):
+            validate_generated_site(
+                ROOT,
+                outputs.entries,
+                outputs.categories,
+                outputs.collections,
+                compromised_site,
+            )
 
     def test_build_output_cannot_replace_source_or_follow_a_symlink(self) -> None:
         temporary = tempfile.TemporaryDirectory()

--- a/scripts/tests/test_catalog_validation.py
+++ b/scripts/tests/test_catalog_validation.py
@@ -20,6 +20,31 @@ from scripts.tests.catalog_test_support import CatalogFixtureMixin, ROOT
 
 
 class CatalogValidationTests(CatalogFixtureMixin, unittest.TestCase):
+    def test_canonical_metadata_cannot_hide_a_remote_resource(self) -> None:
+        for relation in (
+            "canonical stylesheet",
+            "canonical icon",
+            "canonical preload",
+        ):
+            with self.subTest(relation=relation):
+                parser = GeneratedHTMLValidator()
+                parser.feed(
+                    f'<link rel="{relation}" href="https://example.com/resource">'
+                )
+
+                self.assertIn(
+                    "Canonical metadata must use only the canonical link relation.",
+                    parser.errors,
+                )
+                self.assertIn(
+                    "Remote page resource is not allowed: "
+                    "https://example.com/resource",
+                    parser.errors,
+                )
+                self.assertEqual(
+                    parser.resources, ["https://example.com/resource"]
+                )
+
     def test_readme_compiler_rejects_unsafe_mermaid(self) -> None:
         unsafe_sources = {
             "unsupported type": "pie\n    title Unsafe",

--- a/site/templates/index.html
+++ b/site/templates/index.html
@@ -14,6 +14,11 @@
     <meta property="og:title" content="NVIDIA NemoClaw Community Examples">
     <meta property="og:description" content="Browse blueprints, showcases, and integrations.">
     <meta property="og:url" content="https://nvidia.github.io/nemoclaw-community/">
+    <meta property="og:image" content="https://nvidia.github.io/nemoclaw-community/assets/nvidia-logo.png">
+    <meta property="og:image:type" content="image/png">
+    <meta property="og:image:width" content="400">
+    <meta property="og:image:height" content="138">
+    <meta property="og:image:alt" content="NVIDIA logo">
     <title>NVIDIA NemoClaw Community Examples</title>
     <link rel="canonical" href="https://nvidia.github.io/nemoclaw-community/">
     <link rel="icon" type="image/png" sizes="64x64" href="assets/nvidia-favicon.png">

--- a/site/templates/index.html
+++ b/site/templates/index.html
@@ -7,11 +7,15 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta
-      name="description"
-      content="Search NemoClaw Community recipes, field demos, and developer tools by example type or industry."
-    >
-    <title>NemoClaw Community Example Catalog | NVIDIA</title>
+    <meta name="description" content="Explore NVIDIA NemoClaw community examples, blueprints, showcases, and integrations for constrained, inspectable AI agent workflows.">
+    <meta name="keywords" content="NemoClaw examples, NemoClaw community, NemoClaw blueprints, AI agent examples, OpenShell, agent integrations, agent workflows">
+    <meta property="og:site_name" content="NVIDIA Developer">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="NVIDIA NemoClaw Community Examples">
+    <meta property="og:description" content="Browse blueprints, showcases, and integrations.">
+    <meta property="og:url" content="https://nvidia.github.io/nemoclaw-community/">
+    <title>NVIDIA NemoClaw Community Examples</title>
+    <link rel="canonical" href="https://nvidia.github.io/nemoclaw-community/">
     <link rel="icon" type="image/png" sizes="64x64" href="assets/nvidia-favicon.png">
     <link rel="stylesheet" href="styles/shared.css">
     <link rel="stylesheet" href="styles/catalog.css">


### PR DESCRIPTION
## Related Issue

N/A — no linked issue.

## Description

- Add the requested homepage title, description, keywords, canonical URL, and complete Open Graph metadata, including the same-origin image, type, dimensions, and alternative text.
- Require exactly one approved standalone canonical URL, and reject mixed resource relations or duplicate HTML attributes so metadata cannot bypass remote-resource validation.
- Document the homepage discovery-metadata contract and add positive and adversarial regression coverage.

## Verification

- [x] `python3 scripts/check_license_headers.py --check` — all 664 checked source files passed
- [x] `git diff --check origin/main...HEAD`
- [x] `python3 scripts/fetch_catalog_assets.py`
- [x] `python3 scripts/build_catalog.py --validate-metadata` — 20 examples passed
- [x] `python3 scripts/build_catalog.py --check` — 20 examples across 7 browse groups passed
- [x] `python3 scripts/build_catalog.py` — built the homepage and 20 detail pages
- [x] `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 74 passed
- [x] `node --test scripts/tests/*.test.mjs` — 14 passed
- [x] Governance metadata was not changed, so the label-taxonomy check is not applicable.
- [x] No browser interaction verification was required because the change only affects document-head metadata. The generated HTML was inspected and is covered by regression tests.

## Documentation Writer Review

- [x] Documentation writer review completed for the final changes
- Result: `docs-updated`
- Evidence or justification: Reviewed the final homepage metadata and catalog-architecture contract against the repository writing guide and controlled-word list. The public URLs, image metadata, and SEO copy contain no private context.
- Reviewer: Codex documentation review
- [x] Changed user-facing text follows the [writing guide](https://github.com/NVIDIA/nemoclaw-community/blob/main/WRITING.md) and [controlled-word list](https://github.com/NVIDIA/nemoclaw-community/blob/main/.agents/skills/_shared/controlled-words.md).
- [x] A public contributor can understand the changed text without internal company context.
- [x] I reviewed any agent-generated text before submission.

## Release And Compliance

- [x] No secrets or credentials are included, including API keys, access tokens, passwords, local `.env` files, private certificates, or token caches.
- [x] No nonpublic project names, environment names, hostnames, URLs, ticket identifiers, workspace paths, logs, screenshots, or configuration values are included.
- [x] No third-party dependencies were changed.
- [x] Public content uses public URLs and contains no private values.
- [x] I added my DCO sign-off declaration to this pull request description.

Signed-off-by: Sam Pastoriza <spastoriza@nvidia.com>
